### PR TITLE
when output file is overwritten CLI shows warning message, implement yes...

### DIFF
--- a/lib/cli/oacis_cli_analysis.rb
+++ b/lib/cli/oacis_cli_analysis.rb
@@ -17,6 +17,9 @@ class OacisCli < Thor
     anz_parameters = Hash[mapped]
 
     return if options[:dry_run]
+    unless options[:yes]
+      return unless overwrite_file?(options[:output])
+    end
     File.open(options[:output], 'w') do |io|
       # for visibility, manually print the json object as follows
       io.puts "[", "  #{anz_parameters.to_json}", "]"
@@ -104,7 +107,11 @@ class OacisCli < Thor
     end
 
   ensure
-    write_analysis_ids_to_file(options[:output], analyses) unless options[:dry_run]
+    return if options[:dry_run]
+    unless options[:yes]
+      return unless overwrite_file?(options[:output])
+    end
+    write_analysis_ids_to_file(options[:output], analyses)
   end
 
   private
@@ -153,7 +160,7 @@ class OacisCli < Thor
       say("Found analyses: #{analyses.map(&:id).to_json}")
     end
 
-    if yes?("Destroy #{analyses.count} analyses?")
+    if options[:yes] or yes?("Destroy #{analyses.count} analyses?")
       progressbar = ProgressBar.create(total: analyses.count, format: "%t %B %p%% (%c/%C)")
       # no_timeout enables destruction of 10000 or more analyses
       analyses.no_timeout.each do |anl|
@@ -182,7 +189,7 @@ class OacisCli < Thor
       say("Found analyses: #{analyses.map(&:id).to_json}")
     end
 
-    if yes?("Replace #{analyses.count} analyses with new ones?")
+    if options[:yes] or yes?("Replace #{analyses.count} analyses with new ones?")
       progressbar = ProgressBar.create(total: analyses.count, format: "%t %B %p%% (%c/%C)")
       # no_timeout enables replacement of 10000 or more analyses
       analyses.no_timeout.each do |anl|

--- a/lib/cli/oacis_cli_analysis.rb
+++ b/lib/cli/oacis_cli_analysis.rb
@@ -17,9 +17,7 @@ class OacisCli < Thor
     anz_parameters = Hash[mapped]
 
     return if options[:dry_run]
-    unless options[:yes]
-      return unless overwrite_file?(options[:output])
-    end
+    return unless options[:yes] or overwrite_file?(options[:output])
     File.open(options[:output], 'w') do |io|
       # for visibility, manually print the json object as follows
       io.puts "[", "  #{anz_parameters.to_json}", "]"
@@ -108,9 +106,7 @@ class OacisCli < Thor
 
   ensure
     return if options[:dry_run]
-    unless options[:yes]
-      return unless overwrite_file?(options[:output])
-    end
+    return unless options[:yes] or overwrite_file?(options[:output])
     write_analysis_ids_to_file(options[:output], analyses)
   end
 

--- a/lib/cli/oacis_cli_common.rb
+++ b/lib/cli/oacis_cli_common.rb
@@ -2,6 +2,7 @@ class OacisCli < Thor
 
   class_option :dry_run, type: :boolean, aliases: '-d', desc: 'dry run'
   class_option :verbose, type: :boolean, aliases: '-v', desc: 'verbose mode'
+  class_option :yes, type: :boolean, aliases: '-y', desc: 'say "yes" for all questions'
 
   USAGE = <<"EOS"
 usage:
@@ -148,4 +149,10 @@ EOS
       raise "Invalid json format. Key 'analysis_id' is necessary."
     end
   end
+
+  def overwrite_file?(path)
+    return yes?("Overwrite output file?") if File.exist?(path)
+    return true
+  end
 end
+

--- a/lib/cli/oacis_cli_parameter_set.rb
+++ b/lib/cli/oacis_cli_parameter_set.rb
@@ -17,6 +17,9 @@ class OacisCli < Thor
     parameter_set = Hash[mapped]
 
     return if options[:dry_run]
+    unless options[:yes]
+      return unless overwrite_file?(options[:output])
+    end
     File.open(options[:output], 'w') do |io|
       # for visibility, manually print the json object as follows
       io.puts "[", "  #{parameter_set.to_json}", "]"
@@ -69,7 +72,11 @@ class OacisCli < Thor
     end
 
   ensure
-    write_parameter_set_ids_to_file(options[:output], parameter_sets) unless options[:dry_run]
+    return if options[:dry_run]
+    unless options[:yes]
+      return unless overwrite_file?(options[:output])
+    end
+    write_parameter_set_ids_to_file(options[:output], parameter_sets)
   end
 
   private

