### PR TITLE
allow access from external hosts on rails 4.2

### DIFF
--- a/lib/tasks/daemon.rake
+++ b/lib/tasks/daemon.rake
@@ -11,7 +11,7 @@ namespace :daemon do
       if is_server_running?
         $stderr.puts "server is already running: #{SERVER_PID}"
       else
-        cmd = "bundle exec rails s -d"
+        cmd = "bundle exec rails s -d -b 0.0.0.0"
         puts cmd
         system(cmd)
       end


### PR DESCRIPTION
# Rails 4.2 allows access only from localhost by default
- See http://edgeguides.rubyonrails.org/4_2_release_notes.html#default-host-for-rails-server