### PR TITLE
Generate preprocess script on manual submission

### DIFF
--- a/app/models/result_directory.rb
+++ b/app/models/result_directory.rb
@@ -67,7 +67,7 @@ module ResultDirectory
     manual_submission_path.join("#{run.id}_preprocess.sh")
   end
 
-  def self.manual_submission_pre_process_executer_path(run)
-    manual_submission_path.join("#{run.id}_preprocess_executer.sh")
+  def self.manual_submission_pre_process_executor_path(run)
+    manual_submission_path.join("#{run.id}_preprocess_executor.sh")
   end
 end

--- a/app/models/result_directory.rb
+++ b/app/models/result_directory.rb
@@ -62,4 +62,12 @@ module ResultDirectory
   def self.manual_submission_input_json_path(run)
     manual_submission_path.join("#{run.id}_input.json")
   end
+
+  def self.manual_submission_pre_process_script_path(run)
+    manual_submission_path.join("#{run.id}_preprocess.sh")
+  end
+
+  def self.manual_submission_pre_process_executer_path(run)
+    manual_submission_path.join("#{run.id}_preprocess_executer.sh")
+  end
 end

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -143,8 +143,8 @@ class Run
     FileUtils.rm(json_path) if json_path.exist?
     pre_process_script_path = ResultDirectory.manual_submission_pre_process_script_path(self)
     FileUtils.rm(pre_process_script_path) if pre_process_script_path.exist?
-    pre_process_executer_path = ResultDirectory.manual_submission_pre_process_executer_path(self)
-    FileUtils.rm(pre_process_executer_path) if pre_process_executer_path.exist?
+    pre_process_executor_path = ResultDirectory.manual_submission_pre_process_executor_path(self)
+    FileUtils.rm(pre_process_executor_path) if pre_process_executor_path.exist?
   end
 
   def set_simulator
@@ -188,9 +188,9 @@ class Run
     if simulator.pre_process_script && simulator.pre_process_script.length > 0
       pre_process_script_path = ResultDirectory.manual_submission_pre_process_script_path(self)
       File.open(pre_process_script_path, 'w') {|io| io.puts simulator.pre_process_script.gsub(/\r\n/, "\n"); io.flush }
-      pre_process_executer_path = ResultDirectory.manual_submission_pre_process_executer_path(self)
-      File.open(pre_process_executer_path, 'w') {|io| io.puts pre_process_executer; io.flush }
-      cmd = "cd #{pre_process_executer_path.dirname}; chmod +x #{pre_process_executer_path.basename}"
+      pre_process_executor_path = ResultDirectory.manual_submission_pre_process_executor_path(self)
+      File.open(pre_process_executor_path, 'w') {|io| io.puts pre_process_executor; io.flush }
+      cmd = "cd #{pre_process_executor_path.dirname}; chmod +x #{pre_process_executor_path.basename}"
       system(cmd)
     end
   end
@@ -280,7 +280,7 @@ class Run
     end
   end
 
-  def pre_process_executer
+  def pre_process_executor
     script = <<-EOS
 #!/bin/bash
 RUN_ID=#{self.id}

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -141,6 +141,10 @@ class Run
     FileUtils.rm(sh_path) if sh_path.exist?
     json_path = ResultDirectory.manual_submission_input_json_path(self)
     FileUtils.rm(json_path) if json_path.exist?
+    pre_process_script_path = ResultDirectory.manual_submission_pre_process_script_path(self)
+    FileUtils.rm(pre_process_script_path) if pre_process_script_path.exist?
+    pre_process_executer_path = ResultDirectory.manual_submission_pre_process_executer_path(self)
+    FileUtils.rm(pre_process_executer_path) if pre_process_executer_path.exist?
   end
 
   def set_simulator
@@ -183,7 +187,7 @@ class Run
 
     if simulator.pre_process_script && simulator.pre_process_script.length > 0
       pre_process_script_path = ResultDirectory.manual_submission_pre_process_script_path(self)
