### PR TITLE
implement multiple column sort for dataTables

### DIFF
--- a/app/controllers/analyses_controller.rb
+++ b/app/controllers/analyses_controller.rb
@@ -43,7 +43,7 @@ class AnalysesController < ApplicationController
 
   def _analyses_table
     stat = params[:analysis_status].to_sym
-    render json: AnalysesListDatatable.new(view_context, Analysis.where(status: stat))
+    render json: AnalysesListDatatable.new(Analysis.where(status: stat), view_context)
   end
 
   private

--- a/app/datatables/analyses_list_datatable.rb
+++ b/app/datatables/analyses_list_datatable.rb
@@ -7,9 +7,9 @@ class AnalysesListDatatable
              '<th style="min-width: 18px; width: 1%;"></th>']
   SORT_BY = ["id", "id", "analyzer_id", "parameters", "status", "analyzer_version", "updated_at", "id"]
 
-  def initialize(view_context, analyses)
-    @view = view_context
+  def initialize(analyses, view_context)
     @analyses = analyses
+    @view = view_context
   end
 
   def as_json(options = {})
@@ -47,7 +47,7 @@ private
   end
 
   def fetch_analyses_list
-    list = @analyses.order_by("#{sort_column} #{sort_direction}")
+    list = @analyses.order_by(sort_column_direction)
     list = list.skip(page).limit(per_page)
     list
   end
@@ -60,14 +60,33 @@ private
     @view.params[:iDisplayLength].to_i > 0 ? @view.params[:iDisplayLength].to_i : 10
   end
 
-  def sort_column
-    idx = @view.params[:iSortCol_0].to_i
-    SORT_BY[idx]
+  def sort_column_direction
+    a = [sort_columns,sort_directions].transpose
+    Hash[*a.flatten]
   end
 
-  def sort_direction
-    @view.params[:sSortDir_0] == "desc" ? "desc" : "asc"
+  def sort_columns
+    idxs = []
+    i=0
+    while true
+      idx=@view.params[("iSortCol_" + i.to_s).to_sym]
+      break unless idx
+      idxs << idx.to_i
+      i+=1
+    end
+    idxs.map {|idx| SORT_BY[idx] }
   end
 
+  def sort_directions
+    dirs = []
+    i=0
+    while true
+      dir=@view.params[("sSortDir_" + i.to_s).to_sym]
+      break unless dir
+      dirs << dir == "desc" ? "desc" : "asc"
+      i+=1
+    end
+    dirs
+  end
 end
 

--- a/app/datatables/analyzers_list_datatable.rb
+++ b/app/datatables/analyzers_list_datatable.rb
@@ -1,5 +1,7 @@
 class AnalyzersListDatatable
 
+  SORT_BY = ["id", "id", "name", "type", "description", "id"]
+
   def initialize(view_context)
     @view = view_context
     @simulator = Simulator.find(@view.params[:id])
@@ -48,7 +50,7 @@ private
   end
 
   def fetch_analyzers_list
-    list = @analyzers.order_by("#{sort_column} #{sort_direction}")
+    list = @analyzers.order_by(sort_column_direction)
     list = list.skip(page).limit(per_page)
     list
   end
@@ -61,15 +63,33 @@ private
     @view.params[:iDisplayLength].to_i > 0 ? @view.params[:iDisplayLength].to_i : 10
   end
 
-  COLUMN_KEYS = ["id", "id", "name", "tyoe", "description", "id"]
-  def sort_column
-    idx = @view.params[:iSortCol_0].to_i
-    COLUMN_KEYS[idx]
+  def sort_column_direction
+    a = [sort_columns,sort_directions].transpose
+    Hash[*a.flatten]
   end
 
-  def sort_direction
-    @view.params[:sSortDir_0] == "desc" ? "desc" : "asc"
+  def sort_columns
+    idxs = []
+    i=0
+    while true
+      idx=@view.params[("iSortCol_" + i.to_s).to_sym]
+      break unless idx
+      idxs << idx.to_i
+      i+=1
+    end
+    idxs.map {|idx| SORT_BY[idx] }
   end
 