--- a/lib/cli/oacis_cli_parameter_set.rb
+++ b/lib/cli/oacis_cli_parameter_set.rb
@@ -17,9 +17,7 @@ class OacisCli < Thor
     parameter_set = Hash[mapped]
 
     return if options[:dry_run]
-    unless options[:yes]
-      return unless overwrite_file?(options[:output])
-    end
+    return unless options[:yes] or overwrite_file?(options[:output])
     File.open(options[:output], 'w') do |io|
       # for visibility, manually print the json object as follows
       io.puts "[", "  #{parameter_set.to_json}", "]"
@@ -73,9 +71,7 @@ class OacisCli < Thor
 
   ensure
     return if options[:dry_run]
-    unless options[:yes]
-      return unless overwrite_file?(options[:output])
-    end
+    return unless options[:yes] or overwrite_file?(options[:output])
     write_parameter_set_ids_to_file(options[:output], parameter_sets)
   end
 
@@ -94,3 +90,4 @@ class OacisCli < Thor
     end
   end
 end
+

--- a/lib/cli/oacis_cli_run.rb
+++ b/lib/cli/oacis_cli_run.rb
@@ -30,6 +30,9 @@ class OacisCli < Thor
     end
 
     return if options[:dry_run]
+    unless options[:yes]
+      return unless overwrite_file?(options[:output])
+    end
     File.open(options[:output], 'w') do |io|
       io.puts JSON.pretty_generate(job_parameters)
     end
@@ -93,7 +96,11 @@ class OacisCli < Thor
     end
 
   ensure
-    write_run_ids_to_file(options[:output], runs) unless options[:dry_run]
+    return if options[:dry_run]
+    unless options[:yes]
+      return unless overwrite_file?(options[:output])
+    end
+    write_run_ids_to_file(options[:output], runs)
   end
 
   private
@@ -146,7 +153,7 @@ class OacisCli < Thor
       say("Found runs: #{runs.map(&:id).to_json}")
     end
 
-    if yes?("Destroy #{runs.count} runs?")
+    if options[:yes] or yes?("Destroy #{runs.count} runs?")
       progressbar = ProgressBar.create(total: runs.count, format: "%t %B %p%% (%c/%C)")
       # no_timeout enables destruction of 10000 or more runs
       runs.no_timeout.each do |run|
@@ -180,7 +187,7 @@ class OacisCli < Thor
       say("Found runs: #{runs.map(&:id).to_json}")
     end
 
-    if yes?("Replace #{runs.count} runs with new ones?")
+    if options[:yes] or yes?("Replace #{runs.count} runs with new ones?")
       progressbar = ProgressBar.create(total: runs.count, format: "%t %B %p%% (%c/%C)")
       # no_timeout enables replacement of 10000 or more runs
       runs.no_timeout.each do |run|

--- a/lib/cli/oacis_cli_run.rb
+++ b/lib/cli/oacis_cli_run.rb
@@ -30,9 +30,7 @@ class OacisCli < Thor
     end
 
     return if options[:dry_run]
-    unless options[:yes]
-      return unless overwrite_file?(options[:output])
-    end
+    return unless options[:yes] or overwrite_file?(options[:output])
     File.open(options[:output], 'w') do |io|
       io.puts JSON.pretty_generate(job_parameters)
     end
@@ -97,9 +95,7 @@ class OacisCli < Thor
 
   ensure
     return if options[:dry_run]
-    unless options[:yes]
-      return unless overwrite_file?(options[:output])
-    end
+    return unless options[:yes] or overwrite_file?(options[:output])
     write_run_ids_to_file(options[:output], runs)
   end
 

--- a/lib/cli/oacis_cli_simulator.rb
+++ b/lib/cli/oacis_cli_simulator.rb
@@ -26,6 +26,9 @@ EOS
     required: true
   def simulator_template
     return if options[:dry_run]
