### PR TITLE
Set polling interval for each host

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -20,6 +20,7 @@ class Host
   field :max_omp_threads, type: Integer, default: 1
   field :template, type: String, default: JobScriptUtil::DEFAULT_TEMPLATE
   field :position, type: Integer # position in the table. start from zero
+  field :polling_interval, type: Integer, default: 60
 
   has_and_belongs_to_many :executable_simulators, class_name: "Simulator", inverse_of: :executable_on
   embeds_many :host_parameter_definitions
@@ -39,6 +40,7 @@ class Host
   validates :max_omp_threads, numericality: {greater_than_or_equal_to: 1}
   validates :status, presence: true,
                      inclusion: {in: HOST_STATUS}
+  validates :polling_interval, numericality: {greater_than_or_equal_to: 5}
   validate :work_base_dir_is_not_editable_when_submitted_runs_exist
   validate :min_is_not_larger_than_max
   validate :template_conform_to_host_parameter_definitions

--- a/app/views/hosts/_about.html.haml
+++ b/app/views/hosts/_about.html.haml
@@ -11,6 +11,9 @@
       %th Status
       %td= raw(host_status_label(@host.status))
     %tr
+      %th Polling interval
+      %td= @host.polling_interval
+    %tr
       %th User
       %td= @host.user
     %tr

--- a/app/views/hosts/_form.html.haml
+++ b/app/views/hosts/_form.html.haml
@@ -14,6 +14,10 @@
     .controls
       = f.select(:status, Host::HOST_STATUS)
   .control-group
+    = f.label(:polling_interval, class: 'control-label')
+    .controls
+      = f.text_field(:polling_interval, class: 'text_field')
+  .control-group
     = f.label(:user, class: 'control-label')
     .controls
       = f.text_field(:user, class: 'text_field')

--- a/app/workers/cache_updater.rb
+++ b/app/workers/cache_updater.rb
@@ -1,5 +1,5 @@
 class CacheUpdater
-  MAX_PS_NUM_TO_UPDATE = 100
+  MAX_PS_NUM_TO_UPDATE = 5
 
   def self.perform(logger)
     logger.info "updating cache for parameter sets"

--- a/app/workers/job_observer.rb
+++ b/app/workers/job_observer.rb
@@ -1,39 +1,7 @@
 class JobObserver
 
   def self.perform(logger)
-    @term_received = false
-    trap('TERM') {
-      @term_received = true
-      logger.info("TERM received by JobObserver. stopping")
-    }
-
-    # { "host_id1"=>"pid1", "host_id2"=>"pid2", ... }
-    # host process will be created: {"host_id"=>nil}
-    # host process is running: {"host_id"=>"pid"}
-    # host process is stopping: {"host_id"=>"pid"}
-    # host process is stopped: {}
-    @host_pids = {}
-    loop do
-      check_host_process(logger)
-      Host.where(status: :enabled).each do |host|
-        @host_pids[host.to_param] ||= nil
-      end
-      num_start_process = @host_pids.values.select {|v| v.nil?}.length
-      logger.info("JobObserver: #{num_start_process} host processes will be forked") if num_start_process > 0
-      fork_host_process(logger)
-      disabled_host_ids = Host.where(status: :disabled).map(&:id).map{|o| o.to_s}
-      kill_host_process(logger, disabled_host_ids)
-
-      if @term_received
-        break
-      else
-        sleep 5 # wait 5 sec
-      end
-    end
-
-    kill_host_process(logger, @host_pids.keys)
-    logger.info("JobObserver: waiting host porcess stopping")
-    Process.waitall
+    JobWorkerUtil.perform(logger, JobObserver.method(:observe_host))
   end
 
   private
@@ -44,6 +12,7 @@ class JobObserver
     host.start_ssh do |ssh|
       handler = RemoteJobHandler.new(host)
       # check if job is finished
+      observed_runs = {}
       host.submitted_runs.each do |run|
         begin
           if run.status == :cancelled
@@ -69,7 +38,10 @@ class JobObserver
           run.status = :failed
           run.save!
         end
+        observed_runs[run.status] ||= []
+        observed_runs[run.status] << run.id
       end
+      logger.info("observed jobs from #{host.name}: #{observed_runs.inspect}")
     end
   end
 
@@ -84,64 +56,6 @@ class JobObserver
       logger.warn("Warn: Too little space left on device.")
     end
     b