+  def sort_directions
+    dirs = []
+    i=0
+    while true
+      dir=@view.params[("sSortDir_" + i.to_s).to_sym]
+      break unless dir
+      dirs << dir == "desc" ? "desc" : "asc"
+      i+=1
+    end
+    dirs
+  end
 end
 

--- a/app/datatables/parameter_sets_list_datatable.rb
+++ b/app/datatables/parameter_sets_list_datatable.rb
@@ -89,7 +89,7 @@ private
   end
 
   def fetch_parameter_sets_list
-    parameter_sets_list = @param_sets.only("v","updated_at").order_by("#{sort_column} #{sort_direction}")
+    parameter_sets_list = @param_sets.only("v","updated_at").order_by(sort_column_direction)
     parameter_sets_list = parameter_sets_list.skip(page).limit(per_page)
     parameter_sets_list
   end
@@ -102,13 +102,33 @@ private
     @view.params[:iDisplayLength].to_i > 0 ? @view.params[:iDisplayLength].to_i : 10
   end
 
-  def sort_column
-    idx = @view.params[:iSortCol_0].to_i
-    sort_by[idx]
+  def sort_column_direction
+    a = [sort_columns,sort_directions].transpose
+    Hash[*a.flatten]
   end
 
-  def sort_direction
-    @view.params[:sSortDir_0] == "desc" ? "desc" : "asc"
+  def sort_columns
+    idxs = []
+    i=0
+    while true
+      idx=@view.params[("iSortCol_" + i.to_s).to_sym]
+      break unless idx
+      idxs << idx.to_i
+      i+=1
+    end
+    idxs.map {|idx| sort_by[idx] }
+  end
+
+  def sort_directions
+    dirs = []
+    i=0
+    while true
+      dir=@view.params[("sSortDir_" + i.to_s).to_sym]
+      break unless dir
+      dirs << dir == "desc" ? "desc" : "asc"
+      i+=1
+    end
+    dirs
   end
 end
 

--- a/app/datatables/runs_list_datatable.rb
+++ b/app/datatables/runs_list_datatable.rb
@@ -54,7 +54,7 @@ private
   end
 
   def fetch_runs_list
-    runs_list = @runs.without(:result).order_by("#{sort_column} #{sort_direction}")
+    runs_list = @runs.without(:result).order_by(sort_column_direction)
     runs_list = runs_list.skip(page).limit(per_page)
     runs_list
   end
@@ -67,13 +67,33 @@ private
     @view.params[:iDisplayLength].to_i > 0 ? @view.params[:iDisplayLength].to_i : 10
   end
 
-  def sort_column
-    idx = @view.params[:iSortCol_0].to_i
-    SORT_BY[idx]
+  def sort_column_direction
+    a = [sort_columns,sort_directions].transpose
+    Hash[*a.flatten]
   end
 
-  def sort_direction
-    @view.params[:sSortDir_0] == "desc" ? "desc" : "asc"
+  def sort_columns
+    idxs = []
+    i=0
+    while true
+      idx=@view.params[("iSortCol_" + i.to_s).to_sym]
+      break unless idx
+      idxs << idx.to_i
+      i+=1
+    end
+    idxs.map {|idx| SORT_BY[idx] }
+  end
+
+  def sort_directions
+    dirs = []
+    i=0
+    while true
+      dir=@view.params[("sSortDir_" + i.to_s).to_sym]
+      break unless dir
+      dirs << dir == "desc" ? "desc" : "asc"
+      i+=1
+    end
+    dirs
   end
 end
 

--- a/spec/datatables/analyses_list_datatable_spec.rb
+++ b/spec/datatables/analyses_list_datatable_spec.rb
@@ -2,8 +2,71 @@ require 'spec_helper'
 
 describe "AnalysesListDatatable" do
 
-  describe "GET _runs_list" do
+  describe "GET _analyses_list" do
 
