### PR TITLE
Add timestamp on log messages

### DIFF
--- a/app/workers/analyzer_worker.rb
+++ b/app/workers/analyzer_worker.rb
@@ -8,6 +8,7 @@ class AnalyzerWorker < DaemonSpawn::Base
 
   def start(args)
     @logger = Logger.new(WORKER_LOG_FILE, 7)
+    @logger.formatter = LoggerFormatWithTime.new
     @logger.level = Logger::INFO
     @logger.info("starting")
 

--- a/app/workers/job_worker.rb
+++ b/app/workers/job_worker.rb
@@ -8,6 +8,7 @@ class JobWorker < DaemonSpawn::Base
 
   def start(args)
     @logger = Logger.new(WORKER_LOG_FILE, 7)
+    @logger.formatter = LoggerFormatWithTime.new
     @logger.level = Logger::INFO
     @logger.info("starting")
 

--- a/app/workers/service_worker.rb
+++ b/app/workers/service_worker.rb
@@ -8,6 +8,7 @@ class ServiceWorker < DaemonSpawn::Base
 
   def start(args)
     @logger = Logger.new(WORKER_LOG_FILE, 7)
+    @logger.formatter = LoggerFormatWithTime.new
     @logger.level = Logger::INFO
     @logger.info("starting")
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,9 +48,19 @@ AcmProto::Application.configure do
 
   config.eager_load = false
 
+  class LoggerFormatWithTime
+    def call(severity, timestamp, progname, msg)
+      format = "[%s] %5s -- %s: %s\n"
+      format % ["#{timestamp.strftime("%Y/%m/%d %H:%M:%S")}.#{'%06d' % timestamp.usec.to_s}", severity, progname, String === msg ? msg : msg.inspect]
+    end
+  end
+
   config.log_level = :error
   FileUtils.mkdir_p( Rails.root.join("log") )
   config.logger = Logger.new(Rails.root.join("log/development.log"), 5, 1.megabytes)
+  config.logger.formatter = LoggerFormatWithTime.new
   Mongoid.logger.level = Logger::WARN
+  Mongoid.logger.formatter = LoggerFormatWithTime.new
   Moped.logger.level = Logger::WARN
+  Moped.logger.formatter = LoggerFormatWithTime.new
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,8 +81,18 @@ AcmProto::Application.configure do
 
   config.eager_load = true
 
+  class LoggerFormatWithTime
+    def call(severity, timestamp, progname, msg)
+      format = "[%s] %5s -- %s: %s\n"
+      format % ["#{timestamp.strftime("%Y/%m/%d %H:%M:%S")}.#{'%06d' % timestamp.usec.to_s}", severity, progname, String === msg ? msg : msg.inspect]
+    end
+  end
+
   FileUtils.mkdir_p( Rails.root.join("log") )
-  config.logger = Logger.new(Rails.root.join("log/development.log"), 5, 1.megabytes)
+  config.logger = Logger.new(Rails.root.join("log/production.log"), 5, 1.megabytes)
+  config.logger.formatter = LoggerFormatWithTime.new
   Mongoid.logger.level = Logger::WARN
+  Mongoid.logger.formatter = LoggerFormatWithTime.new
   Moped.logger.level = Logger::WARN
+  Moped.logger.formatter = LoggerFormatWithTime.new
 end


### PR DESCRIPTION
fixed #296

- Add time stamp for log files
- change the name of log file from log/development.log to log/production.log