-  end
-
-  def self.fork_host_process(logger)
-    Mongoid::sessions.clear # before forking a process, clear Mongo session. Otherwise, invalid data may be obtained.
-    begin
-    @host_pids.each do |host_id, pid|
-      next unless pid.nil?
-      @host_pids[host_id] = fork do
-        logger.info("#{host_id} host process is forked")
-        @term_received_host ||= {}
-        @term_received_host[host_id] = false
-        trap('TERM') {
-          @term_received_host[host_id] = true
-          logger.info("JobObserver: TERM received by host #{host_id}. stopping")
-        }
-
-        begin
-          Mongoid::Config.load!(File.join(Rails.root, 'config/mongoid.yml')) # make a new Mongo session in each process.
-          loop do
-            host = Host.find(host_id)
-            observe_host(host, logger)
-
-            break if @term_received
-            break if @term_received_host[host_id]
-            sleep host.polling_interval
-            break if @term_received
-            break if @term_received_host[host_id]
-          end
-          logger.info("JobObserver: host process(#{host_id}) is finished")
-        rescue => ex
-          logger.error("Error in JobObserver#host_process: #{ex.inspect}")
-          logger.error(ex.backtrace)
-        end
-      end
-    end
-    rescue => ex
-      logger.error("Error in JobObserver#fork_host_process: #{ex.inspect}")
-      logger.error(ex.backtrace)
-    ensure
-      # anyway, try to clear Mongoid session, then try to make a new Mongoid session
-      Mongoid::sessions.clear
-      Mongoid::Config.load!(File.join(Rails.root, 'config/mongoid.yml'))
-    end
-  end
-
-  def self.kill_host_process(logger, host_ids)
-    @host_pids.keys.select {|enabled_host_id| host_ids.include?(enabled_host_id)}.each do |kill_host_id|
-      logger.info("JobObserver: TERM submitted to host #{kill_host_id}(#{@host_pids[kill_host_id]})")
-      Process.kill( "TERM", @host_pids[kill_host_id] )
-    end
-  end
-
-  def self.check_host_process(logger)
-    @host_pids.each do |host_id, pid|
-      if Process.waitpid(pid, Process::WNOHANG) # No blocking mode
-        @host_pids.delete(host_id)
-      end
-    end
   end
 end
 

--- a/app/workers/job_observer.rb
+++ b/app/workers/job_observer.rb
@@ -1,13 +1,39 @@
 class JobObserver
 
   def self.perform(logger)
-    Host.where(status: :enabled).each do |host|
-      begin
-        observe_host(host, logger)
-      rescue => ex
-        logger.error("Error in JobObserver: #{ex.inspect}")
+    @term_received = false
+    trap('TERM') {
+      @term_received = true
+      logger.info("TERM received by JobObserver. stopping")
+    }
+
+    # { "host_id1"=>"pid1", "host_id2"=>"pid2", ... }
+    # host process will be created: {"host_id"=>nil}
+    # host process is running: {"host_id"=>"pid"}
+    # host process is stopping: {"host_id"=>"pid"}
+    # host process is stopped: {}
+    @host_pids = {}
+    loop do
+      check_host_process(logger)
+      Host.where(status: :enabled).each do |host|
+        @host_pids[host.to_param] ||= nil
+      end
+      num_start_process = @host_pids.values.select {|v| v.nil?}.length
+      logger.info("JobObserver: #{num_start_process} host processes will be forked") if num_start_process > 0
+      fork_host_process(logger)
+      disabled_host_ids = Host.where(status: :disabled).map(&:id).map{|o| o.to_s}
+      kill_host_process(logger, disabled_host_ids)
+
+      if @term_received
+        break
+      else
+        sleep 5 # wait 5 sec
       end
     end
+
+    kill_host_process(logger, @host_pids.keys)
+    logger.info("JobObserver: waiting host porcess stopping")
+    Process.waitall
   end
 
   private
@@ -58,6 +84,64 @@ class JobObserver
       logger.warn("Warn: Too little space left on device.")
     end
     b
