### PR TITLE
return 1 when check oacis env fails

### DIFF
--- a/bin/check_oacis_env
+++ b/bin/check_oacis_env
@@ -68,4 +68,6 @@ if verify_ruby_version and
    verify_mongodb_version and
    verify_mongod_process_is_running
   puts "\e[32mAll the environment checks have passed!\e[0m"
+else
+  exit 1
 end


### PR DESCRIPTION
check_oacics_env で適切なprerequisitesがない時にreturn code 1を返す