### PR TITLE
Pause job submission and observation

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -15,7 +15,7 @@ class HostsController < ApplicationController
   def show
     @host = Host.find(params[:id])
     if (@host.connected? rescue false)
-      @status = @host.status
+      @status = @host.scheduler_status
     else
       flash.now[:alert] = "Failed to establish connection. Check host information."
       @status = @host.connection_error.inspect

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -15,10 +15,10 @@ class HostsController < ApplicationController
   def show
     @host = Host.find(params[:id])
     if (@host.connected? rescue false)
-      @status = @host.scheduler_status
+      @scheduler_status = @host.scheduler_status
     else
       flash.now[:alert] = "Failed to establish connection. Check host information."
-      @status = @host.connection_error.inspect
+      @scheduler_status = @host.connection_error.inspect
     end
 
     respond_to do |format|

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -1,0 +1,14 @@
+module HostsHelper
+
+  def host_status_label(status)
+    case status
+    when :submittable
+      '<span class="label label-success">submittable</span>'
+    when :stopping
+      '<span class="label label-important">stopping</span>'
+    else
+      "<span class=\"label\">#{status}</span>"
+    end
+  end
+end
+

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -2,10 +2,10 @@ module HostsHelper
 
   def host_status_label(status)
     case status
-    when :submittable
-      '<span class="label label-success">submittable</span>'
-    when :stopping
-      '<span class="label label-important">stopping</span>'
+    when :enabled
+      '<span class="label label-success">enabled</span>'
+    when :disabled
+      '<span class="label label-important">disabled</span>'
     else
       "<span class=\"label\">#{status}</span>"
     end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -4,9 +4,9 @@ class Host
   field :name, type: String
   field :hostname, type: String
 
-  HOST_STATUS = [:submittable, :stopping]
+  HOST_STATUS = [:enabled, :disabled]
 
-  field :status, type: Symbol, default: HOST_STATUS[0] # either :submittable, :stopping
+  field :status, type: Symbol, default: HOST_STATUS[0]
   field :user, type: String
   field :port, type: Integer, default: 22
   field :ssh_key, type: String, default: '~/.ssh/id_rsa'

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -3,6 +3,10 @@ class Host
   include Mongoid::Timestamps
   field :name, type: String
   field :hostname, type: String
+
+  HOST_STATUS = [:submittable, :stopping]
+
+  field :status, type: Symbol, default: HOST_STATUS[0] # either :submittable, :stopping
   field :user, type: String
   field :port, type: Integer, default: 22
   field :ssh_key, type: String, default: '~/.ssh/id_rsa'
@@ -33,6 +37,8 @@ class Host
   validates :max_mpi_procs, numericality: {greater_than_or_equal_to: 1}
   validates :min_omp_threads, numericality: {greater_than_or_equal_to: 1}
   validates :max_omp_threads, numericality: {greater_than_or_equal_to: 1}
+  validates :status, presence: true,
+                     inclusion: {in: HOST_STATUS}
   validate :work_base_dir_is_not_editable_when_submitted_runs_exist
   validate :min_is_not_larger_than_max
   validate :template_conform_to_host_parameter_definitions
@@ -64,7 +70,7 @@ class Host
 
   attr_reader :connection_error
 
-  def status
+  def scheduler_status
     ret = nil
     start_ssh do |ssh|
       wrapper = SchedulerWrapper.new(self)

--- a/app/views/hosts/_about.html.haml
+++ b/app/views/hosts/_about.html.haml
@@ -8,6 +8,9 @@
       %th Hostname
       %td= @host.hostname
     %tr
+      %th Status
+      %td= raw(host_status_label(@host.status))
+    %tr
       %th User
       %td= @host.user
     %tr

--- a/app/views/hosts/_form.html.haml
+++ b/app/views/hosts/_form.html.haml
@@ -10,6 +10,10 @@
     .controls
       = f.text_field(:hostname, class: 'text_field')
   .control-group
+    = f.label(:status, class: 'control-label')
+    .controls
+      = f.select(:status, Host::HOST_STATUS)
+  .control-group
     = f.label(:user, class: 'control-label')
     .controls
       = f.text_field(:user, class: 'text_field')

--- a/app/views/hosts/_info.html.haml
+++ b/app/views/hosts/_info.html.haml
@@ -1,4 +1,4 @@
-%h3 Host Status
+%h3 Job Status
 
 %table.table.table-striped{style: "table-layout: fixed;"}
   %thead
