### PR TITLE
show results of analysis together with results of runs

### DIFF
--- a/app/views/runs/_results.html.haml
+++ b/app/views/runs/_results.html.haml
@@ -1,0 +1,9 @@
+%h2
+  Result of Run
+= render partial: "shared/results", locals: {result: @run.result, result_paths: @run.result_paths, archived_result_path: @run.archived_result_path }
+
+- @run.analyses.where(status: :finished).each do |anl|
+  %hr
+  %h2= "Result of Analysis: #{anl.analyzer.name}"
+  = link_to(anl.id,anl)
+  = render partial: "shared/results", locals: {result: anl.result, result_paths: anl.result_paths, archived_result_path: anl.archived_result_path }

--- a/app/views/runs/show.html.haml
+++ b/app/views/runs/show.html.haml
@@ -11,14 +11,18 @@
     %li
       %a{"href"=>"#tab-about", "data-toggle" => "tab"} About
     %li.active
-      %a{"href"=>"#tab-analyses", "data-toggle" => "tab"} Results and Analyses
+      %a{"href"=>"#tab-results", "data-toggle" => "tab"} Results
+    %li
+      %a{"href"=>"#tab-analyses", "data-toggle" => "tab"} Analyses
 
   %div.tab-content
     %div.tab-pane#tab-about
       = render "about"
-    %div.tab-pane.active#tab-analyses
+    %div.tab-pane.active#tab-results
       - if @run.error_messages
         %h3 Error messages
         %pre~ @run.error_messages
-      = render partial: "shared/results", locals: {result: @run.result, result_paths: @run.result_paths, archived_result_path: @run.archived_result_path }
+      = render "results"
+    %div.tab-pane#tab-analyses
       = render "analyses", run: @run
+

--- a/app/views/shared/_results.html.haml
+++ b/app/views/shared/_results.html.haml
@@ -20,7 +20,7 @@
 
 - if result_paths.present?
   %h3 Output Files
-  #result-tree
+  .result-tree
     = File.dirname(file_path_to_link_path(result_paths.first))+"/"
     = make_tree_from_result_paths( result_paths )
   - if File.exist?( archived_result_path.to_s )
@@ -38,11 +38,13 @@
 
 :javascript
   $(function () {
-    $("#result-tree").dynatree({
-      onClick: function(node) {
-        if (node.data.href) {
-          location.href=node.data.href;
+    $(".result-tree").each( function() {
+      $(this).dynatree({
+        onClick: function(node) {
+          if (node.data.href) {
+            location.href=node.data.href;
+          }
         }
-      }
+      });
     });
   });


### PR DESCRIPTION
Runの結果の表示方法を変更。
fixed #377 
Runの結果とAnalysisの結果を同じページに表示できるようにした。

- タブを [Results and Analyses] から [Results], [Analyses] の二つに変更
  - resutlsのタブにRunの結果とAnalysisの結果をまとめて表示
  - AnalysesのタブにAnalysisのデータテーブルと作成用フォームを作成

before
![image](https://cloud.githubusercontent.com/assets/718731/11057251/c701a52e-87cc-11e5-9af6-52d6f6e20b0c.png)

after
![image](https://cloud.githubusercontent.com/assets/718731/11057257/d617c4d0-87cc-11e5-9e83-215a9d24f233.png)
---
![image](https://cloud.githubusercontent.com/assets/718731/11057261/df888d38-87cc-11e5-9792-fce508bb8215.png)


