### PR TITLE
enable to rename simulator

### DIFF
--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -18,7 +18,6 @@ class Simulator
   has_and_belongs_to_many :executable_on, class_name: "Host", inverse_of: :executable_simulators
 
   validates :name, presence: true, uniqueness: true, format: {with: /\A\w+\z/}
-  validate :name_not_changed_after_ps_created
   validates :command, presence: true
   validates :parameter_definitions, presence: true
 
@@ -254,11 +253,5 @@ EOS
 
   def create_simulator_dir
     FileUtils.mkdir_p(ResultDirectory.simulator_path(self))
-  end
-
-  def name_not_changed_after_ps_created
-    if self.persisted? and self.parameter_sets.any? and self.name_changed?
-      errors.add(:name, "is not editable when a parameter set exists")
-    end
   end
 end

--- a/app/views/simulators/_form.html.haml
+++ b/app/views/simulators/_form.html.haml
@@ -4,7 +4,7 @@
   .control-group
     = f.label(:name, class: 'control-label')
     .controls
-      = f.text_field(:name, class: 'text_field', disabled: has_ps)
+      = f.text_field(:name, class: 'text_field')
   #parameters_form.control-group
     = label_tag('', 'Definition of Parameters', class: 'control-label')
     .controls

--- a/spec/models/simulator_spec.rb
+++ b/spec/models/simulator_spec.rb
@@ -32,10 +32,10 @@ describe Simulator do
       Simulator.new(@valid_fields.update({name:"b l a n k"})).should_not be_valid
     end
 
-    it "is not editable after a parameter set is created" do
+    it "is editable after a parameter set is created" do
       sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 0)
       sim.name = "AnotherSimulator"
-      sim.should_not be_valid
+      sim.should be_valid
     end
   end
 


### PR DESCRIPTION
For #161 
- now enable to rename simulator
- after the name of simulator changed, time stamp of simulator is also updated.
