### PR TITLE
add link to English document

### DIFF
--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -17,5 +17,11 @@
         %li
           = link_to 'Hosts', hosts_path
       %ul.nav.navbar-nav.navbar-right
-        %li
-          = link_to 'Document', "#{root_path}oacis_document/index.html", target: '_blank'
+        %li.dropdown
+          %a.dropdown-toggle{href:"#", 'data-toggle':"dropdown", role:"button", "aria-haspopup":"true", "aria-expanded":"false" }
+            Document
+            %span.caret
+          %ul.dropdown-menu
+            %li
+              = link_to 'English', "https://github.com/crest-cassia/oacis/wiki", target: '_blank'
+              = link_to '日本語', "#{root_path}oacis_document/index.html", target: '_blank'


### PR DESCRIPTION
fix #361

英語ドキュメント(githubのwiki)へのリンクを追加
