### PR TITLE
a bug is fixed in displaying boolean values

### DIFF
--- a/app/controllers/parameter_sets_controller.rb
+++ b/app/controllers/parameter_sets_controller.rb
@@ -12,7 +12,7 @@ class ParameterSetsController < ApplicationController
     simulator = Simulator.find(params[:simulator_id])
     v = {}
     simulator.parameter_definitions.each do |defn|
-      v[defn.key] = defn.default if defn.default
+      v[defn.key] = defn.default unless defn.default.nil?
     end
     @param_set = simulator.parameter_sets.build(v: v)
   end

--- a/app/views/parameter_sets/_form.html.haml
+++ b/app/views/parameter_sets/_form.html.haml
@@ -9,7 +9,7 @@
       = label_tag(property, "#{key} (#{pd.type})", class: 'control-label')
       .controls
         - if pd.type == "Boolean"
-          = select_tag( property, options_for_select([[true,"true"],[false,"false"]], selected: value))
+          = select_tag( property, options_for_select([[true,"true"],[false,"false"]], selected: pd.default))
         - else
           = text_field_tag(property, value, class: 'text_field')
         = pd.description

--- a/app/views/parameter_sets/_form.html.haml
+++ b/app/views/parameter_sets/_form.html.haml
@@ -9,7 +9,7 @@
       = label_tag(property, "#{key} (#{pd.type})", class: 'control-label')
       .controls
         - if pd.type == "Boolean"
-          = select_tag( property, options_for_select([[true,"true"],[false,"false"]], selected: pd.default))
+          = select_tag( property, options_for_select([[true,"true"],[false,"false"]], selected: value))
         - else
           = text_field_tag(property, value, class: 'text_field')
         = pd.description

--- a/app/views/simulators/_about.html.haml
+++ b/app/views/simulators/_about.html.haml
@@ -36,7 +36,7 @@
       %tr
         %th= pd.key
         %td= pd.type
-        %td= pd.default || '-'
+        %td= pd.default.nil? ? '-' : pd.default
         %td= pd.description ? pd.description : "-"
 
 %h3 Commands


### PR DESCRIPTION
some bugs are fixed.
This request is related with #95 and #96.
After this request is merged, still the default value of boolean field is set to false when the default field is empty.
(In the default specification, it is not accepted to enter nothing in default field.)
