### PR TITLE
add a field for sort with progress

### DIFF
--- a/app/datatables/parameter_sets_list_datatable.rb
+++ b/app/datatables/parameter_sets_list_datatable.rb
@@ -30,7 +30,7 @@ class ParameterSetsListDatatable
 
 private
   def sort_by
-    ["id", "id", "id", "updated_at"] + @param_keys.map {|key| "v.#{key}"} + ["id"]
+    ["id", "order_of_progress_rate", "id", "updated_at"] + @param_keys.map {|key| "v.#{key}"} + ["id"]
   end
 
   def data

--- a/app/datatables/parameter_sets_list_datatable.rb
+++ b/app/datatables/parameter_sets_list_datatable.rb
@@ -30,7 +30,7 @@ class ParameterSetsListDatatable
 
 private
   def sort_by
-    ["id", "order_of_progress_rate", "id", "updated_at"] + @param_keys.map {|key| "v.#{key}"} + ["id"]
+    ["id", "progress_rate_cache", "id", "updated_at"] + @param_keys.map {|key| "v.#{key}"} + ["id"]
   end
 
   def data
@@ -39,7 +39,7 @@ private
       tmp << @view.image_tag("/assets/expand.png", parameter_set_id: param.id.to_s, align: "center", state: "close", class: "treebtn")
       counts = param.runs_status_count
       counts.delete(:cancelled)
-      progress = @view.progress_bar( counts.values.inject(:+), counts[:finished], counts[:running], counts[:failed] )
+      progress = @view.progress_bar( counts.values.inject(:+), counts[:finished], counts[:failed], counts[:running] )
       tmp << @view.raw(progress)
       tmp << "<tt>"+@view.link_to( @view.shortened_id(param.id), @view.parameter_set_path(param) )+"</tt>"
       tmp << @view.distance_to_now_in_words(param.updated_at)

--- a/app/models/parameter_set.rb
+++ b/app/models/parameter_set.rb
@@ -3,6 +3,7 @@ class ParameterSet
   include Mongoid::Timestamps
   field :v, type: Hash
   field :runs_status_count_cache, type: Hash
+  field :order_of_progress_rate, type: Integer
   index({ v: 1 }, { name: "v_index" })
   belongs_to :simulator, autosave: false
   has_many :runs, dependent: :destroy
@@ -60,6 +61,10 @@ class ParameterSet
     # disable automatic time-stamp update when updating cache
     # See http://mongoid.org/en/mongoid/docs/extras.html#timestamps
     timeless.update_attribute(:runs_status_count_cache, counts)
+    total = counts.inject(0) {|sum, v| sum += v[1]}
+    rate = 0
+    rate = - (counts[:finished]*1000000/total).to_i - (counts[:running]*10000/total).to_i - (counts[:failed]*100/total).to_i  if total > 0
+    timeless.update_attribute(:order_of_progress_rate, rate)
     counts
   end
 

--- a/app/models/parameter_set.rb
+++ b/app/models/parameter_set.rb
@@ -3,7 +3,7 @@ class ParameterSet
   include Mongoid::Timestamps
   field :v, type: Hash
   field :runs_status_count_cache, type: Hash
-  field :order_of_progress_rate, type: Integer
+  field :progress_rate_cache, type: Integer # used for sorting by progress. updated at the same time with the run_status_count_cache
   index({ v: 1 }, { name: "v_index" })
   belongs_to :simulator, autosave: false
   has_many :runs, dependent: :destroy
@@ -41,6 +41,7 @@ class ParameterSet
     # I do not know why but reload is necessary. Otherwise, _cache is always nil.
     reload
     if runs_status_count_cache
+      update_progress_rate_cache unless progress_rate_cache
       return Hash[ runs_status_count_cache.map {|key,val| [key.to_sym, val]} ]
     end
 
@@ -61,10 +62,9 @@ class ParameterSet
     # disable automatic time-stamp update when updating cache
     # See http://mongoid.org/en/mongoid/docs/extras.html#timestamps
     timeless.update_attribute(:runs_status_count_cache, counts)
-    total = counts.inject(0) {|sum, v| sum += v[1]}
-    rate = 0
-    rate = - (counts[:finished]*1000000/total).to_i - (counts[:running]*10000/total).to_i - (counts[:failed]*100/total).to_i  if total > 0
-    timeless.update_attribute(:order_of_progress_rate, rate)
+
+    update_progress_rate_cache
+
     counts
   end
 
@@ -106,5 +106,14 @@ class ParameterSet
     if self.simulator and File.directory?(self.dir)
       FileUtils.rm_r(self.dir)
     end
+  end
+
+  def update_progress_rate_cache
+    # make it negative in order to show all-finished-ps on top when sorted in ascending order
+    counts = Hash[ runs_status_count_cache.map {|key,val| [key.to_sym, val]} ]
+    total = counts.inject(0) {|sum, v| sum += v[1]}
+    rate = 0
+    rate = - (counts[:finished]*1000000/total).to_i - (counts[:failed]*10000/total).to_i - (counts[:running]*100/total).to_i  if total > 0
+    timeless.update_attribute(:progress_rate_cache, rate)
   end
 end