+    unless options[:yes]
+      return unless overwrite_file?(options[:output])
+    end
     File.open(options[:output], 'w') {|io|
       io.puts SIMULATOR_TEMPLATE
       io.flush
@@ -67,6 +70,9 @@ EOS
 
     if sim.valid?
       unless options[:dry_run]
+        unless options[:yes]
+          return unless overwrite_file?(options[:output])
+        end
         sim.save!
         write_simulator_id_to_file(options[:output], sim)
       end

--- a/lib/cli/oacis_cli_simulator.rb
+++ b/lib/cli/oacis_cli_simulator.rb
@@ -26,9 +26,7 @@ EOS
     required: true
   def simulator_template
     return if options[:dry_run]
-    unless options[:yes]
-      return unless overwrite_file?(options[:output])
-    end
+    return unless options[:yes] or overwrite_file?(options[:output])
     File.open(options[:output], 'w') {|io|
       io.puts SIMULATOR_TEMPLATE
       io.flush
@@ -70,9 +68,7 @@ EOS
 
     if sim.valid?
       unless options[:dry_run]
-        unless options[:yes]
-          return unless overwrite_file?(options[:output])
-        end
+        return unless options[:yes] or overwrite_file?(options[:output])
         sim.save!
         write_simulator_id_to_file(options[:output], sim)
       end

--- a/spec/lib/cli/oacis_cli_analysis_spec.rb
+++ b/spec/lib/cli/oacis_cli_analysis_spec.rb
@@ -389,7 +389,7 @@ describe OacisCli do
           options = {analyzer_id: analyzer_id, query: {"analyzer_version" => "v0.1.0"}}
           expect {
             OacisCli.new.invoke(:destroy_analyses, [], options)
-          }.to change { Analysis.where(analyzer_version: "v0.1.0").count }.by(0)
+          }.not_to change { Analysis.where(analyzer_version: "v0.1.0").count }
         }
       end
     end
@@ -464,7 +464,7 @@ describe OacisCli do
           options = {analyzer_id: analyzer_id, query: {"status" => "failed"}, input: "anz_parameters.json"}
           expect {
             OacisCli.new.invoke(:replace_analyses, [], options)
-          }.to change { Analysis.where(status: :created).count }.by(0)
+          }.not_to change { Analysis.where(status: :created).count }
         }
       end
     end

--- a/spec/lib/cli/oacis_cli_analysis_spec.rb
+++ b/spec/lib/cli/oacis_cli_analysis_spec.rb
@@ -6,13 +6,6 @@ describe OacisCli do
   before(:each) do
     @sim = FactoryGirl.create(:simulator, parameter_sets_count: 2, runs_count: 0, finished_runs_count: 2, analyzers_count: 1, run_analysis: false, analyzers_on_parameter_set_count: 1, run_analysis_on_parameter_set: false)
     @sim.save!
-
-    class OacisCli
-      private
-      def yes?(str) # define as a private method otherwise mock will define the method as public
-        true
-      end
-    end
   end
 
   def create_options(option={})
@@ -74,6 +67,32 @@ describe OacisCli do
           options = { analyzer_id: @sim.analyzers.first.id.to_s, output: 'analyzres.json', dry_run: true }
           OacisCli.new.invoke(:analyses_template, [], options)
           File.exist?('analyzers.json').should be_false
+        }
+      end
+    end
+
+    context "when output file exists" do
+
+      it "asks a question to overwrite the output file" do
+        at_temp_dir {
+          options = { analyzer_id: @sim.analyzers.first.id.to_s, output: 'anz_parameters.json' }
+          FileUtils.touch(options[:output])
+          expect(Thor::LineEditor).to receive(:readline).with("Overwrite output file? ", :add_to_history => false).and_return("y")
+          OacisCli.new.invoke(:analyses_template, [], options)
+        }
+      end
+    end
+
+    context "with yes option when output file exists" do
+
+      it "does not ask a question to overwrite the output file" do
+        at_temp_dir {
+          options = { analyzer_id: @sim.analyzers.first.id.to_s, output: 'anz_parameters.json', yes: true}
+          FileUtils.touch(options[:output])
+          expect(Thor::LineEditor).not_to receive(:readline).with("Overwrite output file? ", :add_to_history => false)
+          OacisCli.new.invoke(:analyses_template, [], options)
+          expected = @sim.analyzers.first.parameter_definitions.map {|pdef| [pdef["key"], pdef["default"]] }
+          JSON.load(File.read('anz_parameters.json')).should eq [Hash[expected]]
         }
       end
     end
@@ -226,6 +245,7 @@ describe OacisCli do
     end
 
     context "when input is not given" do