-      File.open(pre_process_script_path, 'w') {|io| io.puts simulator.pre_process_script; io.flush }
+      File.open(pre_process_script_path, 'w') {|io| io.puts simulator.pre_process_script.gsub(/\r\n/, "\n"); io.flush }
       pre_process_executer_path = ResultDirectory.manual_submission_pre_process_executer_path(self)
       File.open(pre_process_executer_path, 'w') {|io| io.puts pre_process_executer; io.flush }
       cmd = "cd #{pre_process_executer_path.dirname}; chmod +x #{pre_process_executer_path.basename}"

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -185,9 +185,9 @@ class Run
       File.open(input_json_path, 'w') {|io| io.puts input.to_json; io.flush }
     end
 
-    if simulator.pre_process_script && simulator.pre_process_script.length > 0
+    if simulator.pre_process_script.present?
       pre_process_script_path = ResultDirectory.manual_submission_pre_process_script_path(self)
-      File.open(pre_process_script_path, 'w') {|io| io.puts simulator.pre_process_script.gsub(/\r\n/, "\n"); io.flush }
+      File.open(pre_process_script_path, 'w') {|io| io.puts simulator.pre_process_script.gsub(/\r\n/, "\n"); io.flush } # Since a string taken from DB may contain \r\n, gsub is necessary
       pre_process_executor_path = ResultDirectory.manual_submission_pre_process_executor_path(self)
       File.open(pre_process_executor_path, 'w') {|io| io.puts pre_process_executor; io.flush }
       cmd = "cd #{pre_process_executor_path.dirname}; chmod +x #{pre_process_executor_path.basename}"

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -409,6 +409,20 @@ EOS
       json_path.should_not be_exist
     end
 
+    it "deletes preprocess script and preprocess executer created for manual submission" do
+      sim = @run.simulator
+      sim.update_attribute(:pre_process_script, 'echo "Hello" > preprocess_result.txt')
+      run = sim.parameter_sets.first.runs.create(submitted_to: nil)
+      pre_process_script_path = ResultDirectory.manual_submission_pre_process_script_path(run)
+      pre_process_executer_path = ResultDirectory.manual_submission_pre_process_executer_path(run)
+
+      pre_process_script_path.should be_exist
+      pre_process_executer_path.should be_exist
+      run.destroy
+      pre_process_script_path.should_not be_exist
+      pre_process_executer_path.should_not be_exist
+    end
+
     context "when status is :submitted or :running" do
 
       before(:each) do

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -409,18 +409,18 @@ EOS
       json_path.should_not be_exist
     end
 
-    it "deletes preprocess script and preprocess executer created for manual submission" do
+    it "deletes preprocess script and preprocess executor created for manual submission" do
       sim = @run.simulator
       sim.update_attribute(:pre_process_script, 'echo "Hello" > preprocess_result.txt')
       run = sim.parameter_sets.first.runs.create(submitted_to: nil)
       pre_process_script_path = ResultDirectory.manual_submission_pre_process_script_path(run)
-      pre_process_executer_path = ResultDirectory.manual_submission_pre_process_executer_path(run)
+      pre_process_executor_path = ResultDirectory.manual_submission_pre_process_executor_path(run)
 
       pre_process_script_path.should be_exist
-      pre_process_executer_path.should be_exist
+      pre_process_executor_path.should be_exist
       run.destroy
       pre_process_script_path.should_not be_exist
-      pre_process_executer_path.should_not be_exist
+      pre_process_executor_path.should_not be_exist
     end
 
     context "when status is :submitted or :running" do
@@ -504,31 +504,31 @@ EOS
           ResultDirectory.manual_submission_pre_process_script_path(run).should be_exist
         end
 
-        it "creates a preprocess executer" do
+        it "creates a preprocess executor" do
           @simulator.update_attribute(:pre_process_script, 'echo "Hello" > preprocess_result.txt')
           run = @param_set.runs.create!(submitted_to: nil)
-          ResultDirectory.manual_submission_pre_process_executer_path(run).should be_exist
+          ResultDirectory.manual_submission_pre_process_executor_path(run).should be_exist
         end
 
-        it "preprocess executer creates _preprocess.sh" do
+        it "preprocess executor creates _preprocess.sh" do
           @simulator.update_attribute(:pre_process_script, 'echo "Hello" > preprocess_result.txt')
           run = @param_set.runs.create!(submitted_to: nil)