-    it "returns json"
+    before(:each) do
+      @sim = FactoryGirl.create(:simulator,
+                                parameter_sets_count:1, runs_count:1,
+                                analyzers_count: 1, run_analysis: false
+                               )
+      @run = @sim.parameter_sets.first.runs.first
+      @azr = @sim.analyzers.first
+     20.times do |i|
+        @valid_attr = {
+          parameters: {"param1" => 1, "param2" => 2.0},
+          analyzer: @azr,
+          analyzer_version: (i%2).to_s
+        }
+        @run.analyses.create!(@valid_attr)
+      end
+      @context = ActionController::Base.new.view_context
+      @context.stub(:params).and_return({sEcho: 1, iDisplayStart: 0, iDisplayLength:10 , iSortCol_0: 0, sSortDir_0: "desc"})
+      @context.stub(:link_to) {|str, link_path| link_path }
+      @context.stub(:image_tag) {|str, link_path| link_path }
+      @context.stub(:analysis_path) {|arn| arn.id.to_s }
+      @context.stub(:analyzer_path) {|anz| anz.id.to_s }
+      @context.stub(:distance_to_now_in_words).and_return("time")
+      @context.stub(:raw).and_return("label")
+      @context.stub(:status_label).and_return("status_label")
+      @context.stub(:shortened_id).and_return("xxxx..yy")
+      @arnld = AnalysesListDatatable.new(Analysis.where(status: :created), @context)
+      @arnld_json = JSON.parse(@arnld.to_json)
+    end
+
+    it "is initialized" do
+      @arnld.instance_variable_get(:@analyses).should eq(Analysis.where(status: :created))
+    end
+
+    it "returns json" do
+      @arnld_json["iTotalRecords"].should == 20
+      @arnld_json["iTotalDisplayRecords"].should == 20
+      @arnld_json["aaData"].size.should == 10
+      @arnld_json["aaData"][0][1].to_s.should == @run.analyses.order_by("id desc").first.id.to_s
+    end
+
+    context "with multiple sort" do
+
+      before(:each) do
+        @context = ActionController::Base.new.view_context
+        @context.stub(:params).and_return({sEcho: 1, iDisplayStart: 0, iDisplayLength:10, iSortCol_0: 4, iSortCol_1: 0, sSortDir_0: "asc", sSortDir_1: "desc"})
+        @context.stub(:link_to) {|str, link_path| link_path }
+        @context.stub(:image_tag) {|str, link_path| link_path }
+        @context.stub(:analysis_path) {|arn| arn.id.to_s }
+        @context.stub(:analyzer_path) {|anz| anz.id.to_s }
+        @context.stub(:distance_to_now_in_words).and_return("time")
+        @context.stub(:raw).and_return("label")
+        @context.stub(:status_label).and_return("status_label")
+        @context.stub(:shortened_id).and_return("xxxx..yy")
+        @arnld = AnalysesListDatatable.new(Analysis.where(status: :created), @context)
+        @arnld_json = JSON.parse(@arnld.to_json)
+      end
+
+      it "returns json" do
+        @arnld_json["iTotalRecords"].should == 20
+        @arnld_json["iTotalDisplayRecords"].should == 20
+        @arnld_json["aaData"].size.should == 10
+        @arnld_json["aaData"][0][1].to_s.should == @run.analyses.order_by({"analyzer_version"=>"asc", "id"=>"desc"}).first.id.to_s
+      end
+    end
   end
 end

--- a/spec/datatables/analyzers_list_datatable_spec.rb
+++ b/spec/datatables/analyzers_list_datatable_spec.rb
@@ -17,11 +17,35 @@ describe "AnalyzersListDatatable" do
     it "is initialized" do
       @azrld.instance_variable_get(:@analyzers).should eq(Analyzer.where(:simulator_id => @simulator.to_param))
     end
-    
+
     it "return json" do
       @azrld_json["iTotalRecords"].should == 25
       @azrld_json["iTotalDisplayRecords"].should == 25
       @azrld_json["aaData"].size.should == 10
+    end
+
+    context "with multiple srot" do
+
+      before(:each) do
+        analyzers = @simulator.analyzers
+        analyzers.each_with_index do |anz, i|
+          anz.description = (i%2).to_s
+          anz.save
+        end
+        @context = ActionController::Base.new.view_context
+        @context.stub(:params).and_return({id: @simulator.to_param, sEcho: 1, iDisplayStart: 0, iDisplayLength:10, iSortCol_0: 4, iSortCol_1: 0, sSortDir_0: "asc", sSortDir_1: "desc"})
+        @context.stub(:shortened_id).and_return("id")
+        @context.stub(:analyzer_path).and_return("/analyzers/00000000")
+        @azrld = AnalyzersListDatatable.new(@context)
+        @azrld_json = JSON.parse(@azrld.to_json)
+      end
+
+      it "resutnr json" do
+        @azrld_json["iTotalRecords"].should == 25
+        @azrld_json["iTotalDisplayRecords"].should == 25
+        @azrld_json["aaData"].size.should == 10
+        @azrld_json["aaData"][0][2].to_s.should == @simulator.analyzers.order_by({"description"=>"asc", "id"=>"desc"}).first.name.to_s
+      end
     end
   end
 end

