### PR TITLE
Default host parameter on simulator

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -98,9 +98,4 @@ class HostsController < ApplicationController
     end
     render nothing: true
   end
-
-  def _host_parameters_field
-    host = Host.where(id: params[:id]).first
-    render partial: "runs/host_parameter_fields", locals: {host: host}
-  end
 end

--- a/app/controllers/simulators_controller.rb
+++ b/app/controllers/simulators_controller.rb
@@ -170,4 +170,13 @@ class SimulatorsController < ApplicationController
     host = Host.where(id: params[:host_id]).first
     render partial: "runs/host_parameter_fields", locals: {sim: sim, host: host}
   end
+
+  def _default_mpi_omp
+    sim = Simulator.find(params[:id])
+    host = Host.where(id: params[:host_id]).first
+    mpi = sim.default_mpi_procs[host.id.to_s] || 1
+    omp = sim.default_omp_threads[host.id.to_s] || 1
+    data = {'mpi_procs' => mpi, 'omp_threads' => omp}
+    render json: data
+  end
 end

--- a/app/controllers/simulators_controller.rb
+++ b/app/controllers/simulators_controller.rb
@@ -164,4 +164,10 @@ class SimulatorsController < ApplicationController
     end
     render nothing: true
   end
+
+  def _host_parameters_field
+    sim = Simulator.find(params[:id])
+    host = Host.where(id: params[:host_id]).first
+    render partial: "runs/host_parameter_fields", locals: {sim: sim, host: host}
+  end
 end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -54,7 +54,8 @@ class Host
   before_destroy :validate_destroyable, :delete_host_parameters_from_executable_simulators
   after_update :get_host_parameters_for_xsub,
                :if => lambda { scheduler_type == "xsub" && status_changed? && status == :enabled }
