### PR TITLE
Do not remove work dir

### DIFF
--- a/app/services/remote_file_path.rb
+++ b/app/services/remote_file_path.rb
@@ -33,7 +33,8 @@ module RemoteFilePath
       result_file_path(host, run),
       Pathname.new(host.work_base_dir).join("#{run.id}_status.json"),
       Pathname.new(host.work_base_dir).join("#{run.id}_time.txt"),
-      Pathname.new(host.work_base_dir).join("#{run.id}.tar")
+      Pathname.new(host.work_base_dir).join("#{run.id}.tmp.tar"),
+      Pathname.new(host.work_base_dir).join("#{run.id}.tmp.tar.bz2")
     ].flatten
   end
 end

--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -50,14 +50,13 @@ else {
 } fi
 EOS
 
-  EXPANDED_VARIABLES = ["run_id", "is_mpi_job", "mounted_work_base_dir", "omp_threads", "mpi_procs", "cmd", "print_version_command"]
+  EXPANDED_VARIABLES = ["run_id", "is_mpi_job", "omp_threads", "mpi_procs", "cmd", "print_version_command"]
 
   def self.script_for(run, host)
     variables = {
       "run_id" => run.id.to_s,
       "is_mpi_job" => run.simulator.support_mpi ? "true" : "false",
       "work_base_dir" => host ? host.work_base_dir : '.',
-      "mounted_work_base_dir" => host ? host.mounted_work_base_dir.to_s : "",
       "omp_threads" => run.omp_threads,
       "mpi_procs" => run.mpi_procs,
       "cmd" => run.command_and_input[0].sub(/;$/, ''),

--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -40,14 +40,11 @@ echo "}" >> ../${OACIS_RUN_ID}_status.json
 cd ..
 \\mv -f ${OACIS_RUN_ID}_status.json ${OACIS_RUN_ID}/_status.json
 \\mv -f ${OACIS_RUN_ID}_time.txt ${OACIS_RUN_ID}/_time.txt
-tar cf ${OACIS_RUN_ID}.tar ${OACIS_RUN_ID}
+tar cf ${OACIS_RUN_ID}.tmp.tar ${OACIS_RUN_ID}
 if test $? -ne 0; then { echo "// Failed to make an archive for ${OACIS_RUN_ID}" >> ./_log.txt; exit; } fi
-bzip2 ${OACIS_RUN_ID}.tar
+bzip2 ${OACIS_RUN_ID}.tmp.tar
 if test $? -ne 0; then { echo "// Failed to compress for ${OACIS_RUN_ID}" >> ./_log.txt; exit; } fi
-if [ -z "$OACIS_MOUNTED_WORK_BASE_DIR" ]
-then
-  rm -rf ${OACIS_RUN_ID}
-fi
+mv ${OACIS_RUN_ID}.tmp.tar.bz2 ${OACIS_RUN_ID}.tar.bz2
 EOS
 
   EXPANDED_VARIABLES = ["run_id", "is_mpi_job", "mounted_work_base_dir", "omp_threads", "mpi_procs", "cmd", "print_version_command"]

--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -8,7 +8,6 @@ export LC_ALL=C
 # VARIABLE DEFINITIONS ------------
 OACIS_RUN_ID=<%= run_id %>
 OACIS_IS_MPI_JOB=<%= is_mpi_job %>
-OACIS_MOUNTED_WORK_BASE_DIR=<%= mounted_work_base_dir %>
 OACIS_MPI_PROCS=<%= mpi_procs %>
 OACIS_OMP_THREADS=<%= omp_threads %>
 OACIS_PRINT_VERSION_COMMAND="<%= print_version_command %>"

--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -43,8 +43,12 @@ cd ..
 tar cf ${OACIS_RUN_ID}.tmp.tar ${OACIS_RUN_ID}
 if test $? -ne 0; then { echo "// Failed to make an archive for ${OACIS_RUN_ID}" >> ./_log.txt; exit; } fi
 bzip2 ${OACIS_RUN_ID}.tmp.tar
-if test $? -ne 0; then { echo "// Failed to compress for ${OACIS_RUN_ID}" >> ./_log.txt; exit; } fi
-mv ${OACIS_RUN_ID}.tmp.tar.bz2 ${OACIS_RUN_ID}.tar.bz2
+if test $? -eq 0; then {
+  mv ${OACIS_RUN_ID}.tmp.tar.bz2 ${OACIS_RUN_ID}.tar.bz2
+}
+else {
+  echo "// Failed to compress for ${OACIS_RUN_ID}" >> ./_log.txt; exit;
+} fi
 EOS
 
   EXPANDED_VARIABLES = ["run_id", "is_mpi_job", "mounted_work_base_dir", "omp_threads", "mpi_procs", "cmd", "print_version_command"]

--- a/spec/lib/job_script_util_spec.rb
+++ b/spec/lib/job_script_util_spec.rb
@@ -58,6 +58,14 @@ describe JobScriptUtil do
       }
     end
 
+    it "does not remove work_dir" do
+      run_test_script_in_temp_dir
+      work_dir = @temp_dir.join("#{@run.id}")
+      archive = @temp_dir.join("#{@run.id}.tar.bz2")
+      expect( File.directory?(work_dir) ).to be_truthy
+      expect( File.exist?(archive) ).to be_truthy
+    end
+
     it "set OACIS_MPI envs and do not call mpiexec when Simulator#support_mpi is true" do
       @sim.support_mpi = true
       @sim.save!

--- a/spec/lib/job_script_util_spec.rb
+++ b/spec/lib/job_script_util_spec.rb
@@ -32,7 +32,7 @@ describe JobScriptUtil do
         result_file = "#{@run.id}.tar.bz2"
         expect(File.exist?(result_file)).to be_truthy
 
-        expect(File.directory?(@run.id.to_s)).to be_falsey
+        expect(File.directory?(@run.id.to_s)).to be_truthy
 
         system("tar xjf #{result_file}")
         json_path = File.join(@run.id.to_s, '_status.json')

--- a/spec/lib/job_script_util_spec.rb
+++ b/spec/lib/job_script_util_spec.rb
@@ -58,16 +58,17 @@ describe JobScriptUtil do
       }
     end
 
-    it "calls mpiexec when Simulator#support_mpi is true" do
+    it "set OACIS_MPI envs and do not call mpiexec when Simulator#support_mpi is true" do
       @sim.support_mpi = true
       @sim.save!
       @run.mpi_procs = 8
       script = JobScriptUtil.script_for(@run, @host)
       expect(script).to match(/OACIS_MPI_PROCS=8/)
       expect(script).to match(/OACIS_IS_MPI_JOB=true/)
+      expect(script).not_to match(/mpiexec/)
     end
 
-    it "does not call insert mpiexec when Simulator#support_mpi is false" do
+    it "do not set OACIS_MPI envs when Simulator#support_mpi is false" do
       @sim.support_mpi = false
       @sim.save!
       @run.mpi_procs = 8


### PR DESCRIPTION
fixed #359 

job script内の処理を以下のように変更

- tar archiveのファイル名を `#{run_id}.tar` から `#{run_id}.tmp.tar` に変更
- 同様に bz2のファイル名も .tmp.tar.bz2にする。
- bzip2の処理が完了した後にファイルを .tar.bz2 にリネームする
- work_dirの削除処理はスクリプト内では行わず、include時に行う
