### PR TITLE
Add priority on runs

### DIFF
--- a/app/datatables/runs_list_datatable.rb
+++ b/app/datatables/runs_list_datatable.rb
@@ -4,7 +4,7 @@ class RunsListDatatable
              '<th>cpu_time</th>', '<th>real_time</th>',
              '<th>MPI</th>', '<th>OMP</th>', '<th>version</th>',
              '<th>created_at</th>', '<th>finished_at</th>', '<th style="min-width: 18px; width: 1%;"></th>']
-  SORT_BY = ["id", "status", "submitted_to", "index_of_priority", "job_id", "cpu_time",
+  SORT_BY = ["id", "status", "submitted_to", "priority", "job_id", "cpu_time",
              "real_time", "mpi_procs", "omp_threads",
              "simulator_version", "created_at", "finished_at", "id"]
 
@@ -32,7 +32,7 @@ private
       tmp << @view.raw( @view.status_label(run.status) )
       host = run.submitted_to
       tmp << (host ? @view.link_to( host.name, @view.host_path(host) ) : "---")
-      tmp << run.priority
+      tmp << Run::PRIORITY_ORDER[run.priority]
       tmp << @view.shortened_job_id(run.job_id)
       tmp << @view.formatted_elapsed_time(run.cpu_time)
       tmp << @view.formatted_elapsed_time(run.real_time)

--- a/app/datatables/runs_list_datatable.rb
+++ b/app/datatables/runs_list_datatable.rb
@@ -4,7 +4,7 @@ class RunsListDatatable
              '<th>cpu_time</th>', '<th>real_time</th>',
              '<th>MPI</th>', '<th>OMP</th>', '<th>version</th>',
              '<th>created_at</th>', '<th>finished_at</th>', '<th style="min-width: 18px; width: 1%;"></th>']
