### PR TITLE
refactoring: shortened_id

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,7 +61,7 @@ module ApplicationHelper
 
   def shortened_id(id)
     str = id.to_s
-    str[3..6] + ".." + str[-3..-1]
+    str[4..7] + str[-6..-5]
   end
 
   def shortened_job_id(job_id)


### PR DESCRIPTION
fixed #346

- display shortend_id like '1ee906' (when id is '558d1ee9742d752f72063000')
    - epoch:558d1ee9, machine identifier:742d75, process id:2f72, counter: 063000