+
       it "creates analyses with default analsis parameters" do
         at_temp_dir {
           expect {
@@ -234,6 +254,31 @@ describe OacisCli do
         }
         expected = @sim.analyzers.first.parameter_definitions.map {|pdef| [pdef["key"], pdef["default"]] }
         Analysis.first.parameters.should eq Hash[expected]
+      end
+    end
+
+    context "when output file exists" do
+
+      it "asks a question to overwrite the output file" do
+        at_temp_dir {
+          FileUtils.touch("analysis_ids_tmp.json")
+          expect(Thor::LineEditor).to receive(:readline).with("Overwrite output file? ", :add_to_history => false).and_return("y")
+          invoke_create_analyses(:on_run, {output: "analysis_ids_tmp.json", input: "anz_parameters.json"})
+        }
+      end
+    end
+
+    context "with yes option when output file exists" do
+
+      it "does not ask a question to overwrite the output file" do
+        at_temp_dir {
+          FileUtils.touch("analysis_ids_tmp.json")
+          expect(Thor::LineEditor).not_to receive(:readline).with("Overwrite output file? ", :add_to_history => false)
+          invoke_create_analyses(:on_run, {output: "analysis_ids_tmp.json", input: "anz_parameters.json", yes: true})
+          File.exist?('analysis_ids_tmp.json').should be_true
+          expected = Analysis.all.map {|anl| {"analysis_id" => anl.id.to_s} }.sort_by {|h| h["analysis_id"]}
+          JSON.load(File.read('analysis_ids_tmp.json')).should =~ expected
+        }
       end
     end
   end
@@ -265,7 +310,7 @@ describe OacisCli do
           anl.status = :failed
           anl.save
         end
-        options = {analyzer_id: analyzer_id, query: {"status" => "failed"} }
+        options = {analyzer_id: analyzer_id, query: {"status" => "failed"}, yes: true}
         expect {
           OacisCli.new.invoke(:destroy_analyses, [], options)
         }.to change { Analysis.where(status: :failed).count }.by(-3)
@@ -280,7 +325,7 @@ describe OacisCli do
           anl.update_attribute(:status, :finished)
           anl.update_attribute(:analyzer_version, "v0.1.0")
         end
-        options = {analyzer_id: analyzer_id, query: {"analyzer_version" => "v0.1.0"} }
+        options = {analyzer_id: analyzer_id, query: {"analyzer_version" => "v0.1.0"}, yes: true}
         expect {
           OacisCli.new.invoke(:destroy_analyses, [], options)
         }.to change { Analysis.where(analyzer_version: "v0.1.0").count }.by(-3)
@@ -297,7 +342,7 @@ describe OacisCli do
         Analysis.limit(2).each do |anl|
           anl.update_attribute(:analyzer_version, "v0.1.0")
         end
-        options = {analyzer_id: analyzer_id, query: {"analyzer_version" => ""} }
+        options = {analyzer_id: analyzer_id, query: {"analyzer_version" => ""}, yes: true}
         specified_analyses_count = Analysis.where(analyzer_version: nil).count
         expect {
           OacisCli.new.invoke(:destroy_analyses, [], options)
@@ -310,18 +355,62 @@ describe OacisCli do
         analyzer_id = @sim.analyzers.where(type: :on_run).first.id
         at_temp_dir {
           invoke_create_analyses(:on_run, {output: "analysis_ids.json", input: "anz_parameters.json"})
-          options = {analyzer_id: analyzer_id, query: "DO_NOT_EXIST" }
+          options = {analyzer_id: analyzer_id, query: "DO_NOT_EXIST", yes: true}
+          expect {
+            $stdout = StringIO.new # set new string stream not to write Thor#say message on test result
+            OacisCli.new.invoke(:destroy_analyses, [], options)
+            $stdout = STDOUT
+          }.to raise_error
+          options = {analyzer_id: analyzer_id, query: { "status" => "DO_NOT_EXIST" }, yes: true}
           expect {
             OacisCli.new.invoke(:destroy_analyses, [], options)
           }.to raise_error
-          options = {analyzer_id: analyzer_id, query: { "status" => "DO_NOT_EXIST" } }
+          options = {analyzer_id: analyzer_id, query: { "analyzer_version" => "DO_NOT_EXIST" }, yes: true}
           expect {
             OacisCli.new.invoke(:destroy_analyses, [], options)
           }.to raise_error
-          options = {analyzer_id: analyzer_id, query: { "analyzer_version" => "DO_NOT_EXIST" } }
+        }
+      end
+    end
+
+    context "if user say \"no\" not to destroy analyses" do
+
+      it "destroys nothing" do
+        analyzer_id = @sim.analyzers.where(type: :on_run).first.id
+        at_temp_dir {
+          invoke_create_analyses(:on_run, {output: "analysis_ids.json", input: "anz_parameters.json"})
+          Analysis.each do |anl|
+            anl.update_attribute(:status, :finished)
+          end
+          Analysis.limit(2).each do |anl|
+            anl.update_attribute(:analyzer_version, "v0.1.0")
+          end
+          expect(Thor::LineEditor).to receive(:readline).with("Destroy 2 analyses? ", :add_to_history => false).and_return("n")
+          options = {analyzer_id: analyzer_id, query: {"analyzer_version" => "v0.1.0"}}
           expect {
             OacisCli.new.invoke(:destroy_analyses, [], options)
-          }.to raise_error
+          }.to change { Analysis.where(analyzer_version: "v0.1.0").count }.by(0)
+        }
+      end
+    end
+
+    context "with yes option" do
+
+      it "destroys analyses without confirmation" do
+        analyzer_id = @sim.analyzers.where(type: :on_run).first.id
+        at_temp_dir {
+          invoke_create_analyses(:on_run, {output: "analysis_ids.json", input: "anz_parameters.json"})
+          Analysis.each do |anl|
+            anl.update_attribute(:status, :finished)
+          end
+          Analysis.limit(2).each do |anl|
+            anl.update_attribute(:analyzer_version, "v0.1.0")
+          end
+          expect(Thor::LineEditor).not_to receive(:readline).with("Destroy 2 analyses? ", :add_to_history => false)
+          options = {analyzer_id: analyzer_id, query: {"analyzer_version" => "v0.1.0"}, yes: true}
+          expect {
+            OacisCli.new.invoke(:destroy_analyses, [], options)
+          }.to change { Analysis.where(analyzer_version: "v0.1.0").count }.by(-2)
         }
       end
     end
@@ -338,7 +427,7 @@ describe OacisCli do
           anl.save
         end
         h = Analysis.first.parameters
-        options = {analyzer_id: analyzer_id, query: {"status" => "failed"}, input: "anz_parameters.json"}
+        options = {analyzer_id: analyzer_id, query: {"status" => "failed"}, input: "anz_parameters.json", yes: true}
         expect {
           OacisCli.new.invoke(:replace_analyses, [], options)
         }.to change { Analysis.where(status: :created).count }.by(2)
@@ -349,16 +438,55 @@ describe OacisCli do
     it "destroys old analysis" do
       analyzer_id = @sim.analyzers.where(type: :on_run).first.id
       at_temp_dir {
-        invoke_create_analyses(:on_run, {output: "analysis_ids.json", input: "anz_parameters.json"})
+        invoke_create_analyses(:on_run, {output: "analysis_ids.json", input: "anz_parameters.json", yes: true})
         Analysis.limit(2).each do |anl|
           anl.status = :failed
           anl.save
         end
-        options = {analyzer_id: analyzer_id, query: {"status" => "failed"}, input: "anz_parameters.json"}
+        options = {analyzer_id: analyzer_id, query: {"status" => "failed"}, input: "anz_parameters.json", yes: true}
         expect {
           OacisCli.new.invoke(:replace_analyses, [], options)
         }.to change { Analysis.where(status: :failed).count  }.from(2).to(0)
       }
     end
+
+    context "if user say \"no\" not to replace analyses" do
+
+      it "replaces nothing" do
+        analyzer_id = @sim.analyzers.where(type: :on_run).first.id
+        at_temp_dir {
+          invoke_create_analyses(:on_run, {output: "analysis_ids.json", input: "anz_parameters.json"})
+          Analysis.limit(2).each do |anl|
+            anl.status = :failed
+            anl.save
+          end
+          expect(Thor::LineEditor).to receive(:readline).with("Replace 2 analyses with new ones? ", :add_to_history => false).and_return("n")
+          options = {analyzer_id: analyzer_id, query: {"status" => "failed"}, input: "anz_parameters.json"}
+          expect {
+            OacisCli.new.invoke(:replace_analyses, [], options)
+          }.to change { Analysis.where(status: :created).count }.by(0)
+        }
+      end
+    end
+  end
+
+  context "with yes option" do
+
+    it "replaces analyses with out confirmation" do
+      analyzer_id = @sim.analyzers.where(type: :on_run).first.id
+      at_temp_dir {
+        invoke_create_analyses(:on_run, {output: "analysis_ids.json", input: "anz_parameters.json"})
+        Analysis.limit(2).each do |anl|
+          anl.status = :failed
+          anl.save
+        end
+        expect(Thor::LineEditor).not_to receive(:readline).with("Replace 2 analyses with new ones? ", :add_to_history => false)
+        options = {analyzer_id: analyzer_id, query: {"status" => "failed"}, input: "anz_parameters.json", yes: true}
+        expect {
+          OacisCli.new.invoke(:replace_analyses, [], options)
+        }.to change { Analysis.where(status: :created).count }.by(2)
+      }
+    end
   end
 end
+

--- a/spec/lib/cli/oacis_cli_parameter_set_spec.rb
+++ b/spec/lib/cli/oacis_cli_parameter_set_spec.rb
@@ -70,6 +70,40 @@ describe OacisCli do
         }
       end
     end