--- a/app/workers/cache_updater.rb
+++ b/app/workers/cache_updater.rb
@@ -2,8 +2,8 @@ class CacheUpdater
   MAX_PS_NUM_TO_UPDATE = 100
 
   def self.perform(logger)
-    logger.info "updating cache"
-    ParameterSet.where(runs_status_count_cache: nil).order_by(:updated_at.asc).limit(MAX_PS_NUM_TO_UPDATE).each do |ps|
+    logger.info "updating cache for parameter sets"
+    ParameterSet.or(progress_rate_cache: nil).or(runs_status_count_cache: nil).order_by(:updated_at.asc).limit(MAX_PS_NUM_TO_UPDATE).each do |ps|
       ps.runs_status_count
     end
   rescue => ex

--- a/spec/controllers/simulators_controller_spec.rb
+++ b/spec/controllers/simulators_controller_spec.rb
@@ -332,7 +332,8 @@ describe SimulatorsController do
                                     simulator: @simulator,
                                     query: {"L" => {"gte" => 5}})
 
-        get :_parameters_list, {id: @simulator.to_param, sEcho: 1, iDisplayStart: 0, iDisplayLength:25 , iSortCol_0: 1, sSortDir_0: "desc", query_id: @query.id}, :format => :json
+        # columns ["id", "progress_rate_cache", "id", "updated_at"] + @param_keys.map {|key| "v.#{key}"} + ["id"]
+        get :_parameters_list, {id: @simulator.to_param, sEcho: 1, iDisplayStart: 0, iDisplayLength:25 , iSortCol_0: 4, sSortDir_0: "desc", query_id: @query.id}, :format => :json
         @parsed_body = JSON.parse(response.body)
       end
 

--- a/spec/datatables/parameter_sets_list_datatable_spec.rb
+++ b/spec/datatables/parameter_sets_list_datatable_spec.rb
@@ -20,6 +20,7 @@ describe "ParameterSetsListDatatable" do
                                     query: {"L" => {"gte" => 5}})
 
         @context = ActionController::Base.new.view_context
+        # columns ["id", "progress_rate_cache", "id", "updated_at"] + @param_keys.map {|key| "v.#{key}"} + ["id"]
         @context.stub(:params).and_return({id: @simulator.to_param, sEcho: 1, iDisplayStart: 0, iDisplayLength:25 , iSortCol_0: 0, sSortDir_0: "asc"})
         @context.stub(:link_to).and_return("#{@simulator.to_param}")
         @context.stub(:distance_to_now_in_words).and_return("time")
@@ -59,7 +60,8 @@ describe "ParameterSetsListDatatable" do
                                     query: {"L" => {"gte" => 5}})
 
         @context = ActionController::Base.new.view_context
-        @context.stub(:params).and_return({id: @simulator.to_param, sEcho: 1, iDisplayStart: 0, iDisplayLength:5 , iSortCol_0: 1, sSortDir_0: "desc", query_id: @query.id})
+        # columns ["id", "progress_rate_cache", "id", "updated_at"] + @param_keys.map {|key| "v.#{key}"} + ["id"]
+        @context.stub(:params).and_return({id: @simulator.to_param, sEcho: 1, iDisplayStart: 0, iDisplayLength:5 , iSortCol_0: 4, sSortDir_0: "desc", query_id: @query.id})
         @context.stub(:link_to).and_return("#{@simulator.to_param}")
         @context.stub(:distance_to_now_in_words).and_return("time")
         @context.stub(:progress_bar).and_return("<div></div>")

--- a/spec/models/parameter_set_spec.rb
+++ b/spec/models/parameter_set_spec.rb
@@ -283,9 +283,15 @@ describe ParameterSet do
       Run.should_receive(:collection).and_call_original
       prm.runs_status_count
       prm.runs_status_count_cache.should be_a(Hash)
+    end
 
-      Run.should_not_receive(:collection)
+    it "update progress_rate_cache field" do
+      prm = prepare_runs
+      prm.runs_status_count_cache.should be_nil
+
+      Run.should_receive(:collection).and_call_original
       prm.runs_status_count
+      prm.progress_rate_cache.should be_a(Integer)
     end
   end
 


### PR DESCRIPTION
For #119 
仮実装です。
見た目を直感と同じにするために、statusごとに割合を計算します。
全レコードに対して毎回計算すると重いので、キャッシュすることにしました。(order_of_progress_rate)
値を負の数にしているのは、一度目のソートでfinishedの割合が大きいものを上部に表示するためです。
order_of_progress_rateのアップデートタイミングはruns_status_count_cacheが更新されるタイミングと同じです。
つまり、すでにruns_status_count_cacheが存在するなどの理由で、runs_status_count_cacheが更新されないとprogressでのソートはできません。
対策として、updata_schemaでruns_status_count_cacheをnilにできますが、再起動のたびにキャッシュしなおさないといけません。
どうしましょうか。

ちなみに、計算式を与えてソートをかけるのはできなさそうです。