+  end
+
+  def self.fork_host_process(logger)
+    Mongoid::sessions.clear # before forking a process, clear Mongo session. Otherwise, invalid data may be obtained.
+    begin
+    @host_pids.each do |host_id, pid|
+      next unless pid.nil?
+      @host_pids[host_id] = fork do
+        logger.info("#{host_id} host process is forked")
+        @term_received_host ||= {}
+        @term_received_host[host_id] = false
+        trap('TERM') {
+          @term_received_host[host_id] = true
+          logger.info("JobObserver: TERM received by host #{host_id}. stopping")
+        }
+
+        begin
+          Mongoid::Config.load!(File.join(Rails.root, 'config/mongoid.yml')) # make a new Mongo session in each process.
+          loop do
+            host = Host.find(host_id)
+            observe_host(host, logger)
+
+            break if @term_received
+            break if @term_received_host[host_id]
+            sleep host.polling_interval
+            break if @term_received
+            break if @term_received_host[host_id]
+          end
+          logger.info("JobObserver: host process(#{host_id}) is finished")
+        rescue => ex
+          logger.error("Error in JobObserver#host_process: #{ex.inspect}")
+          logger.error(ex.backtrace)
+        end
+      end
+    end
+    rescue => ex
+      logger.error("Error in JobObserver#fork_host_process: #{ex.inspect}")
+      logger.error(ex.backtrace)
+    ensure
+      # anyway, try to clear Mongoid session, then try to make a new Mongoid session
+      Mongoid::sessions.clear
+      Mongoid::Config.load!(File.join(Rails.root, 'config/mongoid.yml'))
+    end
+  end
+
+  def self.kill_host_process(logger, host_ids)
+    @host_pids.keys.select {|enabled_host_id| host_ids.include?(enabled_host_id)}.each do |kill_host_id|
+      logger.info("JobObserver: TERM submitted to host #{kill_host_id}(#{@host_pids[kill_host_id]})")
+      Process.kill( "TERM", @host_pids[kill_host_id] )
+    end
+  end
+
+  def self.check_host_process(logger)
+    @host_pids.each do |host_id, pid|
+      if Process.waitpid(pid, Process::WNOHANG) # No blocking mode
+        @host_pids.delete(host_id)
+      end
+    end
   end
 end
 

--- a/app/workers/job_submitter.rb
+++ b/app/workers/job_submitter.rb
@@ -32,7 +32,7 @@ class JobSubmitter
     end
 
     kill_host_process(logger, @host_pids.keys)
-    logger.info("JobSubmitter waits host porcess stopping")
+    logger.info("JobSubmitter: waiting host porcess stopping")
     Process.waitall
   end
 
@@ -73,12 +73,12 @@ class JobSubmitter
     @host_pids.each do |host_id, pid|
       next unless pid.nil?
       @host_pids[host_id] = fork do
-        logger.info("#{host_id} host process is forked")
+        logger.info("JobSubmitter: #{host_id} host process is forked")
         @term_received_host ||= {}
         @term_received_host[host_id] = false
         trap('TERM') {
           @term_received_host[host_id] = true
-          logger.info("TERM received by host #{host_id}. stopping")
+          logger.info("JobSubmitter: TERM received by host #{host_id}. stopping")
         }
 
         begin
@@ -93,7 +93,7 @@ class JobSubmitter
             break if @term_received
             break if @term_received_host[host_id]
           end
-          logger.info("host process(#{host_id}) is finished")
+          logger.info("JobSubmitter: host process(#{host_id}) is finished")
         rescue => ex
           logger.error("Error in JobSubmitter#host_process: #{ex.inspect}")
           logger.error(ex.backtrace)
@@ -112,7 +112,7 @@ class JobSubmitter
 
   def self.kill_host_process(logger, host_ids)
     @host_pids.keys.select {|enabled_host_id| host_ids.include?(enabled_host_id)}.each do |kill_host_id|
-      logger.info("TERM submitted to host #{kill_host_id}(#{@host_pids[kill_host_id]})")
+      logger.info("JobSubmitter: TERM submitted to host #{kill_host_id}(#{@host_pids[kill_host_id]})")
       Process.kill( "TERM", @host_pids[kill_host_id] )
     end
   end

--- a/app/workers/job_submitter.rb
+++ b/app/workers/job_submitter.rb
@@ -1,23 +1,39 @@
 class JobSubmitter
 
   def self.perform(logger)