+
+    context "when output file exists" do
+
+      it "asks a question to overwrite the output file" do
+        at_temp_dir {
+          create_simulator_id_json(@sim, 'simulator_id.json')
+          FileUtils.touch('parameter_sets.json')
+          expect(Thor::LineEditor).to receive(:readline).with("Overwrite output file? ", :add_to_history => false).and_return("y")
+          option = {simulator: 'simulator_id.json', output: 'parameter_sets.json'}
+          OacisCli.new.invoke(:parameter_sets_template, [], option)
+          File.exist?('parameter_sets.json').should be_true
+          expect {
+            JSON.load(File.read('parameter_sets.json'))
+          }.not_to raise_error
+        }
+      end
+    end
+
+    context "with yes option when output file exists" do
+
+      it "does not ask a question to overwrite the output file" do
+        at_temp_dir {
+          create_simulator_id_json(@sim, 'simulator_id.json')
+          FileUtils.touch('parameter_sets.json')
+          expect(Thor::LineEditor).not_to receive(:readline).with("Overwrite output file? ", :add_to_history => false)
+          option = {simulator: 'simulator_id.json', output: 'parameter_sets.json', yes: true}
+          OacisCli.new.invoke(:parameter_sets_template, [], option)
+          File.exist?('parameter_sets.json').should be_true
+          expect {
+            JSON.load(File.read('parameter_sets.json'))
+          }.not_to raise_error
+        }
+      end
+    end
   end
 
   describe "#create_parameter_sets" do
