### PR TITLE
take shorter time to create many ps

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -32,7 +32,7 @@ class Run
   # validations
   validates :status, presence: true,
                      inclusion: {in: [:created,:submitted,:running,:failed,:finished, :cancelled]}
-  validates :seed, presence: true, uniqueness: {scope: :parameter_set_id}
+  validates :seed, presence: true
   validates :mpi_procs, numericality: {greater_than_or_equal_to: 1, only_integer: true}
   validates :omp_threads, numericality: {greater_than_or_equal_to: 1, only_integer: true}
   validates :priority, presence: true,
@@ -156,18 +156,10 @@ class Run
     end
   end
 
-  SeedMax = 2 ** 31
-  SeedIterationLimit = 1024
   def set_unique_seed
     unless seed
-      SeedIterationLimit.times do |i|
-        candidate = rand(SeedMax)
-        if self.class.where(:parameter_set_id => parameter_set, :seed => candidate).exists? == false
-          self.seed = candidate
-          break
-        end
-      end
-      errors.add(:seed, "Failed to set unique seed") unless seed
+      counter_epoch = self.id.to_s[-6..-1] + self.id.to_s[0..7]
+      self.seed = counter_epoch.hex
     end
   end
 

--- a/lib/cli/oacis_cli_run.rb
+++ b/lib/cli/oacis_cli_run.rb
@@ -99,22 +99,18 @@ class OacisCli < Thor
       list_runs[ps_runs['_id']] = ps_runs['run_ids']
     end
     parameter_sets.map(&:id).each do |ps_id|
-      new_runs_count = num_runs
-      if list_runs[ps_id]
-        existing_run_ids = list_runs[ps_id]
-        new_runs_count -= existing_run_ids.count
-        if new_runs_count < 1
-          run_ids += existing_run_ids[0..(num_runs-1)]
-          progressbar.increment
-          next
-        end
+      if list_runs[ps_id] and list_runs[ps_id].size >= num_runs
+        run_ids += list_runs[ps_id][0..(num_runs-1)]
+        progressbar.increment
+        next
       end
-      run_ids += existing_run_ids || []
+      existing_run_ids = list_runs[ps_id] || []
+      run_ids += existing_run_ids
       ps = ParameterSet.find(ps_id)
       sim = ps.simulator
       mpi_procs = sim.support_mpi ? mpi_procs : 1
       omp_threads = sim.support_omp ? omp_threads : 1
-      new_runs_count.times do |i|
+      (num_runs - existing_run_ids.count).times do |i|
         run = ps.runs.build(submitted_to: submitted_to,
                             mpi_procs: mpi_procs,
                             omp_threads: omp_threads,

--- a/spec/controllers/runs_controller_spec.rb
+++ b/spec/controllers/runs_controller_spec.rb
@@ -80,10 +80,6 @@ describe RunsController do
           post 'create', @req_param, valid_session
         }.to raise_error
       end
-
-      it "fails with a duplicated seed" do
-        skip "it is no longer needed because seed is defined by unique bson object id."
-      end
     end
 
     describe "with no permitted params" do

--- a/spec/controllers/runs_controller_spec.rb
+++ b/spec/controllers/runs_controller_spec.rb
@@ -82,11 +82,7 @@ describe RunsController do
       end
 
       it "fails with a duplicated seed" do
-        seed_val = @par.runs.first.seed
-        @req_param[:run].update(seed: seed_val)
-        expect {
-          post 'create', @req_param, valid_session
-        }.to change(Run, :count).by(0)
+        skip "it is no longer needed because seed is defined by unique bson object id."
       end
     end
 

--- a/spec/lib/cli/oacis_cli_parameter_set_spec.rb
+++ b/spec/lib/cli/oacis_cli_parameter_set_spec.rb
@@ -35,7 +35,7 @@ describe OacisCli do
         OacisCli.new.invoke(:parameter_sets_template, [], option)
 
         parameters = Hash[ @sim.parameter_definitions.map {|pd| [pd.key, pd.default]} ]
-        loaded = expect(JSON.load(File.read('parameter_sets.json'))).to eq [parameters]
+        expect(JSON.load(File.read('parameter_sets.json'))).to eq [parameters]
       }
     end
 
@@ -330,11 +330,11 @@ describe OacisCli do
       end
 
       def invoke_create_parameter_sets_with_invalid_parameter_sets_json