-    Host.where(status: :enabled).each do |host|
-      begin
-        num = host.max_num_jobs - host.submitted_runs.count
-        if num > 0
-          Run::PRIORITY_ORDER.keys.sort.each do |priority|
-            runs = host.submittable_runs.where(priority: priority).limit(num)
-            logger.info("submitting jobs to #{host.name}: #{runs.map do |r| r.id.to_s end.inspect}")
-            num -= runs.length
-            submit(runs, host, logger)
-            break if num == 0
-          end
-        end
-      rescue => ex
-        logger.error("Error in JobSubmitter: #{ex.inspect}")
-        logger.error(ex.backtrace)
+    @term_received = false
+    trap('TERM') {
+      @term_received = true
+      logger.info("TERM received by JobSubmitter. stopping")
+    }
+
+    # { "host_id1"=>"pid1", "host_id2"=>"pid2", ... }
+    # host process will be created: {"host_id"=>nil}
+    # host process is running: {"host_id"=>"pid"}
+    # host process is stopping: {"host_id"=>"pid"}
+    # host process is stopped: {}
+    @host_pids = {}
+    loop do
+      check_host_process(logger)
+      Host.where(status: :enabled).each do |host|
+        @host_pids[host.to_param] ||= nil
+      end
+      num_start_process = @host_pids.values.select {|v| v.nil?}.length
+      logger.info("#{num_start_process} host processes will be forked") if num_start_process > 0
+      fork_host_process(logger)
+      disabled_host_ids = Host.where(status: :disabled).map(&:id).map{|o| o.to_s}
+      kill_host_process(logger, disabled_host_ids)
+
+      if @term_received
+        break
+      else
+        sleep 5 # wait 5 sec
       end
     end
+
+    kill_host_process(logger, @host_pids.keys)
+    logger.info("JobSubmitter waits host porcess stopping")
+    Process.waitall
   end
 
   private
@@ -35,4 +51,78 @@ class JobSubmitter
       end
     end
   end
+
+  def self.host_process(host, logger)
+    num = host.max_num_jobs - host.submitted_runs.count
+    if num > 0
+      submitted_runs = []
+      Run::PRIORITY_ORDER.keys.sort.each do |priority|
+        runs = host.submittable_runs.where(priority: priority).limit(num)
+        num -= runs.length
+        submitted_runs += runs.map do |r| r.id.to_s end
+        submit(runs, host, logger)
+        break if num == 0
+      end
+      logger.info("submitting jobs to #{host.name}: #{submitted_runs.inspect}")
+    end
+  end
+
+  def self.fork_host_process(logger)
+    Mongoid::sessions.clear # before forking a process, clear Mongo session. Otherwise, invalid data may be obtained.
+    begin
+    @host_pids.each do |host_id, pid|
+      next unless pid.nil?
+      @host_pids[host_id] = fork do
+        logger.info("#{host_id} host process is forked")
+        @term_received_host ||= {}
+        @term_received_host[host_id] = false
+        trap('TERM') {
+          @term_received_host[host_id] = true
+          logger.info("TERM received by host #{host_id}. stopping")
+        }
+
+        begin
+          Mongoid::Config.load!(File.join(Rails.root, 'config/mongoid.yml')) # make a new Mongo session in each process.
+          loop do
+            host = Host.find(host_id)
+            host_process(host, logger)
+
+            break if @term_received
+            break if @term_received_host[host_id]
+            sleep host.polling_interval
+            break if @term_received
+            break if @term_received_host[host_id]
+          end
+          logger.info("host process(#{host_id}) is finished")
+        rescue => ex
+          logger.error("Error in JobSubmitter#host_process: #{ex.inspect}")
+          logger.error(ex.backtrace)
+        end
+      end
+    end
+    rescue => ex
+      logger.error("Error in JobSubmitter#fork_host_process: #{ex.inspect}")
+      logger.error(ex.backtrace)
+    ensure
+      # anyway, try to clear Mongoid session, then try to make a new Mongoid session
+      Mongoid::sessions.clear
+      Mongoid::Config.load!(File.join(Rails.root, 'config/mongoid.yml'))
+    end
+  end
+
+  def self.kill_host_process(logger, host_ids)
+    @host_pids.keys.select {|enabled_host_id| host_ids.include?(enabled_host_id)}.each do |kill_host_id|
+      logger.info("TERM submitted to host #{kill_host_id}(#{@host_pids[kill_host_id]})")
+      Process.kill( "TERM", @host_pids[kill_host_id] )
+    end
+  end
+
+  def self.check_host_process(logger)
+    @host_pids.each do |host_id, pid|
+      if Process.waitpid(pid, Process::WNOHANG) # No blocking mode
+        @host_pids.delete(host_id)
+      end
+    end
+  end
 end