@@ -253,5 +287,35 @@ describe OacisCli do
         }
       end
     end
+
+    context "when output file exists" do
+
+      it "asks a question to overwrite the output file" do
+        at_temp_dir {
+          FileUtils.touch('parameter_set_ids.json')
+          expect(Thor::LineEditor).to receive(:readline).with("Overwrite output file? ", :add_to_history => false).and_return("y")
+          invoke_create_parameter_sets
+        }
+      end
+    end
+
+    context "with yes option when output file exists" do
+
+      it "does not ask a question to overwrite the output file" do
+        at_temp_dir {
+          FileUtils.touch('parameter_set_ids.json')
+          expect(Thor::LineEditor).not_to receive(:readline).with("Overwrite output file? ", :add_to_history => false)
+          create_simulator_id_json(@sim, 'simulator_id.json')
+          create_parameter_sets_json('parameter_sets.json')
+          option = {simulator: 'simulator_id.json', input: 'parameter_sets.json', output: "parameter_set_ids.json", yes: true}
+          OacisCli.new.invoke(:create_parameter_sets, [], option)
+          File.exist?('parameter_set_ids.json').should be_true
+          expect {
+            JSON.load(File.read('parameter_set_ids.json'))
+          }.not_to raise_error
+        }
+      end
+    end
   end
 end
+

--- a/spec/lib/cli/oacis_cli_run_spec.rb
+++ b/spec/lib/cli/oacis_cli_run_spec.rb
@@ -3,15 +3,6 @@ require File.join(Rails.root, 'lib/cli/oacis_cli')
 
 describe OacisCli do
 
-  before(:each) do
-    class OacisCli
-      private
-      def yes?(str)  # define as a private method otherwise mock will define the method as public
-        true
-      end
-    end
-  end
-
   describe "#job_parameter_template" do
 
     before(:each) do
@@ -67,6 +58,34 @@ describe OacisCli do
           }
           OacisCli.new.invoke(:job_parameter_template, [], options)
           File.exist?('job_parameters.json').should be_false
+        }
+      end
+    end
+
+    context "when output file exists" do
+
+      it "asks a question to overwrite the output file" do
+        at_temp_dir {
+          FileUtils.touch("job_parameters.json")
+          expect(Thor::LineEditor).to receive(:readline).with("Overwrite output file? ", :add_to_history => false).and_return("y")
+          options = { host_id: @host.id.to_s, output: 'job_parameters.json'}
+          OacisCli.new.invoke(:job_parameter_template, [], options)
+        }
+      end
+    end
+
+    context "with yes option when output file exists" do
+
+      it "does not ask a question to overwrite the output file" do
+        at_temp_dir {
+          FileUtils.touch("job_parameters.json")
+          expect(Thor::LineEditor).not_to receive(:readline).with("Overwrite output file? ", :add_to_history => false)
+          options = { host_id: @host.id.to_s, output: 'job_parameters.json', yes: true}
+          OacisCli.new.invoke(:job_parameter_template, [], options)
+          File.exist?('job_parameters.json').should be_true
+          expect {
+            JSON.load(File.read('job_parameters.json'))
+          }.not_to raise_error
         }
       end
     end
