### PR TITLE
Record simulator version when job is failed

### DIFF
--- a/app/services/job_includer.rb
+++ b/app/services/job_includer.rb
@@ -14,6 +14,7 @@ module JobIncluder
         include_archive(run)
       else
         download_work_dir_if_exists(host, run, ssh)
+        include_work_dir(run)
         run.status = :failed
         run.save!
       end
@@ -25,7 +26,12 @@ module JobIncluder
 
   private
   def self.include_archive(run)
-    JobScriptUtil.expand_result_file_and_update_run(run)
+    JobScriptUtil.expand_result_file(run)
+    JobScriptUtil.update_run(run)
+  end
+
+  def self.include_work_dir(run)
+    JobScriptUtil.update_run(run)
   end
 
   def self.create_auto_run_analyses(run)

--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -26,7 +26,7 @@ echo "  \\"hostname\\": \\"`hostname`\\"," >> ../${OACIS_RUN_ID}_status.json
 
 # PRINT SIMULATOR VERSION ---------
 if [ -n "$OACIS_PRINT_VERSION_COMMAND" ]; then
-  (eval ${OACIS_PRINT_VERSION_COMMAND}) > ../${OACIS_RUN_ID}_version.txt
+  (eval ${OACIS_PRINT_VERSION_COMMAND}) > _version.txt
 fi
 
 # JOB EXECUTION -------------------
@@ -45,9 +45,6 @@ echo "}" >> ../${OACIS_RUN_ID}_status.json
 cd ..
 \\mv -f ${OACIS_RUN_ID}_status.json ${OACIS_RUN_ID}/_status.json
 \\mv -f ${OACIS_RUN_ID}_time.txt ${OACIS_RUN_ID}/_time.txt
-if [ -e ${OACIS_RUN_ID}_version.txt ]; then
-  \\mv -f ${OACIS_RUN_ID}_version.txt ${OACIS_RUN_ID}/_version.txt
-fi
 tar cf ${OACIS_RUN_ID}.tar ${OACIS_RUN_ID}
 if test $? -ne 0; then { echo "// Failed to make an archive for ${OACIS_RUN_ID}" >> ./_log.txt; exit; } fi
 bzip2 ${OACIS_RUN_ID}.tar

--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -131,9 +131,9 @@ EOS
       json_path = '_output.json'
       if File.exist?(json_path)
         begin
-        run.result = JSON.load(File.open(json_path))
-        run.result = {"result"=>run.result} unless run.result.is_a?(Hash)
-        is_updated = true
+          run.result = JSON.load(File.open(json_path))
+          run.result = {"result"=>run.result} unless run.result.is_a?(Hash)
+          is_updated = true
         rescue => ex
           $stderr.puts ex.message
         end

--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -78,39 +78,74 @@ EOS
     rendered_script.gsub(/(\r\n|\r|\n)/, "\n")
   end
 
-  def self.expand_result_file_and_update_run(run)
+  def self.expand_result_file(run)
+
     Dir.chdir(run.dir.join('..')) {
       cmd = "tar xjf #{run.id}.tar.bz2"
       system(cmd)
       raise "failed to extract the archive"  unless $?.to_i == 0
     }
