### PR TITLE
Improve analyzer performance when the number of runs are large

### DIFF
--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -84,15 +84,10 @@ class Analysis
     when :on_run
       run = self.analyzable
       obj[:simulation_parameters] = run.parameter_set.v
-      obj[:result] = run.result
     when :on_parameter_set
       ps = self.analyzable
       obj[:simulation_parameters] = ps.v
-      results = Run.collection.aggregate([
-        {'$match' => ps.runs.where(status: :finished).selector },
-        {'$group' => {_id: "$_id", result: {"$first" => "$result"}} }
-      ])
-      obj[:result] = Hash[results.map {|r| [r["_id"].to_s, r["result"]]}]
+      obj[:run_ids] = ps.runs.where(status: :finished).map {|run| run.to_param}
     else
       raise "not supported type"
     end

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -87,10 +87,7 @@ class Analysis
     when :on_parameter_set
       ps = self.analyzable
       obj[:simulation_parameters] = ps.v
-      run_ids = Run.collection.aggregate([
-        {'$match' => ps.runs.where(status: :finished).selector },
-        {'$group' => {_id: "$_id"} }
-      ]).map {|run_id| run_id["_id"].to_s}
+      run_ids = ps.runs.where(status: :finished).only(:id).map(&:id).map {|id| id.to_s}
       obj[:run_ids] = run_ids
     else
       raise "not supported type"
@@ -109,10 +106,7 @@ class Analysis
       # TODO: add directories of dependent analysis
     when :on_parameter_set
       ps = self.analyzable
-      run_ids = Run.collection.aggregate([
-        {'$match' => ps.runs.where(status: :finished).selector },
-        {'$group' => {_id: "$_id"} }
-      ]).map {|run_id| run_id["_id"].to_s}
+      run_ids = ps.runs.where(status: :finished).only(:id).map(&:id).map {|id| id.to_s}
       base_dir = ps.runs.where(status: :finished).first.dir.join('../')
       files = run_ids.map {|run_id| base_dir.join(run_id)}
     else

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -98,15 +98,14 @@ class Analysis
     return obj
   end
 
-  # returns a hash
-  #   key: relative path of the destination directory from _input/
-  #   value: array of aboslute pathnames of files to be copied to _input/
+  # returns an array
+  #   array of run.results_paths or run.dir(s) to be linked to _input/
   def input_files
-    files = {}
+    files = []
     case self.analyzer.type
     when :on_run
       run = self.analyzable
-      files['.'] = run.result_paths
+      files = run.result_paths
       # TODO: add directories of dependent analysis
     when :on_parameter_set
       ps = self.analyzable
@@ -115,9 +114,7 @@ class Analysis
         {'$group' => {_id: "$_id"} }
       ]).map {|run_id| run_id["_id"].to_s}
       base_dir = ps.runs.where(status: :finished).first.dir.join('../')
-      run_ids.each do |run_id|
-        files[run_id] = [base_dir.join(run_id)]
-      end
+      files = run_ids.map {|run_id| base_dir.join(run_id)}
     else
       raise "not supported type"
     end

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -88,10 +88,11 @@ class Analysis
     when :on_parameter_set
       ps = self.analyzable
       obj[:simulation_parameters] = ps.v
-      obj[:result] = {}
-      ps.runs.each do |run|
-        obj[:result][run.to_param] = run.result
-      end
+      results = Run.collection.aggregate([
+        {'$match' => ps.runs.where(status: :finished).selector },
+        {'$group' => {_id: "$_id", result: {"$first" => "$result"}} }
+      ])
+      obj[:result] = Hash[results.map {|r| [r["_id"].to_s, r["result"]]}]
     else
       raise "not supported type"
     end

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -87,7 +87,7 @@ class Analysis
     when :on_parameter_set
       ps = self.analyzable
       obj[:simulation_parameters] = ps.v
