### PR TITLE
Fix position of tooltip

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -33,6 +33,19 @@
 .progress-tooltip {
   z-index: 10;
 }
+.plot-tooltip {
+  opacity: 0;
+  position: absolute;
+  text-align: center;
+  padding: 2px;
+  font: 12px sans-serif;
+  background: black;
+  color: white;
+  border: 0px;
+  border-radius: 8px;
+  pointer-events: none;
+  z-index: 10;
+}
 i.padding-8 {
   padding-top: 8px;
   padding-bottom: 8px;

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -30,6 +30,9 @@
 .progress {
   margin-bottom: 0;
 }
+.progress-tooltip {
+  z-index: 10;
+}
 i.padding-8 {
   padding-top: 8px;
   padding-bottom: 8px;

--- a/app/views/parameter_sets/_plot.html.haml
+++ b/app/views/parameter_sets/_plot.html.haml
@@ -54,21 +54,6 @@
 #plot
   #plot-tooltip.plot-tooltip
 
-:css
-  div.plot-tooltip {
-    opacity: 0;
-    position: absolute;
-    text-align: center;
-    padding: 2px;
-    font: 12px sans-serif;
-    background: black;
-    color: white;
-    border: 0px;
-    border-radius: 8px;
-    pointer-events: none;
-    z-index: 10;
-  }
-
 :javascript
   function show_form_for_plots() {
     if( $('#plot-type').val() == 'line' ) {

--- a/app/views/parameter_sets/_plot.html.haml
+++ b/app/views/parameter_sets/_plot.html.haml
@@ -180,7 +180,14 @@
     add_figure_viewer(x, y, result, irrelevants);
   });
 
+  function add_tooltip() {
+    // in order to avoid 'position: relative' style of '.col-lg-12' tag, we put 'tooltip' before '.col-lg-12' tag
+    // See http://stackoverflow.com/questions/8828387
+    $('#plot-tooltip').insertBefore('.col-lg-12');
+  }
+
   $(function() {  // parse plot parameters from URL
+    add_tooltip();
     function get_query_param() {
       console.log('hoge');
       if( 1 < document.location.search.length ) {

--- a/app/views/simulators/_progress.html.haml
+++ b/app/views/simulators/_progress.html.haml
@@ -65,4 +65,9 @@
     var rp = $('#row_parameter option:selected').val();
     var url_with_param = url + "?row_parameter=" + rp + "&column_parameter=" + cp;
     draw_progress_overview(url_with_param);
-  })
+  });
+  $(function() {
+      // in order to avoid 'position: relative' style of '.col-lg-12' tag, we put 'tooltip' before '.col-lg-12' tag
+    // See http://stackoverflow.com/questions/8828387
+    $('#progress-tooltip').insertBefore('.col-lg-12');
+  });


### PR DESCRIPTION
plotとprogressのtooltipの位置がずれていた。bootstrap3への更新の影響。
col-lg-12クラスに `position: relative;` が指定されている。そのため、それらの子要素の位置をマウスの位置を使ってtopやleftで指定しようとするとずれる。
回避するためには、tooltipのタグを col-lg-12 の外側に持っていく必要がある。jsでtooltipのタグの位置を変更するように変更した。