+

--- a/app/workers/job_submitter.rb
+++ b/app/workers/job_submitter.rb
@@ -1,58 +1,11 @@
 class JobSubmitter
 
   def self.perform(logger)
-    @term_received = false
-    trap('TERM') {
-      @term_received = true
-      logger.info("TERM received by JobSubmitter. stopping")
-    }
-
-    # { "host_id1"=>"pid1", "host_id2"=>"pid2", ... }
-    # host process will be created: {"host_id"=>nil}
-    # host process is running: {"host_id"=>"pid"}
-    # host process is stopping: {"host_id"=>"pid"}
-    # host process is stopped: {}
-    @host_pids = {}
-    loop do
-      check_host_process(logger)
-      Host.where(status: :enabled).each do |host|
-        @host_pids[host.to_param] ||= nil
-      end
-      num_start_process = @host_pids.values.select {|v| v.nil?}.length
-      logger.info("#{num_start_process} host processes will be forked") if num_start_process > 0
-      fork_host_process(logger)
-      disabled_host_ids = Host.where(status: :disabled).map(&:id).map{|o| o.to_s}
-      kill_host_process(logger, disabled_host_ids)
-
-      if @term_received
-        break
-      else
-        sleep 5 # wait 5 sec
-      end
-    end
-
-    kill_host_process(logger, @host_pids.keys)
-    logger.info("JobSubmitter: waiting host porcess stopping")
-    Process.waitall
+    JobWorkerUtil.perform(logger, JobSubmitter.method(:submit_runs))
   end
 
   private
-  def self.submit(runs, host, logger)
-    # call start_ssh in order to avoid establishing SSH connection for each run
-    host.start_ssh do |ssh|
-      handler = RemoteJobHandler.new(host)
-      runs.each do |run|
-        begin
-          handler.submit_remote_job(run)
-        rescue => ex
-          logger.info ex.inspect
-          logger.info ex.backtrace
-        end
-      end
-    end
-  end
-
-  def self.host_process(host, logger)
+  def self.submit_runs(host, logger)
     num = host.max_num_jobs - host.submitted_runs.count
     if num > 0
       submitted_runs = []
@@ -67,60 +20,17 @@ class JobSubmitter
     end
   end
 
-  def self.fork_host_process(logger)
-    Mongoid::sessions.clear # before forking a process, clear Mongo session. Otherwise, invalid data may be obtained.
-    begin
-    @host_pids.each do |host_id, pid|
-      next unless pid.nil?
-      @host_pids[host_id] = fork do
-        logger.info("JobSubmitter: #{host_id} host process is forked")
-        @term_received_host ||= {}
-        @term_received_host[host_id] = false
-        trap('TERM') {
-          @term_received_host[host_id] = true
-          logger.info("JobSubmitter: TERM received by host #{host_id}. stopping")
-        }
-
+  def self.submit(runs, host, logger)
+    # call start_ssh in order to avoid establishing SSH connection for each run
+    host.start_ssh do |ssh|
+      handler = RemoteJobHandler.new(host)
+      runs.each do |run|
         begin
-          Mongoid::Config.load!(File.join(Rails.root, 'config/mongoid.yml')) # make a new Mongo session in each process.
-          loop do
-            host = Host.find(host_id)
-            host_process(host, logger)
-
-            break if @term_received
-            break if @term_received_host[host_id]
-            sleep host.polling_interval
-            break if @term_received
-            break if @term_received_host[host_id]
-          end
-          logger.info("JobSubmitter: host process(#{host_id}) is finished")
+          handler.submit_remote_job(run)
         rescue => ex
-          logger.error("Error in JobSubmitter#host_process: #{ex.inspect}")
-          logger.error(ex.backtrace)
+          logger.info ex.inspect
+          logger.info ex.backtrace
         end