@@ -279,6 +298,51 @@ describe OacisCli do
         }
       end
     end
+
+    context "when output file exists" do
+
+      it "asks a question to overwrite the output file" do
+        at_temp_dir {
+          FileUtils.touch("run_ids.json")
+          expect(Thor::LineEditor).to receive(:readline).with("Overwrite output file? ", :add_to_history => false).and_return("y")
+          options = { host_id: @host.id.to_s, output: 'job_parameters.json'}
+          create_parameter_set_ids_json(@sim.parameter_sets, 'parameter_set_ids.json')
+          create_job_parameters_json('job_parameters.json')
+          options = {
+            parameter_sets: 'parameter_set_ids.json',
+            job_parameters: 'job_parameters.json',
+            number_of_runs: 3,
+            output: 'run_ids.json'
+          }
+          OacisCli.new.invoke(:create_runs, [], options)
+        }
+      end
+    end
+
+    context "with yes option when output file exists" do
+
+      it "does not ask a question to overwrite the output file" do
+        at_temp_dir {
+          FileUtils.touch("run_ids.json")
+          expect(Thor::LineEditor).not_to receive(:readline).with("Overwrite output file? ", :add_to_history => false)
+          options = { host_id: @host.id.to_s, output: 'job_parameters.json'}
+          create_parameter_set_ids_json(@sim.parameter_sets, 'parameter_set_ids.json')
+          create_job_parameters_json('job_parameters.json')
+          options = {
+            parameter_sets: 'parameter_set_ids.json',
+            job_parameters: 'job_parameters.json',
+            number_of_runs: 3,
+            output: 'run_ids.json',
+            yes: true
+          }
+          OacisCli.new.invoke(:create_runs, [], options)
+          File.exist?('run_ids.json').should be_true
+          expect {
+            JSON.load(File.read('run_ids.json'))
+          }.not_to raise_error
+        }
+      end
+    end
   end
 
   describe "#run_status" do