-          create_simulator_id_json(@sim, 'simulator_id.json')
-          create_invalid_parameter_sets_json('parameter_sets.json')
-          option = {simulator: 'simulator_id.json', input: 'parameter_sets.json', output: "parameter_set_ids.json"}
-          OacisCli.new.invoke(:create_parameter_sets, [], option)
-        end
+        create_simulator_id_json(@sim, 'simulator_id.json')
+        create_invalid_parameter_sets_json('parameter_sets.json')
+        option = {simulator: 'simulator_id.json', input: 'parameter_sets.json', output: "parameter_set_ids.json"}
+        OacisCli.new.invoke(:create_parameter_sets, [], option)
+      end
 
       it "raises an exception" do
         at_temp_dir {

--- a/spec/lib/job_script_util_spec.rb
+++ b/spec/lib/job_script_util_spec.rb
@@ -425,7 +425,7 @@ EOS
     context "fails to parse simulator version" do
 
       it "update run.error_messages" do
-        skip
+        skip "not yet implemented"
       end
     end
   end

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -42,9 +42,7 @@ describe Run do
     end
 
     it "seed must be unique" do
-      seed_val = @param_set.runs.first.seed
-      @valid_attribute.update(seed: seed_val)
-      expect(@param_set.runs.build(@valid_attribute)).not_to be_valid
+      skip "it is no longer needed because seed is defined by unique bson object id."
     end
 
     it "status must be either :created, :submitted, :running, :failed, :finished, or :cancelled" do
@@ -220,12 +218,11 @@ describe Run do
     it "is not created when validation fails" do
       sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1)
       prm = sim.parameter_sets.first
-      seed_val = prm.runs.first.seed
-      @valid_attribute.update(seed: seed_val)
+      @valid_attribute.update(status: nil)
 
-      prev_count = Dir.entries(ResultDirectory.parameter_set_path(prm)).size
-      prm.runs.create(@valid_attribute)
-      prev_count = expect(Dir.entries(ResultDirectory.parameter_set_path(prm)).size).to eq(prev_count)
+      expect {
+        prm.runs.create(@valid_attribute)
+      }.not_to change {Dir.entries(ResultDirectory.parameter_set_path(prm)).size }
     end
 
     it "is removed when the item is destroyed" do

--- a/spec/services/remote_job_handler_spec.rb
+++ b/spec/services/remote_job_handler_spec.rb
@@ -145,7 +145,7 @@ describe RemoteJobHandler do
     describe "prepare_job_script" do
 
       it "raise RemoteJobHandler::RemoteOperationError if rc != 0" do
-        skip
+        skip "not yet implemented"
       end
     end
 


### PR DESCRIPTION
fixed #315

#  多数のps, runの作成時にcliのレスポンスが遅いのを解消
##  原因
-  パラメータのユニークネスのチェックを個々の値に対して実施
- runのシードのユニークネスのチュエックを実施
- 個々のpsに対してrun数のチェックを実施

## 解決方法
- パラメータのユニークネスのチュックをまとめて実施(aggregation pipeline)
- runのシードをBSON object idから算出
- run数のチェックをまとめて実施(aggregation pipeline)

## ベンチマーク
- create_parameter_sets
    - Create: 22パラメータのpsを65536通り作成するのに必要な時間
        real	4m0.166s
        user	3m20.304s
        sys	0m16.392s

  - Reference: 作成済みps65536通りのidを参照するのに必要な時間
        real	0m41.919s
        user	0m35.556s
        sys	0m3.240s

- create_runs
    - Create: 22パラメータのps65536通りに対しrunを1つづつ(計65536)作成するのに必要な時間
        real	21m37.199s
        user	17m51.875s
        sys	1m9.126s

    - Reference: 作成済みrunのidを参照するのに必要な時間
        real	0m30.203s
        user	0m27.237s
        sys	0m2.349s

## 参考( 旧仕様のベンチマーク)
- create_parameter_sets
    - Create: 22パラメータのpsを65536通り作成するのに必要な時間
        real	78m34.964s
        user	8m7.891s
        sys	0m42.329s

- create_runs
    - Create: 22パラメータのps65536通りに対しrunを1つづつ(計65536)作成するのに必要な時間
        real	148m38.743s
        user	49m24.340s
        sys	2m15.319s