-      end
-    end
-    rescue => ex
-      logger.error("Error in JobSubmitter#fork_host_process: #{ex.inspect}")
-      logger.error(ex.backtrace)
-    ensure
-      # anyway, try to clear Mongoid session, then try to make a new Mongoid session
-      Mongoid::sessions.clear
-      Mongoid::Config.load!(File.join(Rails.root, 'config/mongoid.yml'))
-    end
-  end
-
-  def self.kill_host_process(logger, host_ids)
-    @host_pids.keys.select {|enabled_host_id| host_ids.include?(enabled_host_id)}.each do |kill_host_id|
-      logger.info("JobSubmitter: TERM submitted to host #{kill_host_id}(#{@host_pids[kill_host_id]})")
-      Process.kill( "TERM", @host_pids[kill_host_id] )
-    end
-  end
-
-  def self.check_host_process(logger)
-    @host_pids.each do |host_id, pid|
-      if Process.waitpid(pid, Process::WNOHANG) # No blocking mode
-        @host_pids.delete(host_id)
       end
     end
   end

--- a/app/workers/service_worker.rb
+++ b/app/workers/service_worker.rb
@@ -1,6 +1,6 @@
 class ServiceWorker < DaemonSpawn::Base
 
-  INTERVAL = 60
+  INTERVAL = 5
 
   WORKER_PID_FILE = Rails.root.join('tmp', 'pids', "service_worker_#{Rails.env}.pid")
   WORKER_LOG_FILE = Rails.root.join('log', "service_worker_#{Rails.env}.log")

--- a/lib/job_worker_util.rb
+++ b/lib/job_worker_util.rb
@@ -1,6 +1,6 @@
 module JobWorkerUtil
 
-  # method needs 2 garguments, like method(host, logger)
+  # method needs 2 arguments, like method(host, logger)
   def self.perform(logger, method)
     @term_received = false
     trap('TERM') {

--- a/lib/job_worker_util.rb
+++ b/lib/job_worker_util.rb
@@ -1,0 +1,103 @@
+module JobWorkerUtil
+
+  # method needs 2 garguments, like method(host, logger)
+  def self.perform(logger, method)
+    @term_received = false
+    trap('TERM') {
+      @term_received = true
+      logger.info("#{message_prefix(method)} TERM received. stopping")
+    }
+
+    # { "host_id1"=>"pid1", "host_id2"=>"pid2", ... }
+    # host process is created: {"host_id"=>nil}
+    # host process is running: {"host_id"=>"pid"}
+    # host process is stopping: {"host_id"=>"pid"}
+    # host process is stopped: {}
+    @host_pids = {}
+    loop do
+      check_host_process(logger)
+      Host.where(status: :enabled).each do |host|
+        @host_pids[host.to_param] ||= nil
+      end
+      num_start_process = @host_pids.values.select {|v| v.nil?}.length
+      logger.info("#{message_prefix(method)} #{num_start_process} host processes will be forked") if num_start_process > 0
+      fork_host_process(logger, method)
+      disabled_host_ids = Host.where(status: :disabled).map(&:id).map{|o| o.to_s}
+      kill_host_process(logger, disabled_host_ids)
+
+      if @term_received
+        break
+      else
+        sleep 5 # wait 5 sec
+      end
+    end
+
+    kill_host_process(logger, @host_pids.keys)
+    logger.info("#{message_prefix(method)} waiting host porcess stopping")
+    Process.waitall
+  end
+
+  private
+  def self.fork_host_process(logger, method)
+    Mongoid::sessions.clear # before forking a process, clear Mongo session. Otherwise, invalid data may be obtained.
+    begin
+    @host_pids.each do |host_id, pid|
+      next unless pid.nil?
+      @host_pids[host_id] = fork do
+        logger.info("#{host_id} host process is forked")
+        @term_received_host ||= {}
+        @term_received_host[host_id] = false
+        trap('TERM') {
+          @term_received_host[host_id] = true
+          logger.info("#{message_prefix(method)} TERM received for host #{host_id}. stopping")
+        }
+
+        begin
+          Mongoid::Config.load!(File.join(Rails.root, 'config/mongoid.yml')) # make a new Mongo session in each process.
+          loop do
+            host = Host.find(host_id)
+            method.call(host, logger)
+
+            break if @term_received
+            break if @term_received_host[host_id]
+            sleep host.polling_interval
+            break if @term_received
+            break if @term_received_host[host_id]
+          end
+          logger.info("#{message_prefix(method)} host process(#{host_id}) is finished")
+        rescue => ex
+          logger.error("#{message_prefix(method)} Error in host_process: #{ex.inspect}")
+          logger.error(ex.backtrace)
+        end
+      end
+    end
+    rescue => ex
+      logger.error("#{message_prefix(method)} Error in fork_host_process: #{ex.inspect}")
+      logger.error(ex.backtrace)
+    ensure
+      # anyway, try to clear Mongoid session, then try to make a new Mongoid session
+      Mongoid::sessions.clear
+      Mongoid::Config.load!(File.join(Rails.root, 'config/mongoid.yml'))
+    end
+  end
+
+  def self.kill_host_process(logger, host_ids)
+    @host_pids.keys.select {|enabled_host_id| host_ids.include?(enabled_host_id)}.each do |kill_host_id|
+      Process.kill( "TERM", @host_pids[kill_host_id] )
+    end
+  end
+
+  def self.check_host_process(logger)
+    @host_pids.each do |host_id, pid|
+      if Process.waitpid(pid, Process::WNOHANG) # No blocking mode, check process status
+        @host_pids.delete(host_id)
+      end
+    end
+  end
+
+  def self.message_prefix(method)
+    str = method.owner.to_s # "#<Class:JobSubmitter>"
+    class_name = str[8..(str.length-2)]
+    class_name + ":"
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -179,6 +179,7 @@ EOS
     max_mpi_procs 8
     min_omp_threads 1
     max_omp_threads 8
+    polling_interval 5
     user {ENV['USER']}
   end
 end

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -138,6 +138,12 @@ describe Host do
       host.should_not be_valid
     end
 
+    it "polling_interval must be larger than or equal to 5" do
+      @valid_attr.update(polling_interval: 0)
+      host = Host.new(@valid_attr)
+      host.should_not be_valid
+    end
+
     it "cannot change when submitted runs exist" do
       host = FactoryGirl.create(:host)
       sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 0)