-      run_ids = ps.runs.where(status: :finished).only(:id).map(&:id).map {|id| id.to_s}
+      run_ids = ps.runs.where(status: :finished).only(:id).map {|run| run.id.to_s}
       obj[:run_ids] = run_ids
     else
       raise "not supported type"
@@ -106,7 +106,7 @@ class Analysis
       # TODO: add directories of dependent analysis
     when :on_parameter_set
       ps = self.analyzable
-      run_ids = ps.runs.where(status: :finished).only(:id).map(&:id).map {|id| id.to_s}
+      run_ids = ps.runs.where(status: :finished).only(:id).map {|run| run.id.to_s}
       base_dir = ps.runs.where(status: :finished).first.dir.join('../')
       files = run_ids.map {|run_id| base_dir.join(run_id)}
     else

--- a/app/workers/analyzer_runner.rb
+++ b/app/workers/analyzer_runner.rb
@@ -66,10 +66,8 @@ class AnalyzerRunner
     end
 
     FileUtils.mkdir_p(INPUT_FILES_DIR)
-    arn.input_files.each do |dir, inputs|
-      inputs.each do |input|
-        FileUtils.ln_s(input, INPUT_FILES_DIR)
-      end
+    arn.input_files.each do |input|
+      FileUtils.ln_s(input, INPUT_FILES_DIR)
     end
   end
 

--- a/app/workers/analyzer_runner.rb
+++ b/app/workers/analyzer_runner.rb
@@ -67,10 +67,8 @@ class AnalyzerRunner
 
     FileUtils.mkdir_p(INPUT_FILES_DIR)
     arn.input_files.each do |dir, inputs|
-      output_dir = File.join(INPUT_FILES_DIR, dir)
-      FileUtils.mkdir_p(output_dir)
       inputs.each do |input|
-        FileUtils.ln_s(input, output_dir)
+        FileUtils.ln_s(input, INPUT_FILES_DIR)
       end
     end
   end

--- a/doc/source/advanced_usage.rst
+++ b/doc/source/advanced_usage.rst
@@ -308,7 +308,8 @@ ParameterSetに対する解析
 
 | ParameterSetに対する解析もRunに対する解析とほぼ同様である。
 | ただし、_input/ディレクトリに保存される形式と `_input.json` の形式が異なる。
-| 形式の変更のため、runの結果ファイルを参照するには `_input` ディレクトリ内からrun_id一覧を取得する処理もしくは、 `_input.json` ファイルからrun_id 一覧を取得する処理をAnalyzer内で実装する。
+| RunのIDの一覧が run_ids というキーに格納される。
+| Runの結果ファイルを参照するには `_input.json` からRunのIDの一覧を取得する処理をAnalyzer内で実装する。
 
 | `_input/` ディレクトリ内のファイルの構成は以下の通り
 
@@ -343,13 +344,13 @@ ParameterSetに対する解析
     ]
   }
 
-| Analyzerでrunの結果ファイルを取得する例(言語：ruby)
+| AnalyzerからRunの結果ファイルを取得する例(言語：ruby)
 
 .. code-block:: ruby
 
   #require 'json'
   #require 'pathname'
-  persed = JSON.load('_input.json')
+  persed = JSON.load(open('_input.json'))
   RESULT_FILE_NAME = 'time_series.dat'
   result_files = persed["run_ids"].map do |id|
     Pathname.new("_input").join(id).join(RESULT_FILE_NAME)

--- a/doc/source/advanced_usage.rst
+++ b/doc/source/advanced_usage.rst
@@ -308,7 +308,7 @@ ParameterSetに対する解析
 
 | ParameterSetに対する解析もRunに対する解析とほぼ同様である。
 | ただし、_input/ディレクトリに保存される形式と `_input.json` の形式が異なる。