-          pre_process_executer_path = ResultDirectory.manual_submission_pre_process_executer_path(run)
-          cmd = "/bin/bash #{pre_process_executer_path.basename}"
-          Dir.chdir(pre_process_executer_path.dirname) {
+          pre_process_executor_path = ResultDirectory.manual_submission_pre_process_executor_path(run)
+          cmd = "/bin/bash #{pre_process_executor_path.basename}"
+          Dir.chdir(pre_process_executor_path.dirname) {
             system(cmd)
             _preprocess_path = Pathname.new(run.id).join("_preprocess.sh")
             _preprocess_path.should be_exist
           }
         end
 
-        it "preprocess executer creates _input.json" do
+        it "preprocess executor creates _input.json" do
           @simulator.update_attribute(:support_input_json, true)
           @simulator.update_attribute(:pre_process_script, 'echo "Hello" > preprocess_result.txt')
           run = @param_set.runs.create!(submitted_to: nil)
-          pre_process_executer_path = ResultDirectory.manual_submission_pre_process_executer_path(run)
-          cmd = "/bin/bash #{pre_process_executer_path.basename}"
-          Dir.chdir(pre_process_executer_path.dirname) {
+          pre_process_executor_path = ResultDirectory.manual_submission_pre_process_executor_path(run)
+          cmd = "/bin/bash #{pre_process_executor_path.basename}"
+          Dir.chdir(pre_process_executor_path.dirname) {
             system(cmd)
             _input_json_path = Pathname.new(run.id).join("_input.json")
             _input_json_path.should be_exist

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -481,6 +481,48 @@ EOS
         run = @param_set.runs.create!(submitted_to: nil)
         ResultDirectory.manual_submission_input_json_path(run).should be_exist
       end
+
+      context "when simulator.pre_process exists" do
+
+        it "creates a preprocess script" do
+          @simulator.update_attribute(:pre_process_script, 'echo "Hello" > preprocess_result.txt')
+          run = @param_set.runs.create!(submitted_to: nil)
+          ResultDirectory.manual_submission_pre_process_script_path(run).should be_exist
+        end
+
+        it "creates a preprocess executer" do
+          @simulator.update_attribute(:pre_process_script, 'echo "Hello" > preprocess_result.txt')
+          run = @param_set.runs.create!(submitted_to: nil)
+          ResultDirectory.manual_submission_pre_process_executer_path(run).should be_exist
+        end
+
+        it "preprocess executer creates _preprocess.sh" do
+          @simulator.update_attribute(:pre_process_script, 'echo "Hello" > preprocess_result.txt')
+          run = @param_set.runs.create!(submitted_to: nil)
+          pre_process_executer_path = ResultDirectory.manual_submission_pre_process_executer_path(run)
+          cmd = "/bin/bash #{pre_process_executer_path.basename}"
+          Dir.chdir(pre_process_executer_path.dirname) {
+            system(cmd)
+            _preprocess_path = Pathname.new(run.id).join("_preprocess.sh")
+            _preprocess_path.should be_exist
+          }
+        end
+
+        it "preprocess executer creates _input.json" do
+          @simulator.update_attribute(:support_input_json, true)
+          @simulator.update_attribute(:pre_process_script, 'echo "Hello" > preprocess_result.txt')
+          run = @param_set.runs.create!(submitted_to: nil)
+          pre_process_executer_path = ResultDirectory.manual_submission_pre_process_executer_path(run)
+          cmd = "/bin/bash #{pre_process_executer_path.basename}"
+          Dir.chdir(pre_process_executer_path.dirname) {
+            system(cmd)
+            _input_json_path = Pathname.new(run.id).join("_input.json")
+            _input_json_path.should be_exist
+            _preprocess_script_result = Pathname.new(run.id).join("preprocess_result.txt")
+            _preprocess_script_result.should be_exist
+          }
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fixed #266

When a run is created with {submitted_to: nil} and when the run.simulator has pre_process_script, pre_process_script and its executor are also created in manual submission directory.
You can run pre_process for ${RUN_ID} like the following command.

``` sh
scp public/Result_development/manual_submission/${RUN_ID}* remotehost:/path/to/work_dir/
ssh remotehost "cd /path/to/work_dir; ./${RUN_ID}_preprocess_executor.sh"
```

Then you can find results of preprocess in ${RUN_ID} directory.
- /path/to/work_dir/${RUN_ID}/
  - _preprocess.sh
  - _input.json (if run.simulator.support_json = true)
  - someting created by _preprocess.sh
