### PR TITLE
Apply bootstrap3 on plot

### DIFF
--- a/app/assets/javascripts/plot/figure_viewer.js
+++ b/app/assets/javascripts/plot/figure_viewer.js
@@ -311,16 +311,21 @@ FigureViewer.prototype.AddDescription = function() {
       });
     plot.description.append("div").style("padding-bottom", "50px");
 
-    plot.description.append("input").attr("type", "checkbox").on("change", function() {
+    var log_check_box = plot.description.append("div").attr("class", "checkbox");
+    var check_box_x_label = log_check_box.append("label").attr("id", "x_log_check");
+    check_box_x_label.html('<input type="checkbox"> log scale on x axis');
+    //d3.select gets the first element. This selection is available only when new svg will appear at the above of the old svg.
+    d3.select('label#x_log_check input').on("change", function() {
       reset_brush(this.checked ? "log" : "linear", plot.IsLog[1] ? "log" : "linear");
     });
-    plot.description.append("span").html("log scale on x axis");
-    plot.description.append("br");
+    log_check_box.append("br");
 
-    plot.description.append("input").attr("type", "checkbox").on("change", function() {
+    var check_box_y_label = log_check_box.append("label").attr("id", "y_log_check");
+    check_box_y_label.html('<input type="checkbox"> log scale on y axis');
+    //d3.select gets the first element. This selection is available only when new svg will appear at the above of the old svg.
+    d3.select('label#y_log_check input').on("change", function() {
       reset_brush(plot.IsLog[0] ? "log" : "linear", this.checked ? "log" : "linear");
     });
-    plot.description.append("span").html("log scale on y axis");
 
     plot.description.append("br");
     var control_plot = plot.description.append("div").style("margin-top", "10px");

--- a/app/assets/javascripts/plot/line_plot.js
+++ b/app/assets/javascripts/plot/line_plot.js
@@ -327,16 +327,19 @@ LinePlot.prototype.AddDescription = function() {
       });
     plot.description.append("div").style("padding-bottom", "50px");
 
-    plot.description.append("input").attr("type", "checkbox").on("change", function() {
+    var log_check_box = plot.description.append("div").attr("class", "checkbox");
+    var check_box_x_label = log_check_box.append("label").attr("id", "x_log_check");
+    check_box_x_label.html('<input type="checkbox"> log scale on x axis');
+    $("#x_log_check input").on("change", function() {
       reset_brush(this.checked ? "log" : "linear", plot.IsLog[1] ? "log" : "linear");
     });
-    plot.description.append("span").html("log scale on x axis");
-    plot.description.append("br");
+    log_check_box.append("br");
 
-    plot.description.append("input").attr("type", "checkbox").on("change", function() {
+    var check_box_y_label = log_check_box.append("label").attr("id", "y_log_check");
+    check_box_y_label.html('<input type="checkbox"> log scale on y axis');
+    $("#y_log_check input").on("change", function() {
       reset_brush(plot.IsLog[0] ? "log" : "linear", this.checked ? "log" : "linear");
     });
-    plot.description.append("span").html("log scale on y axis");
 
     plot.description.append("br");
     var control_plot = plot.description.append("div").style("margin-top", "10px");

--- a/app/assets/javascripts/plot/line_plot.js
+++ b/app/assets/javascripts/plot/line_plot.js
@@ -330,14 +330,16 @@ LinePlot.prototype.AddDescription = function() {
     var log_check_box = plot.description.append("div").attr("class", "checkbox");
     var check_box_x_label = log_check_box.append("label").attr("id", "x_log_check");
     check_box_x_label.html('<input type="checkbox"> log scale on x axis');
-    $("#x_log_check input").on("change", function() {
+    //d3.select gets the first element. This selection is available only when new svg will appear at the above of the old svg.
+    d3.select('label#x_log_check input').on("change", function() {
       reset_brush(this.checked ? "log" : "linear", plot.IsLog[1] ? "log" : "linear");
     });
     log_check_box.append("br");
 
     var check_box_y_label = log_check_box.append("label").attr("id", "y_log_check");
     check_box_y_label.html('<input type="checkbox"> log scale on y axis');
-    $("#y_log_check input").on("change", function() {
+    //d3.select gets the first element. This selection is available only when new svg will appear at the above of the old svg.
+    d3.select('label#y_log_check input').on("change", function() {
       reset_brush(plot.IsLog[0] ? "log" : "linear", this.checked ? "log" : "linear");
     });
 

--- a/app/assets/javascripts/plot/scatter_plot.js
+++ b/app/assets/javascripts/plot/scatter_plot.js
@@ -334,16 +334,21 @@ ScatterPlot.prototype.AddDescription = function() {
       });
     plot.description.append("div").style("margin-bottom", "20px");
 
-    plot.description.append("input").attr("type", "checkbox").on("change", function() {
+    var log_check_box = plot.description.append("div").attr("class", "checkbox");
+    var check_box_x_label = log_check_box.append("label").attr("id", "x_log_check");
+    check_box_x_label.html('<input type="checkbox"> log scale on x axis');
+    //d3.select gets the first element. This selection is available only when new svg will appear at the above of the old svg.
+    d3.select('label#x_log_check input').on("change", function() {
       reset_brush(this.checked ? "log" : "linear", plot.IsLog[1] ? "log" : "linear");
     });
-    plot.description.append("span").html("log scale on x axis");
-    plot.description.append("br");
+    log_check_box.append("br");
 
-    plot.description.append("input").attr("type", "checkbox").on("change", function() {
+    var check_box_y_label = log_check_box.append("label").attr("id", "y_log_check");
+    check_box_y_label.html('<input type="checkbox"> log scale on y axis');
+    //d3.select gets the first element. This selection is available only when new svg will appear at the above of the old svg.
+    d3.select('label#y_log_check input').on("change", function() {
       reset_brush(plot.IsLog[0] ? "log" : "linear", this.checked ? "log" : "linear");
     });
-    plot.description.append("span").html("log scale on y axis");
 
     plot.description.append("br");
     var control_plot = plot.description.append("div").style("margin-top", "10px");

--- a/app/assets/javascripts/simulator.js
+++ b/app/assets/javascripts/simulator.js
@@ -201,7 +201,7 @@ function draw_progress_overview(url) {
         stroke: "black",
         "stroke-width": 1
       });
-    
+
     var rectRegion = inner_svg.append("g");
 
     var row = rectRegion.selectAll("g")
@@ -323,7 +323,10 @@ function draw_progress_overview(url) {
       })
       .text(function(d) { return d; });
   })
-  .on("error", function() { loading.remove(); })
+  .on("error", function(error) {
+    console.warn(error);
+    loading.remove();
+  })
   .get();
 
   loading.on("mousedown", function() {

--- a/app/views/hosts/_form.html.haml
+++ b/app/views/hosts/_form.html.haml
@@ -91,7 +91,7 @@
   .form-group
     .col-md-4.col-md-offset-2
       = f.submit('Save', class: 'btn btn-primary')
-      = link_to('Cancel', (@host.persisted? ? @host : hosts_path), class: 'btn')
+      = link_to('Cancel', (@host.persisted? ? @host : hosts_path), class: 'btn btn-default')
       %a{class: 'btn btn-warning', id: 'load_default_template', data: JobScriptUtil::DEFAULT_TEMPLATE} Load default template
 
 :javascript

--- a/app/views/simulators/_progress.html.haml
+++ b/app/views/simulators/_progress.html.haml
@@ -57,7 +57,7 @@
               = select_tag 'row_parameter', options_for_select(parameter_keys, selected: parameter_keys[1]), id: 'row_parameter', class: 'form-control'
           .form-group
             .col-md-9.col-md-offset-3
-              = submit_tag 'Show', name: 'show_progress_button', class: 'btn btn-primary', id: 'show_progress_button'
+              %a.btn.btn-primary#show_progress_button Show
 :javascript
   var url = "#{_progress_simulator_path}" + ".json";
   $('#show_progress_button').on('click', function () {


### PR DESCRIPTION
## update_bootstrap3 の未対応項目
- [x]  iconの幅指定を em でする
  - 展開の機能をmodal で実装時にするときにicon をAwesome iconに変更する
  - fa iiconの幅指定は em ではなく class .fa-1g .fa-x2 のように指定する
  - 参考:http://fortawesome.github.io/Font-Awesome/examples/
- [x] cancelのボタンに btn-default クラスをつける
- [x] progressを表示しようとするとsimulator#showのページが再描画されてしまう
- [x] plotの右側のlogscaleのon/offのcheckboxをbootstrap流に直す
- [x] class: 'btn' にbtn btn-defaultをつける
  - RunのformのPreviewは.btnだが，xsubへの移行で消えるのでそのままにする

## 追加修正した項目