@@ -25,4 +25,6 @@
       %td= "#{stat_count[:submitted]} (#{(100.0*stat_count[:submitted]/total.to_f).round(1)} %)"
       %td= "#{stat_count[:created]} (#{(100.0*stat_count[:created]/total.to_f).round(1)} %)"
 
-%pre= @status
+%h3 Scheduler status
+
+%pre= @scheduler_status

--- a/app/views/hosts/index.html.haml
+++ b/app/views/hosts/index.html.haml
@@ -6,6 +6,7 @@
     %tr
       %th Name
       %th Hostname
+      %th Status
       %th User
       %th Port
       %th Ssh key
@@ -23,6 +24,7 @@
       = content_tag_for :tr, host do
         %td= link_to(host.name, host)
         %td= host.hostname
+        %td= raw(host_status_label(host.status))
         %td= host.user
         %td= host.port
         %td= host.ssh_key

--- a/app/views/hosts/show.html.haml
+++ b/app/views/hosts/show.html.haml
@@ -6,10 +6,10 @@
     %li
       %a{"href"=>"#tab-about", "data-toggle" => "tab"} About
     %li.active
-      %a{"href"=>"#tab-status", "data-toggle" => "tab"} Status
+      %a{"href"=>"#tab-info", "data-toggle" => "tab"} Infomation
 
   %div.tab-content
     %div.tab-pane#tab-about
       = render "about"
-    %div.tab-pane.active#tab-status
-      = render "status"
+    %div.tab-pane.active#tab-info
+      = render "info"

--- a/app/workers/job_observer.rb
+++ b/app/workers/job_observer.rb
@@ -1,7 +1,7 @@
 class JobObserver
 
   def self.perform(logger)
-    Host.all.each do |host|
+    Host.where(status: :enabled).each do |host|
       begin
         observe_host(host, logger)
       rescue => ex

--- a/app/workers/job_submitter.rb
+++ b/app/workers/job_submitter.rb
@@ -1,7 +1,7 @@
 class JobSubmitter
 
   def self.perform(logger)
-    Host.all.each do |host|
+    Host.where(status: :enabled).each do |host|
       begin
         num = host.max_num_jobs - host.submitted_runs.count
         if num > 0

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -13,7 +13,7 @@ describe Host do
         ssh_key: '~/.ssh/id_rsa',
         scheduler_type: 'none',
         work_base_dir: '~/__cm_work__',
-        status: :submittable
+        status: :enabled
       }
     end
 
@@ -129,8 +129,8 @@ describe Host do
       host.should_not be_valid
     end
 
-    it "status must be either ':submittable' or ':stopping'" do
-      @valid_attr.update(status: :stopping)
+    it "status must be either ':enabled' or ':disabled'" do
+      @valid_attr.update(status: :disabled)
       host = Host.new(@valid_attr)
       host.should be_valid
       @valid_attr.update(status: :running)

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -13,6 +13,7 @@ describe Host do
         ssh_key: '~/.ssh/id_rsa',
         scheduler_type: 'none',
         work_base_dir: '~/__cm_work__',
+        status: :submittable
       }
     end
 
@@ -124,6 +125,15 @@ describe Host do
 
     it "max_omp_threads must be larger than min_omp_threads" do
       @valid_attr.update(min_omp_threads: 2, max_omp_threads: 1)
+      host = Host.new(@valid_attr)
+      host.should_not be_valid
+    end
+
+    it "status must be either ':submittable' or ':stopping'" do
+      @valid_attr.update(status: :stopping)
+      host = Host.new(@valid_attr)
+      host.should be_valid
+      @valid_attr.update(status: :running)
       host = Host.new(@valid_attr)
       host.should_not be_valid
     end

--- a/spec/workers/job_submitter_spec.rb
+++ b/spec/workers/job_submitter_spec.rb
@@ -34,6 +34,18 @@ describe JobSubmitter do
       }.to_not raise_error
     end
 
+    it "do nothing if there is no 'enabled' hosts" do
+      @sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1)
+      @host.update_attribute(:status, :disabled)
+      @sim.executable_on.push @host
+      expect {
+        JobSubmitter.perform(@logger)
+      }.to change { Run.where(status: :created).count }.by(0)
+      expect {
+        JobSubmitter.perform(@logger)
+      }.to_not raise_error
+    end
+
     it "enqueus jobs to remote host in order of priorities on runs" do
       @sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1)
       @sim.executable_on.push @host


### PR DESCRIPTION
Fixed #128 
### Specifiication
- host has 'status' field
  - status field is either enable or disable
  - status disable means that the host does not submit and include any jobs
- update host view
  - host status is editable
  - separate 'host status' to 'job status' and 'scheduler status'
    Note
- restart worker before try to change host status.
