### PR TITLE
Put torque stdout and stderr on work base dir

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -64,7 +64,7 @@ class Host
   def status
     ret = nil
     start_ssh do |ssh|
-      wrapper = SchedulerWrapper.new(self.scheduler_type)
+      wrapper = SchedulerWrapper.new(self)
       cmd = wrapper.all_status_command
       ret = SSHUtil.execute(ssh, cmd)
     end

--- a/app/services/remote_file_path.rb
+++ b/app/services/remote_file_path.rb
@@ -22,19 +22,20 @@ module RemoteFilePath
 
   def self.scheduler_log_file_paths(host, run)
     a = []
+    work_base_dir = Pathname.new(host.work_base_dir)
     case host.scheduler_type
     when "pjm"
-      a << Pathname.new("~").join("#{run.id}.sh.o#{run.job_id}")
-      a << Pathname.new("~").join("#{run.id}.sh.e#{run.job_id}")
-      a << Pathname.new("~").join("#{run.id}.sh.i#{run.job_id}")
+      a << work_base_dir.join("#{run.id}.sh.o#{run.job_id}")
+      a << work_base_dir.join("#{run.id}.sh.e#{run.job_id}")
+      a << work_base_dir.join("#{run.id}.sh.i#{run.job_id}")
     when "pjm_k"
-      a << Pathname.new("~").join("J#{run.id}.sh.o#{run.job_id}")
-      a << Pathname.new("~").join("J#{run.id}.sh.e#{run.job_id}")
-      a << Pathname.new("~").join("J#{run.id}.sh.i#{run.job_id}")
-      a << Pathname.new("~").join("J#{run.id}.sh.s#{run.job_id}")
+      a << work_base_dir.join("J#{run.id}.sh.o#{run.job_id}")
+      a << work_base_dir.join("J#{run.id}.sh.e#{run.job_id}")
+      a << work_base_dir.join("J#{run.id}.sh.i#{run.job_id}")
+      a << work_base_dir.join("J#{run.id}.sh.s#{run.job_id}")
     when "torque"
-      a << Pathname.new("~").join("#{run.id}.sh.o#{run.job_id.to_i}") # run.job_id = 12345.host
-      a << Pathname.new("~").join("#{run.id}.sh.e#{run.job_id.to_i}")
+      a << work_base_dir.join("#{run.id}.sh.o#{run.job_id.to_i}") # run.job_id = 12345.host
+      a << work_base_dir.join("#{run.id}.sh.e#{run.job_id.to_i}")
     end
     a
   end

--- a/app/services/remote_job_handler.rb
+++ b/app/services/remote_job_handler.rb
@@ -92,7 +92,7 @@ class RemoteJobHandler
   end
 
   def submit_to_scheduler(run, job_script_path)
-    cmd = SchedulerWrapper.new(@host.scheduler_type).submit_command(job_script_path)
+    cmd = SchedulerWrapper.new(@host).submit_command(job_script_path)
     @host.start_ssh do |ssh|
       out, err, rc, sig = SSHUtil.execute2(ssh, cmd)
       raise RemoteOperationError, "#{cmd} failed : #{rc}, #{err}" unless rc == 0

--- a/app/services/remote_job_handler.rb
+++ b/app/services/remote_job_handler.rb
@@ -26,7 +26,7 @@ class RemoteJobHandler
 
   def remote_status(run)
     status = :unknown
-    scheduler = SchedulerWrapper.new(@host.scheduler_type)
+    scheduler = SchedulerWrapper.new(@host)
     cmd = scheduler.status_command(run.job_id)
     @host.start_ssh do |ssh|
       out, err, rc, sig = SSHUtil.execute2(ssh, cmd)
@@ -38,7 +38,7 @@ class RemoteJobHandler
   def cancel_remote_job(run)
     stat = remote_status(run)
     if stat == :submitted or stat == :running
-      scheduler = SchedulerWrapper.new(@host.scheduler_type)
+      scheduler = SchedulerWrapper.new(@host)
       cmd = scheduler.cancel_command(run.job_id)
       @host.start_ssh do |ssh|
         out, err, rc, sig = SSHUtil.execute2(ssh, cmd)

