### PR TITLE
seed must be less than 2**31

### DIFF
--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -159,7 +159,7 @@ class Run
   def set_unique_seed
     unless seed
       counter_epoch = self.id.to_s[-6..-1] + self.id.to_s[0..7]
-      self.seed = counter_epoch.hex
+      self.seed = counter_epoch.hex % (2**31-1)
     end
   end
 

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -45,6 +45,11 @@ describe Run do
       skip "it is no longer needed because seed is defined by unique bson object id."
     end
 
+    it "seeds must be less than 2**31-1" do
+      run = @param_set.runs.build
+      expect( run.seed ).to be < 2**31
+    end
+
     it "status must be either :created, :submitted, :running, :failed, :finished, or :cancelled" do
       run = @param_set.runs.build(@valid_attribute)
       run.status = :unknown


### PR DESCRIPTION
Because the digit of random number is too long for practical applications, we set the upper limit of the random number seed to 2**31.
in order to take the randomness of upper bit into account, take mod of 2**31-1.