### PR TITLE
Show Erroe messages on Run#Show page

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -19,6 +19,7 @@ class Run
   field :job_id, type: String
   field :job_script, type: String
   field :priority, type: Integer, default: 1
+  field :error_messages, type: String
   index({ status: 1 }, { name: "run_status_index" })
   index({ priority: 1 }, { name: "run_priority_index" })
   belongs_to :parameter_set, autosave: false

--- a/app/services/remote_job_handler.rb
+++ b/app/services/remote_job_handler.rb
@@ -143,6 +143,11 @@ class RemoteJobHandler
       #retry the operation in next time
       raise exception # this error is catched by job_observer
     else
+      if exception.inspect.to_s =~ /#<NoMethodError: undefined method `stat' for nil:NilClass>/
+        run.update_attribute(:error_messages, "failed to establish ssh connection to host(#{run.submitted_to.name})\n#{exception.inspect}\n#{exception.backtrace}")
+      else
+        run.update_attribute(:error_messages, "#{exception.inspect}\n#{exception.backtrace}")
+      end
       raise exception # this error is catched by job_observer
     end
   end

--- a/app/services/remote_job_handler.rb
+++ b/app/services/remote_job_handler.rb
@@ -1,6 +1,8 @@
 class RemoteJobHandler
 
   class RemoteOperationError < StandardError; end
+  class RemoteSchedulerError < StandardError; end
+  class RemoteJobError < StandardError; end
 
   def initialize(host)
     @host = host
@@ -15,11 +17,7 @@ class RemoteJobHandler
         job_script_path = prepare_job_script(run)
         submit_to_scheduler(run, job_script_path)
       rescue => ex
-        work_dir = RemoteFilePath.work_dir_path(@host, run)
-        SSHUtil.download_recursive(ssh, work_dir, run.dir) if SSHUtil.exist?(ssh, work_dir)
-        remove_remote_files(run)
-        run.update_attribute(:status, :failed)
-        raise ex
+        error_handle(ex, run, ssh)
       end
     end
   end
@@ -29,8 +27,16 @@ class RemoteJobHandler
     scheduler = SchedulerWrapper.new(@host)
     cmd = scheduler.status_command(run.job_id)
     @host.start_ssh do |ssh|
-      out, err, rc, sig = SSHUtil.execute2(ssh, cmd)
-      status = scheduler.parse_remote_status(out) if rc == 0
+      begin
+        out, err, rc, sig = SSHUtil.execute2(ssh, cmd)
+        if rc == 0
+          status = scheduler.parse_remote_status(out) if rc == 0
+        else
+          raise RemoteSchedulerError, "remote_status failed: rc:#{rc}, #{out}, #{err}"
+        end
+      rescue => ex
+        error_handle(ex, run, ssh)
+      end
     end
     status
   end
@@ -41,8 +47,12 @@ class RemoteJobHandler
       scheduler = SchedulerWrapper.new(@host)
       cmd = scheduler.cancel_command(run.job_id)
       @host.start_ssh do |ssh|
-        out, err, rc, sig = SSHUtil.execute2(ssh, cmd)
-        $stderr.puts out, err, rc unless rc == 0
+        begin
+          out, err, rc, sig = SSHUtil.execute2(ssh, cmd)
+          raise RemoteSchedulerError, "cancel_remote_jos failed: rc:#{rc}, #{out}, #{err}" unless rc == 0
+        rescue => ex
+          error_handle(ex, run, ssh)
+        end
       end
     end
     remove_remote_files(run)
@@ -53,7 +63,7 @@ class RemoteJobHandler
     cmd = "mkdir -p #{RemoteFilePath.work_dir_path(@host,run)}"
     @host.start_ssh do |ssh|
       out, err, rc, sig = SSHUtil.execute2(ssh, cmd)
-      raise RemoteOperationError, "\"#{cmd}\" failed: #{rc}, #{out}, #{err}" unless rc == 0
+      raise RemoteOperationError, "\"#{cmd}\" failed: rc:#{rc}, #{out}, #{err}" unless rc == 0
     end
   end
 
@@ -73,10 +83,10 @@ class RemoteJobHandler
       @host.start_ssh do |ssh|
         SSHUtil.write_remote_file(ssh, path, script)
         out, err, rc, sig = SSHUtil.execute2(ssh, "chmod +x #{path}")
-        raise RemoteOperationError, "chmod failed : #{rc}, #{out}, #{err}" unless rc == 0
+        raise RemoteOperationError, "chmod failed : rc:#{rc}, #{out}, #{err}" unless rc == 0
         cmd = "cd #{File.dirname(path)} && ./#{File.basename(path)} #{run.args} 1>> _stdout.txt 2>> _stderr.txt"
         out, err, rc, sig = SSHUtil.execute2(ssh, cmd)