+  end
+
+  def self.update_run(run)
 
     Dir.chdir(run.dir) {
-      parsed = JSON.load(File.open("_status.json"))
-      run.hostname = parsed["hostname"]
-      run.started_at = parsed["started_at"]
-      run.finished_at = parsed["finished_at"]
-      run.status = (parsed["rc"].to_i == 0) ? :finished : :failed
+      is_updated = false
 
-      File.open("_time.txt", 'r').each do |line|
-        if line =~ /^real \d/
-          run.real_time = line.sub(/^real /, '').to_f
-        elsif line =~ /^user \d/
-          # sum up cpu_times over processes
-          run.cpu_time = run.cpu_time.to_f + line.sub(/^user /,'').to_f
+      if File.exist?("_status.json")
+        begin
+          parsed = JSON.load(File.open("_status.json"))
+          run.hostname = parsed["hostname"]
+          run.started_at = parsed["started_at"]
+          run.finished_at = parsed["finished_at"]
+          run.status = (parsed["rc"].to_i == 0) ? :finished : :failed
+          is_updated = true
+        rescue => ex
+          $stderr.puts ex.message
+        end
+      end
+
+      if File.exist?("_time.txt")
+        begin
+          File.open("_time.txt", 'r').each do |line|
+            if line =~ /^real \d/
+              run.real_time = line.sub(/^real /, '').to_f
+            elsif line =~ /^user \d/
+              # sum up cpu_times over processes
+              run.cpu_time = run.cpu_time.to_f + line.sub(/^user /,'').to_f
+            end
+          end
+          is_updated = true
+        rescue => ex
+          $stderr.puts ex.message
         end
       end
 
       if File.exist?("_version.txt")
-        version = File.open("_version.txt", 'r').read.chomp
-        run.simulator_version = version
+        begin
+          version = File.open("_version.txt", 'r').read.chomp
+          run.simulator_version = version
+          is_updated = true
+        rescue => ex
+          $stderr.puts ex.message
+        end
       end
 
       json_path = '_output.json'
-      run.result = JSON.load(File.open(json_path)) if File.exist?(json_path)
-      run.result = {"result"=>run.result} unless run.result.is_a?(Hash)
-      run.included_at = DateTime.now
-      run.save!
+      if File.exist?(json_path)
+        begin
+        run.result = JSON.load(File.open(json_path))
+        run.result = {"result"=>run.result} unless run.result.is_a?(Hash)
+        is_updated = true
+        rescue => ex
+          $stderr.puts ex.message
+        end
+      end
+
+      if is_updated
+        run.included_at = DateTime.now
+        run.save!
+      end
     }
   end
 end

--- a/spec/lib/job_script_util_spec.rb
+++ b/spec/lib/job_script_util_spec.rb
@@ -275,7 +275,7 @@ EOS
         end
 
         expect {
-        JobScriptUtil.update_run(@run)
+          JobScriptUtil.update_run(@run)
         }.not_to change { @run.result }
 
         # parse status

--- a/spec/lib/job_script_util_spec.rb
+++ b/spec/lib/job_script_util_spec.rb
@@ -109,9 +109,9 @@ EOS
     end
   end
 
-  describe ".expand_result_file_and_update_run" do
+  describe ".expand_result" do
 
-    it "expand results and parse _status.json" do
+    it "expand results" do
       @sim.command = "echo '{\"timeline\":[1,2,3]}' > _output.json"
       @sim.support_input_json = true
       @sim.save!
