### PR TITLE
update omp/mpi fields by default values

### DIFF
--- a/app/views/runs/_fields.html.haml
+++ b/app/views/runs/_fields.html.haml
@@ -50,4 +50,5 @@
       }
       update_host_parameters();
     });
+    $('select#run_submitted_to').trigger('change');
   });


### PR DESCRIPTION
OpenMP/MPIのパラメータのデフォルト値がフィールドに適用されない場合があったので修正

![image](https://cloud.githubusercontent.com/assets/718731/8593992/958adfee-2645-11e5-9577-5807ffa807b6.png)
