### PR TITLE
fixed a bug that an invalid get request is sent to the server

### DIFF
--- a/app/views/runs/_analyses.html.haml
+++ b/app/views/runs/_analyses.html.haml
@@ -34,5 +34,7 @@
         });
       }
       $('#analysis_analyzer').change(show_analysis_parameter_form);
-      show_analysis_parameter_form();
+      if( $('#analysis_analyzer').length > 0 ) {
+        show_analysis_parameter_form();
+      }
     });


### PR DESCRIPTION
Runがfinishedになっていない時に、analysisのフォームを取得するためのリクエストがサーバーに送られ例外を発生させていた。普段使っているだけなら気づかない問題だが修正。