@@ -119,156 +119,254 @@ EOS
       Dir.chdir(@temp_dir) {
         result_file = "#{@run.id}.tar.bz2"
         FileUtils.mv( result_file, @run.dir.join('..') )
-        JobScriptUtil.expand_result_file_and_update_run(@run)
+        JobScriptUtil.expand_result_file(@run)
 
         # expand result properly
         File.exist?(@run.dir.join('_stdout.txt')).should be_true
         File.exist?(@run.dir.join('_output.json')).should be_true
         File.exist?(@run.dir.join('..', "#{@run.id}.tar")).should be_false
         File.exist?(@run.dir.join('..', "#{@run.id}.tar.bz2")).should be_true
+      }
+    end
+
+    context "when archive is invalid archive" do
+      it "raise error" do
+        Dir.chdir(@temp_dir) {
+          system("echo 1.2345 > #{@run.id}.tar.bz2")
+          result_file = "#{@run.id}.tar.bz2"
+          FileUtils.mv( result_file, @run.dir.join('..') )
+          expect {
+            JobScriptUtil.expand_result_file(@run)
+          }.to raise_error
+        }
+      end
+    end
+  end
+
+  describe ".update_run" do
+
+    before(:each) do
+      @sim.command = "echo '{\"timeline\":[1,2,3]}' > _output.json"
+      @sim.support_input_json = true
+      @sim.save!
+      run_test_script_in_temp_dir
+      Dir.chdir(@temp_dir) {
+        result_file = "#{@run.id}.tar.bz2"
+        FileUtils.mv( result_file, @run.dir.join('..') )
+      }
+      JobScriptUtil.expand_result_file(@run)
+    end
+
+    it "parse _status.json" do
+
+      JobScriptUtil.update_run(@run)
+
+      # parse status
+      @run.reload
+      @run.status.should eq :finished
+      @run.hostname.should_not be_empty
+      @run.started_at.should be_a(DateTime)
+      @run.finished_at.should be_a(DateTime)
+      @run.real_time.should_not be_nil
+      @run.cpu_time.should_not be_nil
+      @run.included_at.should be_a(DateTime)
+    end
+
+    context "when _status.json has invalid json format" do
+
+      it "do not update status" do
+
+        parsed = JSON.load(File.open(@run.dir.join("_status.json")))
+        File.open(@run.dir.join("_status.json"), "w") do |io|
+          #puts a part of string
+          io.puts parsed.to_json[0..10]
+        end
+
+        JobScriptUtil.update_run(@run)
+
+        # parse status
+        @run.reload
+        @run.status.should eq :created
+        @run.hostname.should be_nil
+        @run.started_at.should be_nil
+        @run.finished_at.should be_nil
+        @run.real_time.should_not be_nil
+        @run.cpu_time.should_not be_nil
+        @run.included_at.should be_a(DateTime)
+      end
+    end
+
+    it "parse _output.json which is not a Hash but a Float" do
+
+      Dir.chdir(@run.dir) {
+        result = 0.12345
+        system("echo #{result} > _output.json")
+      }
+
+      JobScriptUtil.update_run(@run)
+
+      # expand result properly
+      File.exist?(@run.dir.join('_output.json')).should be_true
+
+      # parse status
+      @run.reload
+      @run.result.should eq Hash["result",0.12345]
+    end
+
+    it "parse _output.json which is not a Hash but a Boolean" do
+
+      Dir.chdir(@run.dir) {
+        result = false
+        system("echo #{result} > _output.json")
+      }
+
+      JobScriptUtil.update_run(@run)
+
+      # expand result properly
+      File.exist?(@run.dir.join('_output.json')).should be_true
+
+      # parse status
+      @run.reload
+      @run.result.should eq Hash["result",false]
+    end
+
+    it "parse _output.json which is not a Hash but a String" do
+
+      Dir.chdir(@run.dir) {
+        result = "12345"
+        system("echo \\\"#{result}\\\" > _output.json")
+      }
+
+      JobScriptUtil.update_run(@run)
+
+      # expand result properly
+      File.exist?(@run.dir.join('_output.json')).should be_true
+
+      # parse status
+      @run.reload
+      @run.result.should eq Hash["result","12345"]
+    end
+
+    it "parse _output.json which is not a Hash but a Array" do
+
+      Dir.chdir(@run.dir) {
+        result = [1,2,3]
+        system("echo #{result} > _output.json")
+      }
+
+      JobScriptUtil.update_run(@run)
+
+      # expand result properly
+      File.exist?(@run.dir.join('_output.json')).should be_true
+
+      # parse status
+      @run.reload
+      @run.result.should eq Hash["result",[1,2,3]]
+    end
+
+    context "when _output.json has invalid json format" do
+
+      it "do not update result" do
+
+        parsed = JSON.load(File.open(@run.dir.join("_output.json")))
+        File.open(@run.dir.join("_output.json"), "w") do |io|
+          #puts a part of string
+          io.puts parsed.to_json[0..10]
+        end
+
+        expect {
+        JobScriptUtil.update_run(@run)
+        }.not_to change { @run.result }
 
         # parse status
         @run.reload
         @run.status.should eq :finished