-| 形式の変更のため、runの結果ファイルを参照するためには `_input` ディレクトリ内からrun_id一覧を取得する処理もしくは、 `_input.json` ファイルからrun_id 一覧を取得する処理をAnalyzer内で実装する。
+| 形式の変更のため、runの結果ファイルを参照するには `_input` ディレクトリ内からrun_id一覧を取得する処理もしくは、 `_input.json` ファイルからrun_id 一覧を取得する処理をAnalyzer内で実装する。
 
 | `_input/` ディレクトリ内のファイルの構成は以下の通り
 

--- a/doc/source/advanced_usage.rst
+++ b/doc/source/advanced_usage.rst
@@ -288,7 +288,7 @@ Description                   Analyzerに対する説明。入力は任意。
 
 | 今回のサンプルでは示されていないが、パラメータを受け付けるAnalyzerの場合には `_input.json` というファイル内に解析のパラメータが記入される。
 | Runに対する解析の場合、 `_input.json` のフォーマットは以下の通りである。
-| "analysis_parameters", "simulation_parameters", "result" はそれぞれ解析パラメータ、シミュレーションパラメータ、Runの結果を表す。
+| "analysis_parameters", "simulation_parameters" はそれぞれ解析パラメータ、シミュレーションパラメータを表す。
 
 .. code-block:: javascript
 
@@ -300,13 +300,6 @@ Description                   Analyzerに対する説明。入力は任意。
    "simulation_parameters": {
      "L": 32,
      "T": 0.5
-   },
-   "result": {
-     "magnetization": 0.5,
-     "energy": 24.5,
-     "another_analysis": {
-         "maximum_energy": 28.1
-     }
    }
   }
 
@@ -315,6 +308,7 @@ ParameterSetに対する解析
 
 | ParameterSetに対する解析もRunに対する解析とほぼ同様である。
 | ただし、_input/ディレクトリに保存される形式と `_input.json` の形式が異なる。
+| 形式の変更のため、runの結果ファイルを参照するためには `_input` ディレクトリ内からrun_id一覧を取得する処理もしくは、 `_input.json` ファイルからrun_id 一覧を取得する処理をAnalyzer内で実装する。
 
 | `_input/` ディレクトリ内のファイルの構成は以下の通り
 
@@ -334,38 +328,33 @@ ParameterSetに対する解析
 .. code-block:: javascript
 
   {
-   "analysis_parameters": {
-     "x": 0.1,
-     "y": 2
-   },
-   "simulation_parameters": {
-     "L": 32,
-     "T": 0.5
-   },
-   "result": {
-     "run_id1": {
-       "magnetization": 0.5,
-       "energy": 24.5,
-       "analysis1": {
-           "maximum_energy": 28.1
-       }
-     },
-     "run_id2": {
-       "magnetization": 0.32,
-       "energy": 25.1,
-       "analysis1": {
-           "maximum_energy": 27.9
-       }
-     },
-     "run_id3": {
-       "magnetization": 0.2,
-       "energy": 20.7,
-       "analysis1": {
-           "maximum_energy": 26.8
-       }
-     }
-   }
+    "analysis_parameters": {
+      "x": 0.1,
+      "y": 2
+    },
+    "simulation_parameters": {
+      "L": 32,
+      "T": 0.5
+    },
+    "run_ids": [
+      "run_id1",
+      "run_id2",
+      "run_id3"
+    ]
   }
+
+| Analyzerでrunの結果ファイルを取得する例(言語：ruby)
+
+.. code-block:: ruby
+
+  #require 'json'
+  #require 'pathname'
+  persed = JSON.load('_input.json')
+  RESULT_FILE_NAME = 'time_series.dat'
+  result_files = persed["run_ids"].map do |id|
+    Pathname.new("_input").join(id).join(RESULT_FILE_NAME)
+  end
+  # result_files.map {|path| path.to_s} = ["_input/526638c781e31e98cf000001/time_series.dat", "_input/526638c781e31e98cf000002/time_series.dat"]
 
 | ParaemterSetに対する解析の場合、Auto Runのフラグはyes, noの２択から選択可能である。
 | yesの場合、ParameterSet内のすべてのRunが :finished または :failed になったときに自動実行される。