--- a/lib/scheduler_wrapper.rb
+++ b/lib/scheduler_wrapper.rb
@@ -8,7 +8,7 @@ class SchedulerWrapper
     unless TYPES.include?(host.scheduler_type)
       raise ArgumentError.new("type must be selected from #{TYPES.inspect}")
     end
-    @type = type
+    @type = host.scheduler_type
     @work_base_dir = Pathname.new(host.work_base_dir)
   end
 

--- a/lib/scheduler_wrapper.rb
+++ b/lib/scheduler_wrapper.rb
@@ -4,11 +4,12 @@ class SchedulerWrapper
 
   attr_reader :type
 
-  def initialize(type)
-    unless TYPES.include?(type)
+  def initialize(host)
+    unless TYPES.include?(host.scheduler_type)
       raise ArgumentError.new("type must be selected from #{TYPES.inspect}")
     end
     @type = type
+    @work_base_dir = Pathname.new(host.work_base_dir)
   end
 
   def submit_command(script)
@@ -16,11 +17,11 @@ class SchedulerWrapper
     when "none"
       "nohup bash #{script} > /dev/null 2>&1 < /dev/null & basename #{script}"
     when "torque"
-      "qsub #{script}"
+      "cd #{@work_base_dir}; qsub #{script}"
     when "pjm"
-      "pjsub #{script}"
+      "cd #{@work_base_dir}; pjsub #{script}"
     when "pjm_k"
-      ". /etc/bashrc; pjsub #{script} < /dev/null"
+      ". /etc/bashrc; cd #{@work_base_dir}; pjsub #{script} < /dev/null"
     else
       raise "not supported"
     end

--- a/spec/lib/scheduler_wrapper_spec.rb
+++ b/spec/lib/scheduler_wrapper_spec.rb
@@ -2,10 +2,16 @@ require 'spec_helper'
 
 describe SchedulerWrapper do
 
+  before(:each) do
+    @host = FactoryGirl.create(:host)
+  end
+
   it "is initialized with a correct type" do
     possible_types = SchedulerWrapper::TYPES.each do |type|
+      @host.scheduler_type = type
+      @host.save!
       expect {
-        SchedulerWrapper.new(type)
+        SchedulerWrapper.new(@host)
       }.to_not raise_error
     end
   end
@@ -19,7 +25,9 @@ describe SchedulerWrapper do
   describe "none" do
 
     before(:each) do
-      @wrapper = SchedulerWrapper.new("none")
+      @host.scheduler_type = "none"
+      @host.save!
+      @wrapper = SchedulerWrapper.new(@host)
     end
 
     describe "#submit_command" do
@@ -65,13 +73,15 @@ EOS
   describe "torque" do
 
     before(:each) do
-      @wrapper = SchedulerWrapper.new("torque")
+      @host.scheduler_type = "torque"
+      @host.save!
+      @wrapper = SchedulerWrapper.new(@host)
     end
 
     describe "#submit_command" do
 
       it "returns a command to submit a job" do
-        @wrapper.submit_command("~/path/to/job.sh").should eq "qsub ~/path/to/job.sh"
+        @wrapper.submit_command("~/path/to/job.sh").should eq "cd #{@host.work_base_dir}; qsub ~/path/to/job.sh"
       end
     end
 
@@ -112,13 +122,15 @@ EOS
   describe "pjm_k" do
 
     before(:each) do
-      @wrapper = SchedulerWrapper.new("pjm_k")
+      @host.scheduler_type = "pjm_k"
+      @host.save!
+      @wrapper = SchedulerWrapper.new(@host)
     end
 
     describe "#submit_command" do
 
       it "returns a command to submit a job" do
-        @wrapper.submit_command("~/path/to/job.sh").should eq ". /etc/bashrc; pjsub ~/path/to/job.sh < /dev/null"
+        @wrapper.submit_command("~/path/to/job.sh").should eq ". /etc/bashrc; cd #{@host.work_base_dir}; pjsub ~/path/to/job.sh < /dev/null"
       end
     end
 


### PR DESCRIPTION
When a job is submitted to torque scheduler or pjm scheduler, stdout file and stderr file should be put on work_base_dir.