-  SORT_BY = ["id", "status", "submitted_to", "priority", "job_id", "cpu_time",
+  SORT_BY = ["id", "status", "submitted_to", "index_of_priority", "job_id", "cpu_time",
              "real_time", "mpi_procs", "omp_threads",
              "simulator_version", "created_at", "finished_at", "id"]
 

--- a/app/datatables/runs_list_datatable.rb
+++ b/app/datatables/runs_list_datatable.rb
@@ -1,10 +1,10 @@
 class RunsListDatatable
 
-  HEADER  = ['<th>ID</th>', '<th>status</th>', '<th>submitted_to</th>', '<th>job_id</th>',
+  HEADER  = ['<th>ID</th>', '<th>status</th>', '<th>submitted_to</th>', '<th>priority</th>', '<th>job_id</th>',
              '<th>cpu_time</th>', '<th>real_time</th>',
              '<th>MPI</th>', '<th>OMP</th>', '<th>version</th>',
              '<th>created_at</th>', '<th>finished_at</th>', '<th style="min-width: 18px; width: 1%;"></th>']
-  SORT_BY = ["id", "status", "submitted_to", "job_id", "cpu_time",
+  SORT_BY = ["id", "status", "submitted_to", "priority", "job_id", "cpu_time",
              "real_time", "mpi_procs", "omp_threads",
              "simulator_version", "created_at", "finished_at", "id"]
 
@@ -32,6 +32,7 @@ private
       tmp << @view.raw( @view.status_label(run.status) )
       host = run.submitted_to
       tmp << (host ? @view.link_to( host.name, @view.host_path(host) ) : "---")
+      tmp << run.priority
       tmp << @view.shortened_job_id(run.job_id)
       tmp << @view.formatted_elapsed_time(run.cpu_time)
       tmp << @view.formatted_elapsed_time(run.real_time)

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -43,7 +43,7 @@ class Run
   # do not write validations for the presence of association
   # because it can be slow. See http://mongoid.org/en/mongoid/docs/relations.html
 
-  attr_accessible :seed, :mpi_procs, :omp_threads, :host_parameters, :submitted_to
+  attr_accessible :seed, :mpi_procs, :omp_threads, :host_parameters, :submitted_to, :priority
 
   before_create :set_simulator, :remove_redundant_host_parameters, :set_job_script
   before_save :remove_runs_status_count_cache, :if => :status_changed?

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -20,7 +20,7 @@ class Run
   field :job_script, type: String
   field :priority, type: Symbol, default: :normal
   index({ status: 1 }, { name: "run_status_index" })
-  index({ priority: 1 }, { name: "run_status_index" })
+  index({ priority: 1 }, { name: "run_priority_index" })
   belongs_to :parameter_set, autosave: false
   belongs_to :simulator, autosave: false  # for caching. do not edit this field explicitly
   has_many :analyses, as: :analyzable, dependent: :destroy
@@ -46,7 +46,7 @@ class Run
   # do not write validations for the presence of association
   # because it can be slow. See http://mongoid.org/en/mongoid/docs/relations.html
 
-  attr_accessible :seed, :mpi_procs, :omp_threads, :host_parameters, :submitted_to, :priority
+  attr_accessible :seed, :mpi_procs, :omp_threads, :host_parameters, :priority, :submitted_to
 
   before_create :set_simulator, :remove_redundant_host_parameters, :set_job_script
   before_save :remove_runs_status_count_cache, :if => :status_changed?

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -20,10 +20,13 @@ class Run
   field :job_script, type: String
   field :priority, type: Symbol, default: :normal
   index({ status: 1 }, { name: "run_status_index" })
+  index({ priority: 1 }, { name: "run_status_index" })
   belongs_to :parameter_set, autosave: false
   belongs_to :simulator, autosave: false  # for caching. do not edit this field explicitly
   has_many :analyses, as: :analyzable, dependent: :destroy
   belongs_to :submitted_to, class_name: "Host"
+
+  PRIORITY_ORDER = [:high, :normal, :low]
 
   # validations
   validates :status, presence: true,
@@ -32,7 +35,7 @@ class Run
   validates :mpi_procs, numericality: {greater_than_or_equal_to: 1, only_integer: true}
   validates :omp_threads, numericality: {greater_than_or_equal_to: 1, only_integer: true}
   validates :priority, presence: true,
-                     inclusion: {in: [:low,:normal,:high]}
+                     inclusion: {in: PRIORITY_ORDER}
   validate :host_parameters_given, on: :create
   validate :host_parameters_format, on: :create
   validate :mpi_procs_is_in_range, on: :create

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -18,6 +18,7 @@ class Run
   field :host_parameters, type: Hash, default: {}
   field :job_id, type: String
   field :job_script, type: String
+  field :priority, type: Symbol, default: :normal
   index({ status: 1 }, { name: "run_status_index" })
   belongs_to :parameter_set, autosave: false
   belongs_to :simulator, autosave: false  # for caching. do not edit this field explicitly
@@ -30,6 +31,8 @@ class Run
   validates :seed, presence: true, uniqueness: {scope: :parameter_set_id}
   validates :mpi_procs, numericality: {greater_than_or_equal_to: 1, only_integer: true}
   validates :omp_threads, numericality: {greater_than_or_equal_to: 1, only_integer: true}
+  validates :priority, presence: true,
+                     inclusion: {in: [:low,:normal,:high]}
   validate :host_parameters_given, on: :create
   validate :host_parameters_format, on: :create
   validate :mpi_procs_is_in_range, on: :create

--- a/app/views/runs/_fields.html.haml
+++ b/app/views/runs/_fields.html.haml
@@ -9,6 +9,10 @@
     .controls
       = f.text_field(:omp_threads)
 .control-group
+  = f.label(:priority, 'Priorities of Runs', class: 'control-label')
+  .controls
+    = f.select(:priority, options_for_select(Run::PRIORITY_ORDER, selected: Run::PRIORITY_ORDER[1]))
+.control-group
   = f.label(:submitted_to, class: 'control-label')
   .controls
     - host_names = run.simulator.executable_on.map {|h| [h.name, h.id.to_s]}

--- a/app/views/runs/_fields.html.haml
+++ b/app/views/runs/_fields.html.haml
@@ -11,7 +11,7 @@
 .control-group
   = f.label(:priority, 'Priorities of Runs', class: 'control-label')
   .controls
-    = f.select(:priority, options_for_select(Run::PRIORITY_ORDER, selected: Run::PRIORITY_ORDER[1]))
+    = f.select(:priority, options_for_select(Run::PRIORITY_ORDER.sort_by {|a| a[0]}.map {|a| [a[1], a[0]]}, selected: 1))
 .control-group
   = f.label(:submitted_to, class: 'control-label')
   .controls

--- a/app/workers/job_submitter.rb
+++ b/app/workers/job_submitter.rb
@@ -5,7 +5,7 @@ class JobSubmitter
       begin
         num = host.max_num_jobs - host.submitted_runs.count
         if num > 0
-          Run::PRIORITY_ORDER.each do |priority|
+          Run::PRIORITY_ORDER.keys.sort.each do |priority|
             runs = host.submittable_runs.where(priority: priority).limit(num)
             logger.info("submitting jobs to #{host.name}: #{runs.map do |r| r.id.to_s end.inspect}")
             num -= runs.length

--- a/app/workers/job_submitter.rb
+++ b/app/workers/job_submitter.rb
@@ -5,9 +5,13 @@ class JobSubmitter
       begin
         num = host.max_num_jobs - host.submitted_runs.count
         if num > 0
-          runs = host.submittable_runs.limit(num)
-          logger.info("submitting jobs to #{host.name}: #{runs.map do |r| r.id.to_s end.inspect}")
-          submit(runs, host, logger)
+          Run::PRIORITY_ORDER.each do |priority|
+            runs = host.submittable_runs.where(priority: priority).limit(num)
+            logger.info("submitting jobs to #{host.name}: #{runs.map do |r| r.id.to_s end.inspect}")
+            num -= runs.length
+            submit(runs, host, logger)
+            break if num == 0
+          end
         end
       rescue => ex
         logger.error("Error in JobSubmitter: #{ex.inspect}")

--- a/lib/tasks/update_schema.rake
+++ b/lib/tasks/update_schema.rake
@@ -16,9 +16,10 @@ namespace :db do
       progressbar.increment
     end
 
-    q = Run.where(index_of_priority: nil)
+    q = Run.where(priority: nil)
     progressbar = ProgressBar.create(total: q.count, format: "%t %B %p%% (%c/%C)")
     q.each do |run|
+      run.priority = 1
       run.save
       progressbar.increment
     end

--- a/lib/tasks/update_schema.rake
+++ b/lib/tasks/update_schema.rake
@@ -15,5 +15,12 @@ namespace :db do
       end
       progressbar.increment
     end
+
+    q = Run.where(index_of_priority: nil)
+    progressbar = ProgressBar.create(total: q.count, format: "%t %B %p%% (%c/%C)")
+    q.each do |run|
+      run.save
+      progressbar.increment
+    end
   end
 end

--- a/spec/datatables/runs_list_datatable_spec.rb
+++ b/spec/datatables/runs_list_datatable_spec.rb
@@ -12,7 +12,7 @@ describe "RunsListDatatable" do
       @context.stub(:params).and_return({id: @param_set.to_param, sEcho: 1, iDisplayStart: 0, iDisplayLength:25 , iSortCol_0: 0, sSortDir_0: "desc"})
       @context.stub(:link_to) {|str, link_path| link_path }
       @context.stub(:run_path) {|run| run.id.to_s }
-      @context.stub(:priority) {|run| run.priority.to_s }
+      @context.stub(:priority) {|run| Run::PRIORITY_ORDER[run.priority].to_s }
       @context.stub(:distance_to_now_in_words).and_return("time")
       @context.stub(:formatted_elapsed_time).and_return("time")
       @context.stub(:raw).and_return("label")

--- a/spec/datatables/runs_list_datatable_spec.rb
+++ b/spec/datatables/runs_list_datatable_spec.rb
@@ -36,3 +36,4 @@ describe "RunsListDatatable" do
     end
   end
 end
+

--- a/spec/datatables/runs_list_datatable_spec.rb
+++ b/spec/datatables/runs_list_datatable_spec.rb
@@ -12,6 +12,7 @@ describe "RunsListDatatable" do
       @context.stub(:params).and_return({id: @param_set.to_param, sEcho: 1, iDisplayStart: 0, iDisplayLength:25 , iSortCol_0: 0, sSortDir_0: "desc"})
       @context.stub(:link_to) {|str, link_path| link_path }
       @context.stub(:run_path) {|run| run.id.to_s }
+      @context.stub(:priority) {|run| run.priority.to_s }
       @context.stub(:distance_to_now_in_words).and_return("time")
       @context.stub(:formatted_elapsed_time).and_return("time")
       @context.stub(:raw).and_return("label")

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -134,19 +134,19 @@ describe Run do
 
     it "assigns a priority by default" do
       run = @param_set.runs.create
-      run.priority.should be_a(Symbol)
+      run.priority.should be_a(Integer)
     end
 
-    it "automatically assigned priority is :normal" do
+    it "automatically assigned priority is 1" do
       run = @param_set.runs.create
-      run.priority.should eq :normal
+      run.priority.should eq 1
     end
 
     it "priority is an accessible attribute" do
-      @valid_attribute.update(priority: :high)
+      @valid_attribute.update(priority: 0)
       run = @param_set.runs.create!(@valid_attribute)
       run.should be_valid
-      run.priority.should eq :high
+      run.priority.should eq 0
     end
 
    describe "'host_parameters' field" do

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -132,7 +132,24 @@ describe Run do
       run.should be_valid
     end
 
-    describe "'host_parameters' field" do
+    it "assigns a priority by default" do
+      run = @param_set.runs.create
+      run.priority.should be_a(Symbol)
+    end
+
+    it "automatically assigned priority is :normal" do
+      run = @param_set.runs.create
+      run.priority.should eq :normal
+    end
+
+    it "priority is an accessible attribute" do
+      @valid_attribute.update(priority: :high)
+      run = @param_set.runs.create!(@valid_attribute)
+      run.should be_valid
+      run.priority.should eq :high
+    end
+
+   describe "'host_parameters' field" do
 
       before(:each) do
         header = <<-EOS

--- a/spec/workers/job_submitter_spec.rb
+++ b/spec/workers/job_submitter_spec.rb
@@ -34,7 +34,7 @@ describe JobSubmitter do
       }.to_not raise_error
     end
 
-    it "enqueus jobs to remote host in order of the priority on the run" do
+    it "enqueus jobs to remote host in order of priorities on runs" do
       @sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1)
       @sim.executable_on.push @host
       @sim.save!

--- a/spec/workers/job_submitter_spec.rb
+++ b/spec/workers/job_submitter_spec.rb
@@ -38,12 +38,12 @@ describe JobSubmitter do
       @sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1)
       @sim.executable_on.push @host
       @sim.save!