--- a/spec/models/analysis_spec.rb
+++ b/spec/models/analysis_spec.rb
@@ -285,7 +285,7 @@ describe Analysis do
         @arn.input[:analysis_parameters].should eq(@arn.parameters)
       end
 
-      it "returns a Hash having Run ids" do
+      it "returns an Array having Run ids" do
         @run.status = :finished
         @run.save!
         run2 = FactoryGirl.create(:finished_run, parameter_set: @ps, result: {"zzz" => true})
@@ -293,8 +293,7 @@ describe Analysis do
         run3.status = :failed
         run3.save
         @arn.input[:run_ids].size.should eq(2)
-        @arn.input[:run_ids].should include(@run.to_param)
-        @arn.input[:run_ids].should include(run2.to_param)
+        @arn.input[:run_ids].should =~ [@run.id.to_s, run2.id.to_s]
       end
     end
   end
@@ -319,7 +318,7 @@ describe Analysis do
         paths = @arn.input_files
         paths.should be_a(Array)
         paths.should have(2).items
-        (paths - [@dummy_path, @dummy_dir]).should be_empty
+        paths.should =~ [@dummy_path, @dummy_dir]
       end
 
       it "does not include analysis directory of self" do

--- a/spec/models/analysis_spec.rb
+++ b/spec/models/analysis_spec.rb
@@ -317,20 +317,20 @@ describe Analysis do
 
       it "returns a file entries in run directory" do
         paths = @arn.input_files
-        paths.should be_a(Hash)
-        paths.should have(1).items
-        (paths['.'] - [@dummy_path, @dummy_dir]).should be_empty
+        paths.should be_a(Array)
+        paths.should have(2).items
+        (paths - [@dummy_path, @dummy_dir]).should be_empty
       end
 
       it "does not include analysis directory of self" do
         paths = @arn.input_files
-        paths.values.flatten.should_not include(@arn.dir)
+        paths.should_not include(@arn.dir)
       end
 
       it "does not include directories of other Analyses by defualt" do
         another_arn = @run.analyses.create!(analyzer: @azr, parameters: {})
         paths = @arn.input_files
-        paths.values.flatten.should_not include(another_arn.dir)
+        paths.should_not include(another_arn.dir)
       end
     end
 
@@ -355,14 +355,10 @@ describe Analysis do
         @dummy_dirs.each {|dir| FileUtils.rm_r(dir) if File.directory?(dir) }
       end
 
-      it "returns a hash whose keys are ids of finished runs" do
-        @arn2.input_files.keys.should eq( [@run2.to_param] )
-        @arn2.input_files.keys.should_not include(@run.to_param)
-      end
-
-      it "returns a hash whose values are output paths of runs" do
-        paths = @arn2.input_files[@run2.to_param]
-        paths.should eq(@run2.result_paths)
+      it "returns a array whose values are dirs of finished runs" do
+        @arn2.input_files.should be_a(Array)
+        @arn2.input_files.should eq([@run2.dir])
+        @arn2.input_files.should_not include(@run.dir)
       end
     end
   end

--- a/spec/models/analysis_spec.rb
+++ b/spec/models/analysis_spec.rb
@@ -266,12 +266,6 @@ describe Analysis do
       it "returns a Hash having 'analysis_parameters'" do
         @arn.input[:analysis_parameters].should eq(@arn.parameters)
       end
-
-      it "returns a Hash having result of Run" do
-        @run.result = {"xxx" => 1234, "yyy" => 0.5}
-        @run.save!
-        @arn.input[:result].should eq(@run.result)
-      end
     end
 
     describe "for :on_parameter_set type" do
@@ -291,19 +285,16 @@ describe Analysis do
         @arn.input[:analysis_parameters].should eq(@arn.parameters)
       end
 