--- a/spec/datatables/parameter_sets_list_datatable_spec.rb
+++ b/spec/datatables/parameter_sets_list_datatable_spec.rb
@@ -35,7 +35,7 @@ describe "ParameterSetsListDatatable" do
       it "is initialized" do
         @psld.instance_variable_get(:@param_sets).should eq @simulator.parameter_sets
       end
-      
+
       it "return json" do
         @psld_json["iTotalRecords"].should == 30
         @psld_json["iTotalDisplayRecords"].should == 30
@@ -81,6 +81,39 @@ describe "ParameterSetsListDatatable" do
         @psld_json["iTotalDisplayRecords"].should == 25
         @psld_json["aaData"].size.should == 5
         @psld_json["aaData"].first[4].to_i.should == @query.parameter_sets.only("v.L").max("v.L")#["aaData"].first[4].to_i is qeual to v.L (["aaData"].first[id, updated_at, [keys]])
+      end
+    end
+
+    context "with multiple sort" do
+
+      before(:each) do
+        @simulator = FactoryGirl.create(:simulator, parameter_sets_count: 0)
+        30.times do |i|
+          FactoryGirl.create(:parameter_set,
+                             simulator: @simulator,
+                             runs_count: 0,
+                             v: {"L" => i%15, "T" => i*2.0}
+                             )
+        end
+        @context = ActionController::Base.new.view_context
+        # columns ["id", "progress_rate_cache", "id", "updated_at"] + @param_keys.map {|key| "v.#{key}"} + ["id"]
+        @context.stub(:params).and_return({id: @simulator.to_param, sEcho: 1, iDisplayStart: 0, iDisplayLength:25 , iSortCol_0: 4, iSortCol_1: 0, sSortDir_0: "desc", sSortDir_1: "asc"})
+        @context.stub(:link_to).and_return("#{@simulator.to_param}")
+        @context.stub(:distance_to_now_in_words).and_return("time")
+        @context.stub(:progress_bar).and_return("<div></div>")
+        @context.stub(:parameter_set_path).and_return("/parameter_sets/00000000ffffff0000ffffffff")
+        @context.stub(:shortened_id).and_return("xxxx..yy")
+        keys = @simulator.parameter_definitions.map {|x| x.key}
+        @psld = ParameterSetsListDatatable.new(@simulator.parameter_sets, keys, @context)
+        @psld_json = JSON.parse(@psld.to_json)
+      end
+
+      it "return json" do
+        @psld_json["iTotalRecords"].should == 30
+        @psld_json["iTotalDisplayRecords"].should == 30
+        @psld_json["aaData"].size.should == 25
+        @psld_json["aaData"].first[4].to_i.should == ParameterSet.only("v.L").where(:simulator_id => @simulator.to_param).max("v.L")
+        @psld_json["aaData"].first[5].to_i.should == ParameterSet.only("v.T").where(:simulator_id => @simulator.to_param).where({"v.L"=>14}).min("v.T")
       end
     end
   end

--- a/spec/models/analysis_spec.rb
+++ b/spec/models/analysis_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Analysis do
 
   before(:each) do
-    @sim = FactoryGirl.create(:simulator, 
+    @sim = FactoryGirl.create(:simulator,
                               parameter_sets_count:1, runs_count:1,
                               analyzers_count: 1, run_analysis: true
                               )


### PR DESCRIPTION
Fixed #300

- impriment multiple column sort for dataTables(parameter_sets_list, runs_list, analyzers_list and analyses_list)
  - You can select the first column by clicking a item name of column.
  - You can select the second column by pushing `shift` key and clicking another item name on column.