### PR TITLE
exclusion uniqueness from index attribute

### DIFF
--- a/app/models/parameter_set.rb
+++ b/app/models/parameter_set.rb
@@ -3,7 +3,7 @@ class ParameterSet
   include Mongoid::Timestamps
   field :v, type: Hash
   field :runs_status_count_cache, type: Hash
-  index({ v: 1 }, { unique: true, name: "v_index" })
+  index({ v: 1 }, { name: "v_index" })
   belongs_to :simulator, autosave: false
   has_many :runs, dependent: :destroy
   has_many :analyses, as: :analyzable, dependent: :destroy


### PR DESCRIPTION
"unique: true" is deleted.
This line is written in #17 , but it is cause of error #63  to create duplicate ps in the other simulator.
- Note: type the following commands after marged this pull request.
  
  remove index: bundle exec rake db:mongoid:remove_indexes
  add index: bundle exec rake db:mongoid:create_indexes
