### PR TITLE
Job error handling when host parameter is invalid

### DIFF
--- a/app/services/remote_job_handler.rb
+++ b/app/services/remote_job_handler.rb
@@ -133,14 +133,14 @@ class RemoteJobHandler
       #retry the operation in next time
       raise exception # this error is catched by job_observer
     elsif exception.is_a?(RemoteJobError)
-        work_dir = RemoteFilePath.work_dir_path(@host, run)
-        SSHUtil.download_recursive(ssh, work_dir, run.dir) if SSHUtil.exist?(ssh, work_dir)
-        remove_remote_files(run) # try it once even when remove operation is failed.
-        run.update_attribute(:status, :failed)
-        run.update_attribute(:error_messages, "#{exception.inspect}\n#{exception.backtrace}")
+      work_dir = RemoteFilePath.work_dir_path(@host, run)
+      SSHUtil.download_recursive(ssh, work_dir, run.dir) if SSHUtil.exist?(ssh, work_dir)
+      remove_remote_files(run) # try it once even when remove operation is failed.
+      run.update_attribute(:status, :failed)
+      run.update_attribute(:error_messages, "#{exception.inspect}\n#{exception.backtrace}")
     elsif exception.is_a?(RemoteSchedulerError)
       run.update_attribute(:error_messages, "Xsub is failed. \n#{exception.inspect}\n#{exception.backtrace}")
-      #retry the operation in next time
+      run.update_attribute(:status, :failed)
       raise exception # this error is catched by job_observer
     else
       if exception.inspect.to_s =~ /#<NoMethodError: undefined method `stat' for nil:NilClass>/

--- a/spec/services/remote_job_handler_spec.rb
+++ b/spec/services/remote_job_handler_spec.rb
@@ -305,6 +305,13 @@ describe RemoteJobHandler do
           RemoteJobHandler.new(@host).submit_remote_job(@run) rescue nil
         }.to change { @run.reload.error_messages }
       end
+
+      it "does not change run status" do
+        expect_any_instance_of(RemoteJobHandler).to receive(:create_remote_work_dir).and_raise(RemoteJobHandler::RemoteOperationError, "error")
+        expect {
+          RemoteJobHandler.new(@host).submit_remote_job(@run) rescue nil
+        }.not_to change { @run.reload.status }
+      end
     end
     context "when it get RemoteJobHandler::RemoteJobError" do
 
@@ -315,7 +322,7 @@ describe RemoteJobHandler do
         }.to change { @run.reload.error_messages }
       end
 
-      it "change run status to :failed" do
+      it "changes run status to :failed" do
         expect_any_instance_of(RemoteJobHandler).to receive(:create_remote_work_dir).and_raise(RemoteJobHandler::RemoteJobError)
         expect {
           RemoteJobHandler.new(@host).submit_remote_job(@run) rescue nil
@@ -330,6 +337,13 @@ describe RemoteJobHandler do
           RemoteJobHandler.new(@host).submit_remote_job(@run) rescue nil
         }.to change { @run.reload.error_messages }
       end
+
+      it "changes run status to :failed" do
+        expect_any_instance_of(RemoteJobHandler).to receive(:create_remote_work_dir).and_raise(RemoteJobHandler::RemoteSchedulerError, "error")
+        expect {
+          RemoteJobHandler.new(@host).submit_remote_job(@run) rescue nil
+        }.to change { @run.reload.status }.to(:failed)
+      end
     end
 
     context "when it get ssh connection error" do
@@ -339,6 +353,13 @@ describe RemoteJobHandler do
         expect {
           RemoteJobHandler.new(@host).submit_remote_job(@run) rescue nil
         }.to change { @run.reload.error_messages }.to match(/failed to establish ssh connection to host\(#{@run.submitted_to.name}\)/)
+      end
+
+      it "does not change run status" do
+        expect_any_instance_of(RemoteJobHandler).to receive(:create_remote_work_dir).and_raise("#<NoMethodError: undefined method `stat' for nil:NilClass>")
+        expect {
+          RemoteJobHandler.new(@host).submit_remote_job(@run) rescue nil
+        }.not_to change { @run.reload.status }
       end
     end
 


### PR DESCRIPTION
fixed #350

# Change specification
- run status is updated to :failed when xsub command returns non zero code