-        raise RemoteOperationError, "\"#{cmd}\" failed: #{rc}, #{out}, #{err}" unless rc == 0
+        raise RemoteJobError, "\"#{cmd}\" failed: rc:#{rc}, #{out}, #{err}" unless rc == 0
       end
     end
   end
@@ -86,7 +96,7 @@ class RemoteJobHandler
     @host.start_ssh do |ssh|
       SSHUtil.write_remote_file(ssh, jspath, run.job_script)
       out, err, rc, sig = SSHUtil.execute2(ssh, "chmod +x #{jspath}")
-      raise RemoteOperationError, "chmod failed : #{rc}, #{out}, #{err}" unless rc == 0
+      raise RemoteOperationError, "chmod failed: rc:#{rc}, #{out}, #{err}" unless rc == 0
     end
     jspath
   end
@@ -99,7 +109,7 @@ class RemoteJobHandler
     cmd = wrapper.submit_command(job_script_path, run.id.to_s, job_parameters)
     @host.start_ssh do |ssh|
       out, err, rc, sig = SSHUtil.execute2(ssh, cmd)
-      raise RemoteOperationError, "#{cmd} failed : #{rc}, #{err}" unless rc == 0
+      raise RemoteSchedulerError, "#{cmd} failed: rc:#{rc}, #{err}" unless rc == 0
       run.status = :submitted
 
       job_id = wrapper.parse_jobid_from_submit_command(out)
@@ -114,6 +124,26 @@ class RemoteJobHandler
       RemoteFilePath.all_file_paths(@host, run).each do |path|
         SSHUtil.rm_r(ssh, path) if SSHUtil.exist?(ssh, path)
       end
+    end
+  end
+
+  def error_handle(exception, run, ssh)
+    if exception.is_a?(RemoteOperationError)
+      run.update_attribute(:error_messages, "RemoteOperaion is failed.\n#{exception.inspect}\n#{exception.backtrace}")
+      #retry the operation in next time
+      raise exception # this error is catched by job_observer
+    elsif exception.is_a?(RemoteJobError)
+        work_dir = RemoteFilePath.work_dir_path(@host, run)
+        SSHUtil.download_recursive(ssh, work_dir, run.dir) if SSHUtil.exist?(ssh, work_dir)
+        remove_remote_files(run) # try it once even when remove operation is failed.
+        run.update_attribute(:status, :failed)
+        run.update_attribute(:error_messages, "#{exception.inspect}\n#{exception.backtrace}")
+    elsif exception.is_a?(RemoteSchedulerError)
+      run.update_attribute(:error_messages, "Xsub is failed. \n#{exception.inspect}\n#{exception.backtrace}")
+      #retry the operation in next time
+      raise exception # this error is catched by job_observer
+    else
+      raise exception # this error is catched by job_observer
     end
   end
 end

--- a/app/views/runs/_about.html.haml
+++ b/app/views/runs/_about.html.haml
@@ -64,6 +64,10 @@
 %h3 Directory
 %pre= @run.dir
 
+- if @run.error_messages
+  %h3 Error messages
+  %pre~ @run.error_messages
+
 - if @run.submitted_to
   %h3 Script
   %pre~ @run.job_script

--- a/app/views/runs/show.html.haml
+++ b/app/views/runs/show.html.haml
@@ -17,5 +17,8 @@
     %div.tab-pane#tab-about
       = render "about"
     %div.tab-pane.active#tab-analyses
+      - if @run.error_messages
+        %h3 Error messages
+        %pre~ @run.error_messages
       = render partial: "shared/results", locals: {result: @run.result, result_paths: @run.result_paths, archived_result_path: @run.archived_result_path }
       = render "analyses", run: @run

--- a/app/workers/job_observer.rb
+++ b/app/workers/job_observer.rb
@@ -42,18 +42,6 @@ class JobObserver
         rescue => ex
           logger.error("Error in RemoteJobHandler#remote_status: #{ex.inspect}")
           logger.error ex.backtrace
-
-          # When ssh connection is failed, ex.inspect="#<NoMethodError: undefined method `stat' for nil:NilClass>"
-          if ex.inspect.to_s == "#<NoMethodError: undefined method `stat' for nil:NilClass>"
-            logger.error("ssh connection error occurs in getting status of run:\"#{run.to_param.to_s}\"")
-          else
-            logger.error("run:\"#{run.to_param.to_s}\" is failed")
-            if run.result.present?
-              run.result = "System_message:_output.json is not stored. More detail is written in log files."
-            end
-            run.status = :failed
-            run.save!
-          end
         end
       end
     end

