### PR TITLE
add a button to destroy the parameter_set

### DIFF
--- a/app/controllers/parameter_sets_controller.rb
+++ b/app/controllers/parameter_sets_controller.rb
@@ -75,11 +75,19 @@ class ParameterSetsController < ApplicationController
 
   def destroy
     @ps = ParameterSet.find(params[:id])
+    simulator = Simulator.find(@ps.simulator_id)
     @ps.destroy
 
+    request_from = Rails.application.routes.recognize_path(request.referer)
     respond_to do |format|
-      format.json { head :no_content }
-      format.js
+      if request_from[:action] == "show" and request_from[:controller] == "simulators"
+        # delete from datatables in :action => "show" and :controller => "simulators"
+        format.json { head :no_content }
+        format.js
+      else
+        format.html { redirect_to simulator_path(simulator) }
+        format.json { head :no_content }
+      end
     end
   end
 

--- a/app/controllers/parameter_sets_controller.rb
+++ b/app/controllers/parameter_sets_controller.rb
@@ -81,7 +81,7 @@ class ParameterSetsController < ApplicationController
     request_from = Rails.application.routes.recognize_path(request.referer)
     respond_to do |format|
       if request_from[:action] == "show" and request_from[:controller] == "simulators"
-        # delete from datatables in :action => "show" and :controller => "simulators"
+        # called by datatables in :action => "show" and :controller => "simulators"
         format.json { head :no_content }
         format.js
       else

--- a/app/views/parameter_sets/show.html.haml
+++ b/app/views/parameter_sets/show.html.haml
@@ -19,6 +19,7 @@
       = render partial: "shared/parameters_table", locals: {parameters_hash: @param_set.v}
       .form-actions
         = link_to("Duplicate", duplicate_parameter_set_path(@param_set), class: 'btn btn-primary')
+        = link_to 'Destroy', @param_set, method: :delete, data: { confirm: 'Are you sure?'}, class: 'btn btn-warning'
     .tab-pane.active#tab-list-runs
       = render "runs", parameter_set: @param_set
     .tab-pane#tab-analyses

--- a/spec/controllers/parameter_sets_controller_spec.rb
+++ b/spec/controllers/parameter_sets_controller_spec.rb
@@ -267,7 +267,7 @@ describe ParameterSetsController do
       it "respond to simulator show" do
         request.stub(:referer).and_return("http://localhost:3000/simulators/53216ec881e31ec599000001")
         delete :destroy, {id: @ps.to_param}, valid_session
-        response.should_not redirect_to(simulator_path(@sim))
+        response.should_not redirect_to(@sim)
       end
     end
 

--- a/spec/controllers/parameter_sets_controller_spec.rb
+++ b/spec/controllers/parameter_sets_controller_spec.rb
@@ -261,6 +261,24 @@ describe ParameterSetsController do
         delete :destroy, {id: @ps.to_param}, valid_session
       }.to change(ParameterSet, :count).by(-1)
     end
+
+    context "called by simulator#show" do
+
+      it "respond to simulator show" do
+        request.stub(:referer).and_return("http://localhost:3000/simulators/53216ec881e31ec599000001")
+        delete :destroy, {id: @ps.to_param}, valid_session
+        response.should_not redirect_to(simulator_path(@sim))
+      end
+    end
+
+    context "called by parameter_set#show" do
+
+      it "respond to simulator show" do
+        request.stub(:referer).and_return("http://localhost:3000/parameter_sets/5321780f81e31eb781000178")
+        delete :destroy, {id: @ps.to_param}, valid_session
+        response.should redirect_to(@sim)
+      end
+    end
   end
 
   describe "GET _runs_list" do


### PR DESCRIPTION
Fixed #192 
### Specification
- add a delete button on parameter_set#show page
- pop-up confirmation message before destroy parameter_set
- link_to simulator#show page after the parameter_set is destroyed