-      run = @sim.parameter_sets.first.runs.create(priority: :high, submitted_to: @host.to_param)
+      run = @sim.parameter_sets.first.runs.create(priority: 0, submitted_to: @host.to_param)
       run.save!
       expect {
         JobSubmitter.perform(@logger)
-      }.to change { Run.where(status: :submitted, priority: :high).count }.by(1)
-      Run.where(status: :submitted, priority: :normal).count.should eq 0
+      }.to change { Run.where(status: :submitted, priority: 0).count }.by(1)
+      Run.where(status: :submitted, priority: 1).count.should eq 0
     end
   end
 end

--- a/spec/workers/job_submitter_spec.rb
+++ b/spec/workers/job_submitter_spec.rb
@@ -33,5 +33,17 @@ describe JobSubmitter do
         JobSubmitter.perform(@logger)
       }.to_not raise_error
     end
+
+    it "enqueus jobs to remote host in order of the priority on the run" do
+      @sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1)
+      @sim.executable_on.push @host
+      @sim.save!
+      run = @sim.parameter_sets.first.runs.create(priority: :high, submitted_to: @host.to_param)
+      run.save!
+      expect {
+        JobSubmitter.perform(@logger)
+      }.to change { Run.where(status: :submitted, priority: :high).count }.by(1)
+      Run.where(status: :submitted, priority: :normal).count.should eq 0
+    end
   end
 end


### PR DESCRIPTION
For #101
Now priority on run is selectable.
Worker submits jobs in order of priories [:high, :normal, :low]
You can see priorities on web browser but the priorities are not modified again.