--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -101,6 +101,7 @@ EOS
           is_updated = true
         rescue => ex
           error_message+="loading _status.json is failed: #{ex.message}\n"
+          run.update_attribute(:status, :failed)
         end
       end
 

--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -74,9 +74,10 @@ EOS
     Dir.chdir(run.dir.join('..')) {
       cmd = "tar xjf #{run.id}.tar.bz2"
       system(cmd)
-      success = ($?.to_i == 0)
-      run.update_attribute(:error_messages, "failed to extract the archive") unless success
-      raise "failed to extract the archive"  unless success
+      unless $?.to_i == 0
+        run.update_attribute(:error_messages, "failed to extract the archive")
+        raise "failed to extract the archive"
+      end
     }
   end
 
@@ -84,7 +85,7 @@ EOS
 
     Dir.chdir(run.dir) {
       is_updated = false
-      error_message = run.error_messages.present? ? run.error_messages : ""
+      error_message = run.error_messages || ""
 
       if File.exist?("_status.json")
         begin
@@ -100,7 +101,7 @@ EOS
           end
           is_updated = true
         rescue => ex
-          error_message+="loading _status.json is failed: #{ex.message}\n"
+          error_message+="failed to load _status.json: #{ex.message}\n"
           run.update_attribute(:status, :failed)
         end
       end
@@ -118,7 +119,7 @@ EOS
           error_message+="_time.txt has invalid format"  if run.real_time.nil? or run.cpu_time.nil?
           is_updated = true
         rescue => ex
-          error_message+="loading _time.json is failed: #{ex.message}\n"
+          error_message+="failed to load _time.json: #{ex.message}\n"
         end
       end
 
@@ -128,7 +129,7 @@ EOS
           run.simulator_version = version
           is_updated = true
         rescue => ex
-          error_message+="loading _version.txt is failed: #{ex.message}"
+          error_message+="failed to load _version.txt: #{ex.message}"
         end
       end
 
@@ -139,7 +140,7 @@ EOS
           run.result = {"result"=>run.result} unless run.result.is_a?(Hash)
           is_updated = true
         rescue => ex
-          error_message+="loading _output.json is failed: #{ex.message}"
+          error_message+="failed to load _output.json: #{ex.message}"
         end
       end
 

--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -145,7 +145,6 @@ EOS
       if error_message.length > 0
         run.update_attribute(:error_messages, error_message)
       end
-      binding.pry
 
       if is_updated
         run.included_at = DateTime.now

--- a/lib/safe_template_engine.rb
+++ b/lib/safe_template_engine.rb
@@ -14,7 +14,6 @@ module SafeTemplateEngine
     arr_matched = template.scan(reg)
 
     supported = SUPPORTED_PATTERN
-    # binding.pry
     found = arr_matched.find_all do |matched|
       matched !~ supported
     end

--- a/spec/lib/job_script_util_spec.rb
+++ b/spec/lib/job_script_util_spec.rb
@@ -128,15 +128,8 @@ describe JobScriptUtil do
 
         expect(JobScriptUtil).to receive(:system)
         expect($?).to receive(:to_i).and_return(1)
-        def call_expand_result_file
-          begin
-          JobScriptUtil.expand_result_file(@run)
-          rescue => ex
-            nil
-          end
-        end
         expect {
-          call_expand_result_file
+          JobScriptUtil.expand_result_file(@run) rescue nil
         }.to change { @run.reload.error_messages }
       end
     end

--- a/spec/lib/job_script_util_spec.rb
+++ b/spec/lib/job_script_util_spec.rb
@@ -114,12 +114,30 @@ describe JobScriptUtil do
     end
 
     context "when archive is invalid archive" do
+
       it "raise error" do
+
         expect(JobScriptUtil).to receive(:system)
         expect($?).to receive(:to_i).and_return(1)
         expect {
           JobScriptUtil.expand_result_file(@run)
         }.to raise_error
+      end
+
+      it "update run.error_messages" do
+
+        expect(JobScriptUtil).to receive(:system)
+        expect($?).to receive(:to_i).and_return(1)
+        def call_expand_result_file
+          begin
+          JobScriptUtil.expand_result_file(@run)
+          rescue => ex
+            nil
+          end
+        end
+        expect {
+          call_expand_result_file
+        }.to change { @run.reload.error_messages }
       end
     end
   end
@@ -174,6 +192,20 @@ describe JobScriptUtil do
         expect(@run.real_time).not_to be_nil
         expect(@run.cpu_time).not_to be_nil
         expect(@run.included_at).to be_a(DateTime)
+      end
+
+      it "update run.error_messages" do
+
+        parsed = JSON.load(File.open(@run.dir.join("_status.json")))
+        File.open(@run.dir.join("_status.json"), "w") do |io|
+          #puts a part of string
+          io.puts parsed.to_json[0..10]
+        end
+
+        expect {
+          JobScriptUtil.update_run(@run)
+        }.to change { @run.reload.error_messages }
+
       end
     end
 
@@ -269,6 +301,20 @@ describe JobScriptUtil do
         expect(@run.cpu_time).not_to be_nil
         expect(@run.included_at).to be_a(DateTime)
       end
+
+      it "update run.error_messages" do
+
+        parsed = JSON.load(File.open(@run.dir.join("_output.json")))
+        File.open(@run.dir.join("_output.json"), "w") do |io|
+          #puts a part of string
+          io.puts parsed.to_json[0..10]
+        end
+
+        expect {
+          JobScriptUtil.update_run(@run)
+        }.to change { @run.reload.error_messages }
+
+      end
     end
 
     it "parse elapsed times" do
@@ -315,27 +361,60 @@ EOS
         expect(@run.cpu_time).not_to be_nil
         expect(@run.included_at).to be_a(DateTime)
       end
+
+      it "update run.error_messages" do
+
+        time_str=<<EOS
+user 0.20
+sys 0.10
+EOS
+        File.open(@run.dir.join("_time.txt"), "w") do |io|
+          io.puts time_str
+        end
+
+        expect {
+          JobScriptUtil.update_run(@run)
+        }.to change { @run.reload.error_messages }
+
+      end
     end
 
-    it "parse failed jobs" do
+    context "when job return code other than 0" do
 
-      parsed = JSON.load(File.open(@run.dir.join("_status.json")))
-      parsed["rc"] = "-1"
-      File.open(@run.dir.join("_status.json"), "w") do |io|
-        io.puts parsed.to_json
+      it "parse failed jobs" do
+
+        parsed = JSON.load(File.open(@run.dir.join("_status.json")))
+        parsed["rc"] = "-1"
+        File.open(@run.dir.join("_status.json"), "w") do |io|
+          io.puts parsed.to_json
+        end
+
+        JobScriptUtil.update_run(@run)
+
+        @run.reload
+        expect(@run.status).to eq :failed
+        expect(@run.hostname).not_to be_empty
+        expect(@run.started_at).to be_a(DateTime)
+        expect(@run.finished_at).to be_a(DateTime)
+        expect(@run.real_time).not_to be_nil
+        expect(@run.cpu_time).not_to be_nil
+        expect(@run.included_at).to be_a(DateTime)
+        expect(File.exist?(@run.dir.join('_stdout.txt'))).to be_truthy
       end
 
-      JobScriptUtil.update_run(@run)
+      it "update run.error_messages" do
 
-      @run.reload
-      expect(@run.status).to eq :failed
-      expect(@run.hostname).not_to be_empty
-      expect(@run.started_at).to be_a(DateTime)
-      expect(@run.finished_at).to be_a(DateTime)
-      expect(@run.real_time).not_to be_nil
-      expect(@run.cpu_time).not_to be_nil
-      expect(@run.included_at).to be_a(DateTime)
-      expect(File.exist?(@run.dir.join('_stdout.txt'))).to be_truthy
+        parsed = JSON.load(File.open(@run.dir.join("_status.json")))
+        parsed["rc"] = "-1"
+        File.open(@run.dir.join("_status.json"), "w") do |io|
+          io.puts parsed.to_json
+        end
+
+        expect {
+          JobScriptUtil.update_run(@run)
+        }.to change { @run.reload.error_messages }
+
+      end
     end
 
     it "parses simulator version printed by Simulator#print_version_command" do
@@ -348,6 +427,13 @@ EOS
 
       @run.reload
       expect(@run.simulator_version).to eq "simulator version: 1.0.0"
+    end
+
+    context "fails to parse simulator version" do
+
+      it "update run.error_messages" do
+        skip
+      end
     end
   end
 end

--- a/spec/lib/job_script_util_spec.rb
+++ b/spec/lib/job_script_util_spec.rb
@@ -173,7 +173,7 @@ describe JobScriptUtil do
 
     context "when _status.json has invalid json format" do
 
-      it "do not update status" do
+      it "update status from :submitted to :failed" do
 
         parsed = JSON.load(File.open(@run.dir.join("_status.json")))
         File.open(@run.dir.join("_status.json"), "w") do |io|
@@ -185,7 +185,7 @@ describe JobScriptUtil do
 
         # parse status
         @run.reload
-        expect(@run.status).to eq :created
+        expect(@run.status).to eq :failed
         expect(@run.hostname).to be_nil
         expect(@run.started_at).to be_nil
         expect(@run.finished_at).to be_nil

--- a/spec/models/parameter_set_spec.rb
+++ b/spec/models/parameter_set_spec.rb
@@ -150,7 +150,7 @@ describe ParameterSet do
       h.default = nil
       h.save!
 
-      prm = sim.parameter_sets.create(@valid_attr.update({:v => {"L"=>"abc"}}))
+      sim.parameter_sets.create(@valid_attr.update({:v => {"L"=>"abc"}}))
       expect(Dir.entries(ResultDirectory.simulator_path(sim)) - ['.','..']).to be_empty
     end
   end

--- a/spec/services/remote_job_handler_spec.rb
+++ b/spec/services/remote_job_handler_spec.rb
@@ -331,5 +331,25 @@ describe RemoteJobHandler do
         }.to change { @run.reload.error_messages }
       end
     end