-        @run.hostname.should_not be_empty
+        @run.hostname.should_not be_nil
         @run.started_at.should be_a(DateTime)
         @run.finished_at.should be_a(DateTime)
         @run.real_time.should_not be_nil
         @run.cpu_time.should_not be_nil
         @run.included_at.should be_a(DateTime)
-        @run.result.should eq Hash["timeline",[1,2,3]]
-      }
-    end
-
-    it "expand results which is not a Hash but a Float" do
-      @sim.command = "echo '0.12345' > _output.json"
-      @sim.support_input_json = true
-      @sim.save!
-      run_test_script_in_temp_dir
-      Dir.chdir(@temp_dir) {
-        result_file = "#{@run.id}.tar.bz2"
-        FileUtils.mv( result_file, @run.dir.join('..') )
-        JobScriptUtil.expand_result_file_and_update_run(@run)
-
-        # expand result properly
-        File.exist?(@run.dir.join('_output.json')).should be_true
-
-        # parse status
-        @run.reload
-        @run.result.should eq Hash["result",0.12345]
-      }
-    end
-
-    it "expand results which is not a Hash but a Boolean" do
-      @sim.command = "echo 'false' > _output.json"
-      @sim.support_input_json = true
-      @sim.save!
-      run_test_script_in_temp_dir
-      Dir.chdir(@temp_dir) {
-        result_file = "#{@run.id}.tar.bz2"
-        FileUtils.mv( result_file, @run.dir.join('..') )
-        JobScriptUtil.expand_result_file_and_update_run(@run)
-
-        # expand result properly
-        File.exist?(@run.dir.join('_output.json')).should be_true
-
-        # parse status
-        @run.reload
-        @run.result.should eq Hash["result",false]
-      }
-    end
-
-    it "expand results which is not a Hash but a String" do
-      @sim.command = "echo '\"12345\"' > _output.json"
-      @sim.support_input_json = true
-      @sim.save!
-      run_test_script_in_temp_dir
-      Dir.chdir(@temp_dir) {
-        result_file = "#{@run.id}.tar.bz2"
-        FileUtils.mv( result_file, @run.dir.join('..') )
-        JobScriptUtil.expand_result_file_and_update_run(@run)
-
-        # expand result properly
-        File.exist?(@run.dir.join('_output.json')).should be_true
-
-        # parse status
-        @run.reload
-        @run.result.should eq Hash["result","12345"]
-      }
-    end
-
-    it "expand results which is not a Hash but a Array" do
-      @sim.command = "echo '[1,2,3]' > _output.json"
-      @sim.support_input_json = true
-      @sim.save!
-      run_test_script_in_temp_dir
-      Dir.chdir(@temp_dir) {
-        result_file = "#{@run.id}.tar.bz2"
-        FileUtils.mv( result_file, @run.dir.join('..') )
-        JobScriptUtil.expand_result_file_and_update_run(@run)
-
-        # expand result properly
-        File.exist?(@run.dir.join('_output.json')).should be_true
-
-        # parse status
-        @run.reload
-        @run.result.should eq Hash["result",[1,2,3]]
-      }
+      end
     end
 
     it "parse elapsed times" do