--- a/spec/workers/job_submitter_spec.rb
+++ b/spec/workers/job_submitter_spec.rb
@@ -23,14 +23,20 @@ describe JobSubmitter do
       @sim.executable_on.push @host
       @sim.save!
       expect {
-        JobSubmitter.perform(@logger)
+        pid = Process.fork do JobSubmitter.perform(@logger) end
+        sleep 1 # sleep is necessary to call perform before terminating the process
+        Process.kill( "TERM", pid )
+        Process.waitall
       }.to change { Run.where(status: :submitted).count }.by(1)
     end
 
     it "do nothing if there is no 'created' jobs" do
       @sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 0)
       expect {
-        JobSubmitter.perform(@logger)
+        pid = Process.fork do JobSubmitter.perform(@logger) end
+        sleep 1 # sleep is necessary to call perform before terminating the process
+        Process.kill( "TERM", pid )
+        Process.waitall
       }.to_not raise_error
     end
 
@@ -39,10 +45,16 @@ describe JobSubmitter do
       @host.update_attribute(:status, :disabled)
       @sim.executable_on.push @host
       expect {
-        JobSubmitter.perform(@logger)
       }.to change { Run.where(status: :created).count }.by(0)
+        pid = Process.fork do JobSubmitter.perform(@logger) end
+        sleep 1 # sleep is necessary to call perform before terminating the process
+        Process.kill( "TERM", pid )
+        Process.waitall
       expect {
-        JobSubmitter.perform(@logger)
+        pid = Process.fork do JobSubmitter.perform(@logger) end
+        sleep 1 # sleep is necessary to call perform before terminating the process
+        Process.kill( "TERM", pid )
+        Process.waitall
       }.to_not raise_error
     end
 
@@ -53,7 +65,10 @@ describe JobSubmitter do
       run = @sim.parameter_sets.first.runs.create(priority: 0, submitted_to: @host.to_param)
       run.save!
       expect {
-        JobSubmitter.perform(@logger)
+        pid = Process.fork do JobSubmitter.perform(@logger) end
+        sleep 1 # sleep is necessary to call perform before terminating the process
+        Process.kill( "TERM", pid )
+        Process.waitall
       }.to change { Run.where(status: :submitted, priority: 0).count }.by(1)
       Run.where(status: :submitted, priority: 1).count.should eq 0
     end


### PR DESCRIPTION
fixed #34 
### Specification
- Host has polling_interval field (>5 sec)
- JobWorker forks JobSubmitter process for each host
- JobWorker forks JobObserver process for each host
### Features
- A frequency of ssh session creation on each process is longer than the polling_interval of the host
- Job submission and job observation are running at same time for each host
- It is not required to restart JobWorker regardless of polling_interval changes
