### PR TITLE
Set seed for oacis cli create runs

### DIFF
--- a/doc/source/cli.rst
+++ b/doc/source/cli.rst
@@ -319,6 +319,8 @@ Runを新規作成する
   +----------------+--------+--------------------------------+-----------+
   |--number_of_runs|-n      |number of runs (Integer)        |no         |
   +----------------+--------+--------------------------------+-----------+
+  |--seeds         |-s      |seeds array (Json String)       |no         |
+  +----------------+--------+--------------------------------+-----------+
   |--output        |-o      |output file path                |yes        |
   +----------------+--------+--------------------------------+-----------+
 
@@ -327,6 +329,7 @@ Runを新規作成する
     - parameter_setsファイルは create_parameter_sets で出力されるJSON形式のファイルまたは文字列を指定する。
     - job_parameterファイルは job_parameter_template で出力されるJSON形式のファイルまたは文字列を指定する。
     - number_of_runs はRunの数を数値で指定する。各ParameterSetごとに、ここで指定された数になるまでRunが作られる。デフォルトは1。
+    - seeds はRunのseedを数値の配列で指定する(--seeds "[0, 1, 2, 3]")。number_of_runs以上のseedが指定された場合、number_of_runsで指定された数になるまで指定されたseedでRunが作られる。
 
 - 出力
     - RunのidをObjectの配列としてJSON形式で出力する。

--- a/lib/cli/oacis_cli_parameter_set.rb
+++ b/lib/cli/oacis_cli_parameter_set.rb
@@ -88,7 +88,7 @@ class OacisCli < Thor
       omp_threads = run_option["omp_threads"] || 1
       priority = run_option["priority"] || 1
 
-      create_runs_impl(parameter_sets, num_runs, submitted_to, host_parameters, mpi_procs, omp_threads, priority)
+      create_runs_impl(parameter_sets, num_runs, submitted_to, host_parameters, mpi_procs, omp_threads, priority, [])
     end
 
   ensure

--- a/lib/cli/oacis_cli_run.rb
+++ b/lib/cli/oacis_cli_run.rb
@@ -67,7 +67,7 @@ class OacisCli < Thor
     parameter_sets = get_parameter_sets(options[:parameter_sets])
     job_parameters = load_json_file_or_string(options[:job_parameters])
     num_runs = options[:number_of_runs]
-    seeds = JSON.parse(options[:seeds]) if options[:seeds]
+    seeds = options[:seeds] ? JSON.parse(options[:seeds]) : []
     submitted_to = job_parameters["host_id"] ? Host.find(job_parameters["host_id"]) : nil
     host_parameters = job_parameters["host_parameters"].to_hash
     mpi_procs = job_parameters["mpi_procs"]

--- a/spec/lib/cli/oacis_cli_run_spec.rb
+++ b/spec/lib/cli/oacis_cli_run_spec.rb
@@ -157,6 +157,40 @@ describe OacisCli do
       }
     end
 
+    context "with seeds option" do
+
+      def invoke_create_runs_with_seeds
+        create_parameter_set_ids_json(@sim.parameter_sets, 'parameter_set_ids.json')
+        create_job_parameters_json('job_parameters.json')
+        options = {
+          parameter_sets: 'parameter_set_ids.json',
+          job_parameters: 'job_parameters.json',
+          number_of_runs: 3,
+          seeds: "[0, 1, 2]",
+          output: 'run_ids.json'
+        }
+        OacisCli.new.invoke(:create_runs, [], options)
+      end
+
+      it "creates runs for each parameter_set" do
+        at_temp_dir {
+          expect {
+            invoke_create_runs_with_seeds
+          }.to change { Run.count }.by(6)
+        }
+      end
+
+      it "creates run having correct attributes" do
+        at_temp_dir {
+          invoke_create_runs_with_seeds
+          run = @sim.parameter_sets.first.runs.first
+          run.seed.should == 0
+          run2 = @sim.parameter_sets.last.runs.first
+          run2.seed.should == 0
+        }
+      end
+    end
+
     it "outputs ids of created runs in json" do
       at_temp_dir {
         invoke_create_runs

--- a/spec/lib/cli/oacis_cli_run_spec.rb
+++ b/spec/lib/cli/oacis_cli_run_spec.rb
@@ -183,10 +183,10 @@ describe OacisCli do
       it "creates run having correct attributes" do
         at_temp_dir {
           invoke_create_runs_with_seeds
-          run = @sim.parameter_sets.first.runs.first
-          run.seed.should == 0
-          run2 = @sim.parameter_sets.last.runs.first
-          run2.seed.should == 0
+          seeds = @sim.parameter_sets.first.reload.runs.map {|run| run.seed }
+          seeds.should =~ [0,1,2]
+          seeds2 = @sim.parameter_sets.last.reload.runs.map {|run| run.seed }
+          seeds2.should =~ [0,1,2]
         }
       end
     end


### PR DESCRIPTION
Fixed #304

- A new option `--seeds` for oacis_cli create_runs is added.
- Created runs have the specific seeds given by `--seeds` option for oacis_cli create_runs.