-      @sim.command = "sleep 1"
-      @sim.support_input_json = true
-      @sim.save!
-      run_test_script_in_temp_dir
-      Dir.chdir(@temp_dir) {
-        result_file = "#{@run.id}.tar.bz2"
-        FileUtils.mv( result_file, @run.dir.join('..') )
-        JobScriptUtil.expand_result_file_and_update_run(@run)
 
+      time_str=<<EOS
+real 0.30
+user 0.20
+sys 0.10
+EOS
+      File.open(@run.dir.join("_time.txt"), "w") do |io|
+        io.puts time_str
+      end
+
+      JobScriptUtil.update_run(@run)
+
+      @run.reload
+      @run.cpu_time.should eq 0.2
+      @run.real_time.should eq 0.3
+    end
+
+    context "when _time.txt has invalid format" do
+
+      it "do not update result" do
+
+        time_str=<<EOS
+user 0.20
+sys 0.10
+EOS
+        File.open(@run.dir.join("_time.txt"), "w") do |io|
+          io.puts time_str
+        end
+
+        expect {
+          JobScriptUtil.update_run(@run)
+        }.not_to change { @run.real_time }
+
+        # parse status
         @run.reload
-        @run.cpu_time.should be_within(0.2).of(0.0)
-        @run.real_time.should be_within(0.2).of(1.0)
-      }
+        @run.status.should eq :finished
+        @run.hostname.should_not be_nil
+        @run.started_at.should be_a(DateTime)
+        @run.finished_at.should be_a(DateTime)
+        @run.real_time.should be_nil
+        @run.cpu_time.should_not be_nil
+        @run.included_at.should be_a(DateTime)
+      end
     end
 
     it "parse failed jobs" do
-      @sim.command = "INVALID"
-      @sim.save!
-      run_test_script_in_temp_dir
-      Dir.chdir(@temp_dir) {
-        result_file = "#{@run.id}.tar.bz2"
-        FileUtils.mv( result_file, @run.dir.join('..') )
-        JobScriptUtil.expand_result_file_and_update_run(@run)
 
-        @run.reload
-        @run.status.should eq :failed
-        @run.hostname.should_not be_empty
-        @run.started_at.should be_a(DateTime)
-        @run.finished_at.should be_a(DateTime)
-        @run.real_time.should_not be_nil
-        @run.cpu_time.should_not be_nil
-        @run.included_at.should be_a(DateTime)
-        File.exist?(@run.dir.join('_stdout.txt')).should be_true
-      }
+      parsed = JSON.load(File.open(@run.dir.join("_status.json")))
+      parsed["rc"] = "-1"
+      File.open(@run.dir.join("_status.json"), "w") do |io|
+        io.puts parsed.to_json
+      end
+
+      JobScriptUtil.update_run(@run)
+
+      @run.reload
+      @run.status.should eq :failed
+      @run.hostname.should_not be_empty
+      @run.started_at.should be_a(DateTime)
+      @run.finished_at.should be_a(DateTime)
+      @run.real_time.should_not be_nil
+      @run.cpu_time.should_not be_nil
+      @run.included_at.should be_a(DateTime)
+      File.exist?(@run.dir.join('_stdout.txt')).should be_true
     end
 
-    context "when print_version_command is not nil" do
+    it "parses simulator version printed by Simulator#print_version_command" do
 
-      it "parses simulator version printed by Simulator#print_version_command" do
-        @sim.command = "echo '[1,2,3]' > _output.json"
-        @sim.support_input_json = true
-        @sim.print_version_command = 'echo "simulator version: 1.0.0"'
-        @sim.save!
-        run_test_script_in_temp_dir
-        Dir.chdir(@temp_dir) {
-          result_file = "#{@run.id}.tar.bz2"
-          FileUtils.mv( result_file, @run.dir.join('..') )
-          JobScriptUtil.expand_result_file_and_update_run(@run)
-
-          @run.simulator_version.should eq "simulator version: 1.0.0"
-        }
+      File.open(@run.dir.join("_version.txt"), "w") do |io|
+        io.puts "simulator version: 1.0.0"
       end
+
+      JobScriptUtil.update_run(@run)
+
+      @run.reload
+      @run.simulator_version.should eq "simulator version: 1.0.0"
     end
   end
 end


### PR DESCRIPTION
For #142 
Implement record simulator version when job is failed.
#### Modification
- separate expand_archive and update_run methods
- update run when job is failed
- put _version.txt in run directory before job execution
#### Note
- update your host script since job_script_template is modified