-  after_update :clear_host_parameters_in_executable_simulators
+  after_update :delete_host_parameters_from_executable_simulators,
+               :if => lambda { status_changed? and status == :disabled }
 
   CONNECTION_EXCEPTIONS = [
     Errno::ECONNREFUSED,
@@ -218,12 +219,6 @@ class Host
     self.executable_simulators.each do |sim|
       modified_host_parameters = sim.default_host_parameters.delete_if{|key, value| key == self.id.to_s}
       sim.timeless.update_attribute(:default_host_parameters, modified_host_parameters)
-    end
-  end
-
-  def clear_host_parameters_in_executable_simulators
-    if self.status == :disabled
-      delete_host_parameters_from_executable_simulators
     end
   end
 end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -48,10 +48,13 @@ class Host
            :if => lambda { scheduler_type != "xsub" and scheduler_type_changed? }
 
   before_validation :get_host_parameters_for_xsub,
-                    :if => lambda {scheduler_type == "xsub" and scheduler_type_changed? }
+                    :if => lambda { scheduler_type == "xsub" and scheduler_type_changed? }
   before_save :use_default_template, :if => lambda { scheduler_type == "xsub" }
   before_create :set_position
-  before_destroy :validate_destroyable
+  before_destroy :validate_destroyable, :delete_host_parameters_from_executable_simulators
+  after_update :get_host_parameters_for_xsub,
+               :if => lambda { scheduler_type == "xsub" && status == :enabled }
+  after_update :check_host_parameters_in_executable_simulators
 
   CONNECTION_EXCEPTIONS = [
     Errno::ECONNREFUSED,
@@ -209,6 +212,19 @@ class Host
 
   def set_position
     self.position = Host.count
+  end
+
+  def delete_host_parameters_from_executable_simulators
+    self.executable_simulators.each do |sim|
+      modified_host_parameters = sim.default_host_parameters.delete_if{|key, value| key == self.to_param}
+      Simulator.find(sim.to_param).timeless.update_attribute(:default_host_parameters, modified_host_parameters)
+    end
+  end
+
+  def check_host_parameters_in_executable_simulators
+    if self.status == :disabled
+      delete_host_parameters_from_executable_simulators
+    end
   end
 end
 

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -53,8 +53,8 @@ class Host
   before_create :set_position
   before_destroy :validate_destroyable, :delete_host_parameters_from_executable_simulators
   after_update :get_host_parameters_for_xsub,
-               :if => lambda { scheduler_type == "xsub" && status == :enabled }
-  after_update :check_host_parameters_in_executable_simulators
+               :if => lambda { scheduler_type == "xsub" && status_changed? && status == :enabled }
+  after_update :clear_host_parameters_in_executable_simulators
 
   CONNECTION_EXCEPTIONS = [
     Errno::ECONNREFUSED,
@@ -216,12 +216,12 @@ class Host
 
   def delete_host_parameters_from_executable_simulators
     self.executable_simulators.each do |sim|
-      modified_host_parameters = sim.default_host_parameters.delete_if{|key, value| key == self.to_param}
-      Simulator.find(sim.to_param).timeless.update_attribute(:default_host_parameters, modified_host_parameters)
+      modified_host_parameters = sim.default_host_parameters.delete_if{|key, value| key == self.id.to_s}
+      sim.timeless.update_attribute(:default_host_parameters, modified_host_parameters)
     end
   end
 
-  def check_host_parameters_in_executable_simulators
+  def clear_host_parameters_in_executable_simulators
     if self.status == :disabled
       delete_host_parameters_from_executable_simulators
     end

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -200,7 +200,7 @@ class Run
       id = self.submitted_to.present? ? self.submitted_to.id : "manual_submission"
       host_parameters = self.simulator.default_host_parameters
       host_parameters[id] = self.host_parameters
-      Simulator.find(self.simulator.to_param).timeless.update_attribute(:default_host_parameters, host_parameters)
+      self.simulator.timeless.update_attribute(:default_host_parameters, host_parameters)
     end
   end
 

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -199,10 +199,10 @@ class Run
 
   def update_default_host_parameter_on_its_simulator
     unless self.host_parameters == self.simulator.get_default_host_parameter(self.submitted_to)
-      id = self.submitted_to.present? ? self.submitted_to.id : "manual_submission"
-      host_parameters = self.simulator.default_host_parameters
-      host_parameters[id] = self.host_parameters
-      self.simulator.timeless.update_attribute(:default_host_parameters, host_parameters)
+      host_id = self.submitted_to.present? ? self.submitted_to.id : "manual_submission"
+      new_host_parameters = self.simulator.default_host_parameters
+      new_host_parameters[host_id] = self.host_parameters
+      self.simulator.timeless.update_attribute(:default_host_parameters, new_host_parameters)
     end
   end
 

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -196,7 +196,7 @@ class Run
   end
 
   def update_default_host_parameter_on_its_simulator
-    unless self.host_parameters == self.simulator.default_host_parameter(self.submitted_to)
+    unless self.host_parameters == self.simulator.get_default_host_parameter(self.submitted_to)
       id = self.submitted_to.present? ? self.submitted_to.id : "manual_submission"
       host_parameters = self.simulator.default_host_parameters
       host_parameters[id] = self.host_parameters

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -323,7 +323,7 @@ EOS
   end
 
   public
-  def default_host_parameter(host)
+  def get_default_host_parameter(host)
     if host.present?
       id = host.id.to_s
       unless self.default_host_parameters[id].present?

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -11,6 +11,8 @@ class Simulator
   field :print_version_command, type: String
   field :position, type: Integer # position in the table. start from zero
   field :default_host_parameters, type: Hash, default: {} # {Host.id => {host_param1 => foo, ...}}
+  field :default_mpi_procs, type: Hash, default: {} # {Host.id => 4, ...}
+  field :default_omp_threads, type: Hash, default: {} # {Host.id => 8, ...}
 
   embeds_many :parameter_definitions
   has_many :parameter_sets, dependent: :destroy

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -332,6 +332,7 @@ EOS
         host_parameter = Hash[*key_value.flatten]
       end
       self.default_host_parameters[id] = host_parameter
+      self.save
     end
     self.default_host_parameters[id]
   end

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -10,7 +10,7 @@ class Simulator
   field :pre_process_script, type: String
   field :print_version_command, type: String
   field :position, type: Integer # position in the table. start from zero
-  field :default_host_parameters, type: Hash, default: {"manual_submission" => {}} # {Host.id => {host_param1 => foo, ...}}
+  field :default_host_parameters, type: Hash, default: {} # {Host.id => {host_param1 => foo, ...}}
 
   embeds_many :parameter_definitions
   has_many :parameter_sets, dependent: :destroy
@@ -27,7 +27,7 @@ class Simulator
   attr_accessible :name, :pre_process_script, :command, :description,
                   :parameter_definitions_attributes, :executable_on_ids,
                   :support_input_json, :support_omp, :support_mpi,
-                  :print_version_command, :default_host_parameters
+                  :print_version_command
 
   before_create :set_position
   after_create :create_simulator_dir
@@ -324,16 +324,20 @@ EOS
 
   public
   def default_host_parameter(host)
-    id = host.present? ? host.to_param : "manual_submission"
-    unless self.default_host_parameters[id].present?
-      host_parameter = {}
-      if host.present?
-        key_value = host.host_parameter_definitions.map {|pd| [pd.key, pd.default]}
-        host_parameter = Hash[*key_value.flatten]
+    if host.present?
+      id = host.id.to_s
+      unless self.default_host_parameters[id].present?
+        host_parameter = {}
+        if host.present?
+          key_value = host.host_parameter_definitions.map {|pd| [pd.key, pd.default]}
+          host_parameter = Hash[*key_value.flatten]
+        end
+        self.default_host_parameters[id] = host_parameter
+        self.timeless.update_attribute(:default_host_parameters, self.default_host_parameters)
       end
-      self.default_host_parameters[id] = host_parameter
-      self.save
+      return self.default_host_parameters[id]
+    else
+      return {} # for manual_submission
     end
-    self.default_host_parameters[id]
   end
 end

--- a/app/views/runs/_fields.html.haml
+++ b/app/views/runs/_fields.html.haml
@@ -20,7 +20,7 @@
     - selected_id = run.submitted_to ? run.submitted_to.id.to_s : nil
     = f.select(:submitted_to, options_for_select(host_names, selected: selected_id) )
 #host_parameters
-  = render 'runs/host_parameter_fields', {sim: run.simulator, host: run.submitted_to}
+  = render 'runs/host_parameter_fields', {run: run, sim: run.simulator, host: run.submitted_to}
 
 :javascript
   $(function() {

--- a/app/views/runs/_fields.html.haml
+++ b/app/views/runs/_fields.html.haml
@@ -20,14 +20,14 @@
     - selected_id = run.submitted_to ? run.submitted_to.id.to_s : nil
     = f.select(:submitted_to, options_for_select(host_names, selected: selected_id) )
 #host_parameters
-  = render 'runs/host_parameter_fields', run: run, host: run.submitted_to
+  = render 'runs/host_parameter_fields', {sim: run.simulator, host: run.submitted_to}
 
 :javascript
   $(function() {
     $('select#run_submitted_to').change(function() {
       var host_id = $(this).val();
       if( host_id == '' ) { host_id = 'manual'; }
-      var url = "#{_host_parameters_field_host_url(':host_id')}".replace(':host_id', host_id);
+      var url = "#{_host_parameters_field_simulator_url(run.simulator)}" + "?host_id=" + host_id;
       $.get(url, function(data) {
         $('#host_parameters').html(data);
         if( $('#new_parameter_set').length > 0 ) {

--- a/app/views/runs/_fields.html.haml
+++ b/app/views/runs/_fields.html.haml
@@ -27,12 +27,26 @@
     $('select#run_submitted_to').change(function() {
       var host_id = $(this).val();
       if( host_id == '' ) { host_id = 'manual'; }
-      var url = "#{_host_parameters_field_simulator_url(run.simulator)}" + "?host_id=" + host_id;
-      $.get(url, function(data) {
-        $('#host_parameters').html(data);
-        if( $('#new_parameter_set').length > 0 ) {
-          $('#new_parameter_set').trigger('change'); // necessary to update CLI command
-        }
-      })
+      var update_mpi_omp_fields = function() {
+        var mpi_field = $('#run_mpi_procs');
+        var omp_field = $('#run_omp_threads');
+        if( mpi_field.size() + omp_field.size() == 0 ) return;
+        var url = "#{_default_mpi_omp_simulator_url(run.simulator)}.json" + "?host_id=" + host_id;
+        $.get(url, function(data) {
+          if( mpi_field.size() > 0 ) { mpi_field.val(data['mpi_procs']); }
+          if( omp_field.size() > 0 ) { omp_field.val(data['omp_threads']); }
+        });
+      }
+      update_mpi_omp_fields();
+      var update_host_parameters = function() {
+        var url = "#{_host_parameters_field_simulator_url(run.simulator)}" + "?host_id=" + host_id;
+        $.get(url, function(data) {
+          $('#host_parameters').html(data);
+          if( $('#new_parameter_set').length > 0 ) {
+            $('#new_parameter_set').trigger('change'); // necessary to update CLI command
+          }
+        });
+      }
+      update_host_parameters();
     });
   });

--- a/app/views/runs/_fields.html.haml
+++ b/app/views/runs/_fields.html.haml
@@ -1,3 +1,14 @@
+.control-group
+  = f.label(:submitted_to, class: 'control-label')
+  .controls
+    - host_names = run.simulator.executable_on.map {|h| [h.name, h.id.to_s]}
+    - host_names += [ ["(manual submission)", nil] ]
+    - selected_id = run.submitted_to ? run.submitted_to.id.to_s : nil
+    = f.select(:submitted_to, options_for_select(host_names, selected: selected_id) )
+.control-group
+  = f.label(:priority, 'Priorities of Runs', class: 'control-label')
+  .controls
+    = f.select(:priority, options_for_select(Run::PRIORITY_ORDER.sort_by {|a| a[0]}.map {|a| [a[1], a[0]]}, selected: 1))
 - if run.parameter_set.simulator.support_mpi
   .control-group
     = f.label(:mpi_procs, "MPI procs", class: 'control-label')
@@ -8,17 +19,7 @@
     = f.label(:omp_threads, "OMP threads", class: 'control-label')
     .controls
       = f.text_field(:omp_threads)
-.control-group
-  = f.label(:priority, 'Priorities of Runs', class: 'control-label')
-  .controls
-    = f.select(:priority, options_for_select(Run::PRIORITY_ORDER.sort_by {|a| a[0]}.map {|a| [a[1], a[0]]}, selected: 1))
-.control-group
-  = f.label(:submitted_to, class: 'control-label')
-  .controls
-    - host_names = run.simulator.executable_on.map {|h| [h.name, h.id.to_s]}
-    - host_names += [ ["(manual submission)", nil] ]
-    - selected_id = run.submitted_to ? run.submitted_to.id.to_s : nil
-    = f.select(:submitted_to, options_for_select(host_names, selected: selected_id) )
+
 #host_parameters
   = render 'runs/host_parameter_fields', {run: run, sim: run.simulator, host: run.submitted_to}
 

--- a/app/views/runs/_host_parameter_fields.html.haml
+++ b/app/views/runs/_host_parameter_fields.html.haml
@@ -1,5 +1,5 @@
 - if host
-  - sim.default_host_parameter(host).each do |key, val|
+  - sim.get_default_host_parameter(host).each do |key, val|
     .control-group
       = label_tag(:"run[host_parameters][#{key}]", key, class: 'control-label')
       .controls

--- a/app/views/runs/_host_parameter_fields.html.haml
+++ b/app/views/runs/_host_parameter_fields.html.haml
@@ -1,8 +1,7 @@
 - if host
-  - host.host_parameter_definitions.each do |hpdef|
+  - sim.default_host_parameter(host).each do |key, val|
     .control-group
-      = label_tag(:"run[host_parameters][#{hpdef.key}]", hpdef.key, class: 'control-label')
+      = label_tag(:"run[host_parameters][#{key}]", key, class: 'control-label')
       .controls
-        - value = (defined?(run) && run.host_parameters[hpdef.key]) || hpdef.default
-        = text_field_tag(:"run[host_parameters][#{hpdef.key}]", value, id: "run_host_parameters_#{hpdef.key}_#{host.id}")
-        = "Format: /#{hpdef.format}/"
+        = text_field_tag(:"run[host_parameters][#{key}]", val, id: "run_host_parameters_#{key}_#{host.id}")
+        = "Format: /#{host.host_parameter_definitions.select {|hpd| hpd.key == key}.first.format }/"

--- a/app/views/runs/_host_parameter_fields.html.haml
+++ b/app/views/runs/_host_parameter_fields.html.haml
@@ -3,5 +3,6 @@
     .control-group
       = label_tag(:"run[host_parameters][#{key}]", key, class: 'control-label')
       .controls
-        = text_field_tag(:"run[host_parameters][#{key}]", val, id: "run_host_parameters_#{key}_#{host.id}")
+        - value = (defined?(run) && run.host_parameters[key]) || val
+        = text_field_tag(:"run[host_parameters][#{key}]", value, id: "run_host_parameters_#{key}_#{host.id}")
         = "Format: /#{host.host_parameter_definitions.select {|hpd| hpd.key == key}.first.format }/"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ AcmProto::Application.routes.draw do
       get "_parameters_list" # for ajax, datatables
       get "_analyzer_list" # for ajax, datatables
       get "_progress" # for progress table
+      get "_host_parameters_field" # for ajax, get the fields for host_parameters
     end
 
     parameter_set_actions = ["show"]
@@ -78,9 +79,6 @@ AcmProto::Application.routes.draw do
   resources :hosts, only: host_actions do
     collection do
       post "_sort" # for ajax, update order of the table
-    end
-    member do
-      get "_host_parameters_field" # for ajax, get the fields for host_parameters
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ AcmProto::Application.routes.draw do
       get "_analyzer_list" # for ajax, datatables
       get "_progress" # for progress table
       get "_host_parameters_field" # for ajax, get the fields for host_parameters
+      get "_default_mpi_omp" # for ajax, get the default mpi_procs and omp_threads
     end
 
     parameter_set_actions = ["show"]

--- a/spec/controllers/hosts_controller_spec.rb
+++ b/spec/controllers/hosts_controller_spec.rb
@@ -177,25 +177,4 @@ describe HostsController do
       }.to change { hosts.first.reload.position }.from(0).to(2)
     end
   end
-
-  describe "GET _host_parameters_field" do
-
-    before(:each) do
-      @host = FactoryGirl.create(:host_with_parameters)
-      @sim = FactoryGirl.create(:simulator, parameter_sets_count: 0)
-      @sim.executable_on.push(@host)
-    end
-
-    it "returns http success" do
-      valid_param = {id: @host}
-      get :_host_parameters_field, valid_param, valid_session
-      response.should be_success
-    end
-
-    it "returns http success if host_id is not found" do
-      param = {id: "manual"}
-      get :_host_parameters_field, param, valid_session
-      response.should be_success
-    end
-  end
 end

--- a/spec/controllers/simulators_controller_spec.rb
+++ b/spec/controllers/simulators_controller_spec.rb
@@ -457,4 +457,25 @@ describe SimulatorsController do
       }.to change { simulators.first.reload.position }.from(0).to(2)
     end
   end
+
+  describe "GET _host_parameters_field" do
+
+    before(:each) do
+      @host = FactoryGirl.create(:host_with_parameters)
+      @sim = FactoryGirl.create(:simulator, parameter_sets_count: 0)
+      @sim.executable_on.push(@host)
+    end
+
+    it "returns http success" do
+      valid_param = {id: @sim.to_param, host_id: @host.to_param}
+      get :_host_parameters_field, valid_param, valid_session
+      response.should be_success
+    end
+
+    it "returns http success if host_id is not found" do
+      param = {id: @sim.to_param, host_id: "manual"}
+      get :_host_parameters_field, param, valid_session
+      response.should be_success
+    end
+  end
 end

--- a/spec/controllers/simulators_controller_spec.rb
+++ b/spec/controllers/simulators_controller_spec.rb
@@ -478,4 +478,52 @@ describe SimulatorsController do
       response.should be_success
     end
   end
+
+  describe "GET _default_mpi_omp" do
+
+    before(:each) do
+      @host = FactoryGirl.create(:host_with_parameters)
+      @sim = FactoryGirl.create(:simulator,
+                                parameter_sets_count: 0, support_mpi: true, support_omp: true)
+      @sim.executable_on.push(@host)
+    end
+
+    it "returns http success" do
+      valid_param = {id: @sim.to_param, host_id: @host.to_param}
+      get :_default_mpi_omp, valid_param, valid_session
+      response.should be_success
+    end
+
+    context "when default_mpi_procs and/or defualt_omp_threads are set" do
+
+      before(:each) do
+        @sim.update_attribute(:default_mpi_procs, {@host.id.to_s => 8})
+        @sim.update_attribute(:default_omp_threads, {@host.id.to_s => 4})
+      end
+
+      it "returns mpi_procs and omp_threads in json" do
+        valid_param = {id: @sim.to_param, host_id: @host.to_param}
+        get :_default_mpi_omp, valid_param, valid_session
+        response.header['Content-Type'].should include 'application/json'
+        parsed = JSON.parse(response.body)
+        parsed.should eq ({'mpi_procs' => 8, 'omp_threads' => 4})
+      end
+    end
+
+    context "when default_mpi_procs or default_omp_threads is not set" do
+
+      before(:each) do
+        @sim.update_attribute(:default_mpi_procs, {})
+        @sim.update_attribute(:default_omp_threads, {})
+      end
+
+      it "returns mpi_procs and omp_threads in json" do
+        valid_param = {id: @sim.to_param, host_id: @host.to_param}
+        get :_default_mpi_omp, valid_param, valid_session
+        response.header['Content-Type'].should include 'application/json'
+        parsed = JSON.parse(response.body)
+        parsed.should eq ({'mpi_procs' => 1, 'omp_threads' => 1})
+      end
+    end
+  end
 end

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -416,12 +416,30 @@ EOS
       @sim.save
     end
 
-    it "delete host parameters from executable simulators" do
+    it "delete default_host_parameters from executable simulators" do
       host_id = @host.id.to_s
       host_parameters = @sim.get_default_host_parameter(@host)
       expect {
         @host.destroy
       }.to change { @sim.reload.default_host_parameters[host_id] }.from(host_parameters).to(nil)
+    end
+
+    it "delete default_mpi_procs from executable simulators" do
+      host_id = @host.id.to_s
+      @sim.update_attribute(:default_mpi_procs, {host_id => 4})
+      host_parameters = @sim.get_default_host_parameter(@host)
+      expect {
+        @host.destroy
+      }.to change { @sim.reload.default_mpi_procs[host_id] }.from(4).to(nil)
+    end
+
+    it "delete default_omp_threads from executable simulators" do
+      host_id = @host.id.to_s
+      @sim.update_attribute(:default_omp_threads, {host_id => 4})
+      host_parameters = @sim.get_default_host_parameter(@host)
+      expect {
+        @host.destroy
+      }.to change { @sim.reload.default_omp_threads[host_id] }.from(4).to(nil)
     end
   end
 
@@ -442,6 +460,26 @@ EOS
         @host.status = :disabled
         @host.save
       }.to change { @sim.reload.default_host_parameters[@host.id.to_s] }.from(host_parameters).to(nil)
+    end
+
+    it "delete default_mpi_procs from executable simulators" do
+      host_id = @host.id.to_s
+      @sim.update_attribute(:default_mpi_procs, {host_id => 4})
+      host_parameters = @sim.get_default_host_parameter(@host)
+      expect {
+        @host.status = :disabled
+        @host.save
+      }.to change { @sim.reload.default_mpi_procs[host_id] }.from(4).to(nil)
+    end
+
+    it "delete default_omp_threads from executable simulators" do
+      host_id = @host.id.to_s
+      @sim.update_attribute(:default_omp_threads, {host_id => 4})
+      host_parameters = @sim.get_default_host_parameter(@host)
+      expect {
+        @host.status = :disabled
+        @host.save
+      }.to change { @sim.reload.default_omp_threads[host_id] }.from(4).to(nil)
     end
   end
 end

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -418,7 +418,7 @@ EOS
 
     it "delete host parameters from executable simulators" do
       host_id = @host.id.to_s
-      host_parameters = @sim.default_host_parameter(@host)
+      host_parameters = @sim.get_default_host_parameter(@host)
       expect {
         @host.destroy
       }.to change { @sim.reload.default_host_parameters[host_id] }.from(host_parameters).to(nil)
@@ -437,7 +437,7 @@ EOS
 
     it "delete host_parameters in executable simulators" do
       host_id = @host.id.to_s
-      host_parameters = @sim.default_host_parameter(@host)
+      host_parameters = @sim.get_default_host_parameter(@host)
       @host.status.should eq :enabled
       expect {
         @host.status = :disabled

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -425,7 +425,7 @@ EOS
     end
   end
 
-  describe "#clear_host_parameters_in_executable_simulators" do
+  context "when status is updated to :disabled" do
 
     before(:each) do
       @host = FactoryGirl.create(:host_with_parameters)
@@ -435,14 +435,13 @@ EOS
       @sim.save
     end
 
-    it "delete host_parameters in executable simulators" do
-      host_id = @host.id.to_s
+    it "delete default_host_parameters of executable simulators" do
       host_parameters = @sim.get_default_host_parameter(@host)
       @host.status.should eq :enabled
       expect {
         @host.status = :disabled
         @host.save
-      }.to change { @sim.reload.default_host_parameters[host_id] }.from(host_parameters).to(nil)
+      }.to change { @sim.reload.default_host_parameters[@host.id.to_s] }.from(host_parameters).to(nil)
     end
   end
 end

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -492,6 +492,24 @@ EOS
       }.to change { run.simulator.default_host_parameters[host.id.to_s] }.from(nil).to(param)
     end
 
+    it "sets default_mpi values" do
+      @simulator.update_attribute(:support_mpi, true)
+      h = Host.first
+      run = @param_set.runs.build(submitted_to: h, mpi_procs: 2)
+      expect {
+        run.save!
+      }.to change { run.simulator.reload.default_mpi_procs[h.id.to_s] }.to(2)
+    end
+
+    it "sets default_omp values" do
+      @simulator.update_attribute(:support_omp, true)
+      h = Host.first
+      run = @param_set.runs.build(submitted_to: h, omp_threads: 4)
+      expect {
+        run.save!
+      }.to change { run.simulator.default_omp_threads[h.id.to_s] }.to(4)
+    end
+
     context "when submitted_to is nil" do
 
       it "creates a job-script" do

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -483,6 +483,15 @@ EOS
       run.job_script.should be_present
     end
 
+    it "sets default_host_parameters to simulator" do
+      host = FactoryGirl.create(:host_with_parameters)
+      param = {"param1" => 3, "param2" => 1}
+      run = @param_set.runs.build(submitted_to: host, host_parameters: param)
+      expect {
+        run.save!
+      }.to change { run.simulator.default_host_parameters[host.id.to_s] }.from(nil).to(param)
+    end
+
     context "when submitted_to is nil" do
 
       it "creates a job-script" do

--- a/spec/models/simulator_spec.rb
+++ b/spec/models/simulator_spec.rb
@@ -466,7 +466,7 @@ describe Simulator do
     end
   end
 
-  describe "default_host_parameter" do
+  describe "get_default_host_parameter" do
 
     before(:each) do
       @sim = FactoryGirl.create(:simulator,
@@ -482,28 +482,28 @@ describe Simulator do
 
       it "return default_host_parameter associated with a host" do
         key_value = @sim.executable_on.first.host_parameter_definitions.map {|pd| [pd.key, pd.default]}
-        @sim.default_host_parameter(@sim.executable_on.first).should eq Hash[*key_value.flatten]
+        @sim.get_default_host_parameter(@sim.executable_on.first).should eq Hash[*key_value.flatten]
       end
 
       it "return default_host_parameter for manual submission" do
-        @sim.default_host_parameter(nil).should eq Hash.new
+        @sim.get_default_host_parameter(nil).should eq Hash.new
       end
     end
 
     context "when new run is created" do
 
       it "return the host parameters of the last created run" do
-        host_parameters = @sim.default_host_parameter(@sim.executable_on.first) # {"param1"=>nil, "param2"=>"XXX"}
+        host_parameters = @sim.get_default_host_parameter(@sim.executable_on.first) # {"param1"=>nil, "param2"=>"XXX"}
         run = @sim.parameter_sets.first.runs.build({submitted_to: @sim.executable_on.first, host_parameters: host_parameters})
         expect {
           run.host_parameters["param2"] = "YYY"
           run.save
-        }.to change { @sim.reload.default_host_parameter(@sim.executable_on.first)["param2"] }.from("XXX").to("YYY")
+        }.to change { @sim.reload.get_default_host_parameter(@sim.executable_on.first)["param2"] }.from("XXX").to("YYY")
       end
 
       it "return {} as default_host_parameter for manual submission" do
         run = @sim.parameter_sets.first.runs.build({submitted_to: nil})
-        @sim.default_host_parameter(run.submitted_to).should eq Hash.new
+        @sim.get_default_host_parameter(run.submitted_to).should eq Hash.new
       end
     end
   end

--- a/spec/models/simulator_spec.rb
+++ b/spec/models/simulator_spec.rb
@@ -492,21 +492,18 @@ describe Simulator do
 
     context "when new run is created" do
 
-      it "return default_host_parameter which the created run has" do
+      it "return the host parameters of the last created run" do
         host_parameters = @sim.default_host_parameter(@sim.executable_on.first) # {"param1"=>nil, "param2"=>"XXX"}
         run = @sim.parameter_sets.first.runs.build({submitted_to: @sim.executable_on.first, host_parameters: host_parameters})
         expect {
           run.host_parameters["param2"] = "YYY"
           run.save
-        }.to change { Simulator.find(@sim.to_param).default_host_parameter(@sim.executable_on.first)["param2"] }.from("XXX").to("YYY")
+        }.to change { @sim.reload.default_host_parameter(@sim.executable_on.first)["param2"] }.from("XXX").to("YYY")
       end
 
-      it "return default_host_parameter which the created run has for manual submission" do
+      it "return {} as default_host_parameter for manual submission" do
         run = @sim.parameter_sets.first.runs.build({submitted_to: nil})
-        expect {
-          run.host_parameters = {"param1"=>nil, "param2"=>"XXX"}
-          run.save
-        }.to change { Simulator.find(@sim.to_param).default_host_parameter(nil) }.from({}).to({"param1"=>nil, "param2"=>"XXX"})
+        @sim.default_host_parameter(run.submitted_to).should eq Hash.new
       end
     end
   end


### PR DESCRIPTION
Fixed #255
- old configuration
  - run.host_paramters are loaded from Host.host_parameter_definitions
- new configuration
  - run.host_parameters are loaded from Simulator.default_host_parameter(run.submitted_to).
  - In Simulator.default_host_parameter(run.submitted_to), if host_parameters are not defined, host_parameters are loaded from Host.host_parameter_definitions.
- new features
  - when Host.scheduler_type == "xsub" and Host.status is changed into :enabled, Host.host_parameter_definitions are reloaded by remote host xsub.
