### PR TITLE
Fail safe for job observer

### DIFF
--- a/app/workers/job_observer.rb
+++ b/app/workers/job_observer.rb
@@ -40,14 +40,20 @@ class JobObserver
             JobIncluder.include_remote_job(host, run)
           end
         rescue => ex
-          logger.error("Error in Host#check_submitted_job_status: #{ex.inspect}")
+          logger.error("Error in RemoteJobHandler#remote_status: #{ex.inspect}")
           logger.error ex.backtrace
-          logger.error("run:\"#{run.to_param.to_s}\" is failed")
-          if run.result.present?
-            run.result = "System_message:_output.json is not stored. More detail is written in log files."
+
+          # When ssh connection is failed, ex.inspect="#<NoMethodError: undefined method `stat' for nil:NilClass"
+          if ex.inspect.to_s == "#<NoMethodError: undefined method `stat' for nil:NilClass>"
+            logger.error("ssh connection error occurs in run:\"#{run.to_param.to_s}\"")
+          else
+            logger.error("run:\"#{run.to_param.to_s}\" is failed")
+            if run.result.present?
+              run.result = "System_message:_output.json is not stored. More detail is written in log files."
+            end
+            run.status = :failed
+            run.save!
           end
-          run.status = :failed
-          run.save!
         end
       end
     end

--- a/app/workers/job_observer.rb
+++ b/app/workers/job_observer.rb
@@ -43,9 +43,9 @@ class JobObserver
           logger.error("Error in RemoteJobHandler#remote_status: #{ex.inspect}")
           logger.error ex.backtrace
 
-          # When ssh connection is failed, ex.inspect="#<NoMethodError: undefined method `stat' for nil:NilClass"
+          # When ssh connection is failed, ex.inspect="#<NoMethodError: undefined method `stat' for nil:NilClass>"
           if ex.inspect.to_s == "#<NoMethodError: undefined method `stat' for nil:NilClass>"
-            logger.error("ssh connection error occurs in run:\"#{run.to_param.to_s}\"")
+            logger.error("ssh connection error occurs in getting status of run:\"#{run.to_param.to_s}\"")
           else
             logger.error("run:\"#{run.to_param.to_s}\" is failed")
             if run.result.present?

--- a/spec/workers/job_observer_spec.rb
+++ b/spec/workers/job_observer_spec.rb
@@ -104,9 +104,20 @@ describe JobObserver do
       end
 
       it "does not include remote data even if remote status is 'includable'" do
-        @host.stub(:remote_status) { :includable }
+        RemoteJobHandler.any_instance.stub(:remote_status) { :includable }
         JobIncluder.should_not_receive(:include_remote_job)
         JobObserver.__send__(:observe_host, @host, @logger)
+      end
+    end
+
+    context "when ssh connection error occers" do
+
+      it "does not change run status into :failed" do
+        # return "#<NoMethodError: undefined method `stat' for nil:NilClass>"
+        RemoteJobHandler.any_instance.stub(:remote_status) { nil.stat }
+        expect {
+          JobObserver.__send__(:observe_host, @host, @logger)
+        }.not_to change { Run.where(status: :failed).count }
       end
     end
   end


### PR DESCRIPTION
Fixed #307 

In old specification, job status is changed into :failed when the ssh connection is failed.
However, the job queue is still in remote host schedulers.

In new specification, job status is not changed into :failed when the ssh connection is failed.