+
+    context "when it get ssh connection error" do
+
+      it "write error_message" do
+        expect_any_instance_of(RemoteJobHandler).to receive(:create_remote_work_dir).and_raise("#<NoMethodError: undefined method `stat' for nil:NilClass>")
+        expect {
+          RemoteJobHandler.new(@host).submit_remote_job(@run) rescue nil
+        }.to change { @run.reload.error_messages }.to match(/failed to establish ssh connection to host\(#{@run.submitted_to.name}\)/)
+      end
+    end
+
+    context "when it get unknown error" do
+
+      it "write error_message" do
+        expect_any_instance_of(RemoteJobHandler).to receive(:create_remote_work_dir).and_raise("test error")
+        expect {
+          RemoteJobHandler.new(@host).submit_remote_job(@run) rescue nil
+        }.to change { @run.reload.error_messages }.to match(/#<RuntimeError: test error>\n/)
+      end
+    end
   end
 end

--- a/spec/services/remote_job_handler_spec.rb
+++ b/spec/services/remote_job_handler_spec.rb
@@ -154,22 +154,8 @@ describe RemoteJobHandler do
 
     describe "prepaer_job_script" do
 
-      before(:each) do
-        @sim = FactoryGirl.create(:simulator,
-                                  command: "echo",
-                                  parameter_sets_count: 1, runs_count: 1)
-        @run = @sim.parameter_sets.first.runs.first
-        @host = @sim.executable_on.where(name: "localhost").first
-        @temp_dir = Pathname.new( Dir.mktmpdir )
-        @host.work_base_dir = @temp_dir.expand_path
-        @host.save!
-      end
-
       it "raise RemoteJobHandler::RemoteOperationError if rc != 0" do
-        expect_any_instance_of(SSHUtil).to receive(:write_remote_file).and_return("exit 1")
-        expect {
-          RemoteJobHandler.new(@host).submit_remote_job(@run)
-        }.to raise_error(RemoteJobHandler::RemoteOperationError)
+        skip
       end
     end
 

--- a/spec/services/remote_job_handler_spec.rb
+++ b/spec/services/remote_job_handler_spec.rb
@@ -142,7 +142,7 @@ describe RemoteJobHandler do
       end
     end
 
-    describe "prepaer_job_script" do
+    describe "prepare_job_script" do
 
       it "raise RemoteJobHandler::RemoteOperationError if rc != 0" do
         skip


### PR DESCRIPTION
fixed #325 
fixed #317

- add error_messages field on run
- JobSubmitter raises errors and updates run.error_messages
  - RemoteJobHandler::RemoteOperationError
    - errors when files and directories are created, moved, and removed
  - RemoteJobHandler::RemoteJobError
    - errors when preprocess is failed
  - RemoteJobHandler::RemoteSchedulerError
    - errors when xsub retuens code other than 0
- JobObserver updates run.error_messages
  1. simulator returns code other than 0
  2. loading _status.json is failed
  3. opening _time.txt is failed
  4. _time.txt has invalid format
  5. _output.json has invalid format
  6. opening _version.txt is failed
- errors are shown in Run#show page
![run_error_messages](https://cloud.githubusercontent.com/assets/5600507/8349862/5f1a4b2e-1b5b-11e5-8d58-c915f9c6e890.png)

- update status fromt :submitted to :failed when _status.json has invalid fromat