@@ -328,7 +392,7 @@ describe OacisCli do
 
     it "destroys runs specified by 'status'" do
       at_temp_dir {
-        options = {simulator: @sim.id.to_s, query: {"status" => "failed"} }
+        options = {simulator: @sim.id.to_s, query: {"status" => "failed"}, yes: true}
         expect {
           OacisCli.new.invoke(:destroy_runs, [], options)
         }.to change { Run.where(status: :failed).count }.by(-1)
@@ -337,7 +401,7 @@ describe OacisCli do
 
     it "destroys runs specified by 'simulator_version'" do
       at_temp_dir {
-        options = {simulator: @sim.id.to_s, query: {"simulator_version" => "1.0.0"}}
+        options = {simulator: @sim.id.to_s, query: {"simulator_version" => "1.0.0"}, yes: true}
         expect {
           OacisCli.new.invoke(:destroy_runs, [], options)
         }.to change { Run.where(simulator_version: "1.0.0").count }.by(-1)
@@ -346,7 +410,7 @@ describe OacisCli do
 
     it "destroys runs of simulator_version=nil when simulator_version is empty" do
       at_temp_dir {
-        options = {simulator: @sim.id.to_s, query: {"simulator_version" => ""}}
+        options = {simulator: @sim.id.to_s, query: {"simulator_version" => ""}, yes: true}
         expect {
           OacisCli.new.invoke(:destroy_runs, [], options)
         }.to change { Run.where(simulator_version: nil).count }.by(-2)
@@ -355,11 +419,39 @@ describe OacisCli do
 
     it "fails neither 'status' nor 'simulator_version' is given as the query-key" do
       at_temp_dir {
-        options = {simulator: @sim.id.to_s, query: {"hostname" => "localhost"}}
+        options = {simulator: @sim.id.to_s, query: {"hostname" => "localhost"}, yes: true}
         expect {
+          $stdout = StringIO.new # set new string stream not to write Thor#say message on test result
           OacisCli.new.invoke(:destroy_runs, [], options)
+          $stdout = STDOUT
         }.to raise_error
       }
+    end
+
+    context "if user say \"no\" not to destroy runs" do
+
+      it "destroys nothing" do
+        at_temp_dir {
+          expect(Thor::LineEditor).to receive(:readline).with("Destroy 1 runs? ", :add_to_history => false).and_return("n")
+          options = {simulator: @sim.id.to_s, query: {"status" => "failed"} }
+          expect {
+            OacisCli.new.invoke(:destroy_runs, [], options)
+          }.to change { Run.where(status: :failed).count }.by(0)
+        }
+      end
+    end
+
+    context "with yes option" do
+
+      it "destroys runs without confirmation" do
+        at_temp_dir {
+          expect(Thor::LineEditor).not_to receive(:readline).with("Destroy 1 runs? ", :add_to_history => false)
+          options = {simulator: @sim.id.to_s, query: {"status" => "failed"}, yes: true}
+          expect {
+            OacisCli.new.invoke(:destroy_runs, [], options)
+          }.to change { Run.where(status: :failed).count }.by(-1)
+        }
+      end
     end
   end
 
@@ -377,7 +469,7 @@ describe OacisCli do
 
     it "newly create runs have the same attribute as old ones" do
       at_temp_dir {
-        options = {simulator: @sim.id.to_s, query: {"simulator_version" => "1.0.0"} }
+        options = {simulator: @sim.id.to_s, query: {"simulator_version" => "1.0.0"}, yes: true}
         expect {
           OacisCli.new.invoke(:replace_runs, [], options)
         }.to change { Run.where(status: :created).count }.by(1)
@@ -387,11 +479,38 @@ describe OacisCli do
 
     it "destroys old run" do
       at_temp_dir {
-        options = { simulator: @sim.id.to_s, query: {"simulator_version" => "1.0.0"} }
+        options = { simulator: @sim.id.to_s, query: {"simulator_version" => "1.0.0"}, yes: true}
         expect {
           OacisCli.new.invoke(:replace_runs, [], options)
         }.to change { Run.where(simulator_version: "1.0.0").count }.from(1).to(0)
       }
     end
+
+    context "if user say \"no\" not to replace runs" do
+
+      it "replaces nothing" do
+        at_temp_dir {
+          expect(Thor::LineEditor).to receive(:readline).with("Replace 1 runs with new ones? ", :add_to_history => false).and_return("n")
+          options = {simulator: @sim.id.to_s, query: {"simulator_version" => "1.0.0"}}
+          expect {
+            OacisCli.new.invoke(:replace_runs, [], options)
+          }.to change { Run.where(status: :created).count }.by(0)
+        }
+      end
+    end
+
+    context "with yes option" do
+
+      it "replaces runs without confirmation" do
+        at_temp_dir {
+          expect(Thor::LineEditor).not_to receive(:readline).with("Replace 1 runs with new ones? ", :add_to_history => false)
+          options = {simulator: @sim.id.to_s, query: {"simulator_version" => "1.0.0"}, yes: true}
+          expect {
+            OacisCli.new.invoke(:replace_runs, [], options)
+          }.to change { Run.where(status: :created).count }.by(1)
+        }
+      end
+    end
   end
 end
+

--- a/spec/lib/cli/oacis_cli_run_spec.rb
+++ b/spec/lib/cli/oacis_cli_run_spec.rb
@@ -436,7 +436,7 @@ describe OacisCli do
           options = {simulator: @sim.id.to_s, query: {"status" => "failed"} }
           expect {
             OacisCli.new.invoke(:destroy_runs, [], options)
-          }.to change { Run.where(status: :failed).count }.by(0)
+          }.not_to change { Run.where(status: :failed).count }
         }
       end
     end
@@ -494,7 +494,7 @@ describe OacisCli do
           options = {simulator: @sim.id.to_s, query: {"simulator_version" => "1.0.0"}}
           expect {
             OacisCli.new.invoke(:replace_runs, [], options)
-          }.to change { Run.where(status: :created).count }.by(0)
+          }.not_to change { Run.where(status: :created).count }
         }
       end
     end


### PR DESCRIPTION
Fixed #38
- When output file is overwritten, CLI shows warning message
  - Now CLI functions shows warning message when they "overwrite output file", "destroy [runs, analyses]" "replace [runs, analyses]"
- add a option "yes" for all CLI functions
  - If you will answer yes to all confirmation, you can put "--yes" or "-y" option on command line like

```
 ./bin/oacis_cli create_runs -p parameter_set_ids.json -j job_parameter.json -n 1 -o run_ids.json --yes
```