-      it "returns a Hash having result of Runs" do
-        @run.result = {"xxx" => 1234, "yyy" => 0.5}
+      it "returns a Hash having Run ids" do
         @run.status = :finished
         @run.save!
         run2 = FactoryGirl.create(:finished_run, parameter_set: @ps, result: {"zzz" => true})
         run3 = FactoryGirl.create(:run, parameter_set: @ps)
         run3.status = :failed
         run3.save
-        @arn.input[:result].size.should eq(2)
-        @arn.input[:result].should have_key(@run.to_param)
-        @arn.input[:result].should have_key(run2.to_param)
-        @arn.input[:result][@run.to_param].should eq(@run.result)
-        @arn.input[:result][run2.to_param].should eq(run2.result)
+        @arn.input[:run_ids].size.should eq(2)
+        @arn.input[:run_ids].should include(@run.to_param)
+        @arn.input[:run_ids].should include(run2.to_param)
       end
     end
   end

--- a/spec/models/analysis_spec.rb
+++ b/spec/models/analysis_spec.rb
@@ -293,8 +293,12 @@ describe Analysis do
 
       it "returns a Hash having result of Runs" do
         @run.result = {"xxx" => 1234, "yyy" => 0.5}
+        @run.status = :finished
         @run.save!
         run2 = FactoryGirl.create(:finished_run, parameter_set: @ps, result: {"zzz" => true})
+        run3 = FactoryGirl.create(:run, parameter_set: @ps)
+        run3.status = :failed
+        run3.save
         @arn.input[:result].size.should eq(2)
         @arn.input[:result].should have_key(@run.to_param)
         @arn.input[:result].should have_key(run2.to_param)

--- a/spec/workers/analyzer_runner_spec.rb
+++ b/spec/workers/analyzer_runner_spec.rb
@@ -66,10 +66,10 @@ describe AnalyzerRunner do
         Dir.chdir(@work_dir) {
           dummy_input = @arn.analyzable.dir.join('dummy.txt')
           FileUtils.touch(dummy_input)
-          @arn.should_receive(:input_files).and_return({'abc' => [dummy_input]})
+          @arn.should_receive(:input_files).and_return([@arn.analyzable.dir])
           AnalyzerRunner.__send__(:prepare_inputs, @arn)
           File.directory?('_input').should be_true
-          File.exist?('_input/abc/dummy.txt').should be_true
+          File.exist?("_input/#{@arn.analyzable.to_param}/dummy.txt").should be_true
         }
       end
     end
@@ -99,13 +99,13 @@ describe AnalyzerRunner do
         Dir.chdir(@work_dir) {
           dummy_input = @arn.analyzable.dir.join('dummy.txt')
           FileUtils.touch(dummy_input)
-          @arn.should_receive(:input_files).and_return({'abc' => [dummy_input]})
+          @arn.should_receive(:input_files).and_return([@arn.analyzable.dir])
           AnalyzerRunner.__send__(:prepare_inputs, @arn)
           File.directory?('_input').should be_true
-          File.exist?('_input/abc/dummy.txt').should be_true
+          File.exist?("_input/#{@arn.analyzable.to_param}/dummy.txt").should be_true
           AnalyzerRunner.__send__(:remove_inputs)
           File.directory?('_input').should_not be_true
-          File.exist?('_input/abc/dummy.txt').should_not be_true
+          File.exist?("_input/#{@arn.analyzable.to_param}/dummy.txt").should_not be_true
         }
       end
     end


### PR DESCRIPTION
fixed #248
-  improve analysis on_ps performance
  - apply aggregation pipeline to collect run ids
  - make links run.dirs instead of run.result_paths to _input directory
### Performance Test
- Settings
  - 160 runs
  - dummy analyzer (command: "echo")
- Analyzing Time
  - old specification: 1065 sec
  - new specification: 7 sec
