### PR TITLE
Bugfix canceled job survives

### DIFF
--- a/app/services/job_includer.rb
+++ b/app/services/job_includer.rb
@@ -18,6 +18,8 @@ module JobIncluder
           include_archive(submittable)
         end
       else
+        # taking care of the case that a run is canceled during being included
+        return if submittable.reload.status == :cancelled
         submittable.status = :failed
         submittable.save!
         download_work_dir_if_exists(host, submittable, ssh)

--- a/app/services/job_includer.rb
+++ b/app/services/job_includer.rb
@@ -19,7 +19,7 @@ module JobIncluder
         end
       else
         # taking care of the case that a run is canceled during being included
-        return if submittable.reload.status == :cancelled
+        return if submittable.class.find(submittable.id).status == :cancelled
         submittable.status = :failed
         submittable.save!
         download_work_dir_if_exists(host, submittable, ssh)

--- a/lib/cli/oacis_cli_analysis.rb
+++ b/lib/cli/oacis_cli_analysis.rb
@@ -187,8 +187,9 @@ class OacisCli < Thor
 
     if options[:yes] or yes?("Replace #{analyses.count} analyses with new ones?")
       progressbar = ProgressBar.create(total: analyses.count, format: "%t %B %p%% (%c/%C)")
-      # no_timeout enables replacement of 10000 or more analyses
-      analyses.no_timeout.each do |anl|
+      anl_ids = analyses.only(:id).map(&:id)
+      anl_ids.each do |anlid|
+        anl = Analysis.find(anlid)
         if anl.analyzable_type == "Run"
           new_analysis = Run.find(anl.analyzable_id).analyses.build
           new_analysis.parameters = anl.parameters

--- a/lib/cli/oacis_cli_run.rb
+++ b/lib/cli/oacis_cli_run.rb
@@ -217,7 +217,6 @@ class OacisCli < Thor
 
     if options[:yes] or yes?("Replace #{runs.count} runs with new ones?")
       progressbar = ProgressBar.create(total: runs.count, format: "%t %B %p%% (%c/%C)")
-      # no_timeout enables replacement of 10000 or more runs
       run_ids = runs.only(:id).map(&:id)
       run_ids.each do |runid|
         run = Run.find(runid)

--- a/lib/cli/oacis_cli_run.rb
+++ b/lib/cli/oacis_cli_run.rb
@@ -218,7 +218,9 @@ class OacisCli < Thor
     if options[:yes] or yes?("Replace #{runs.count} runs with new ones?")
       progressbar = ProgressBar.create(total: runs.count, format: "%t %B %p%% (%c/%C)")
       # no_timeout enables replacement of 10000 or more runs
-      runs.no_timeout.each do |run|
+      run_ids = runs.only(:id).map(&:id)
+      run_ids.each do |runid|
+        run = Run.find(runid)
         run_attr = { submitted_to: run.submitted_to,
                      mpi_procs: run.mpi_procs,
                      omp_threads: run.omp_threads,

--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -105,7 +105,8 @@ EOS
           is_updated = true
         rescue => ex
           error_message+="failed to load _status.json: #{ex.message}\n"
-          job.update_attribute(:status, :failed)
+          job.status = :failed
+          is_updated = true
         end
       end
 
@@ -153,7 +154,8 @@ EOS
 
       if is_updated
         job.included_at = DateTime.now
-        job.save!
+        job.save! unless job.reload.status == :cancelled
+        # do not update status when job is canceled
       end
     }
   end

--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -154,7 +154,7 @@ EOS
 
       if is_updated
         job.included_at = DateTime.now
-        job.save! unless job.reload.status == :cancelled
+        job.save! if job.class.find(job.id).status != :cancelled
         # do not update status when job is canceled
       end
     }

--- a/spec/lib/job_script_util_spec.rb
+++ b/spec/lib/job_script_util_spec.rb
@@ -451,6 +451,16 @@ EOS
         skip "not yet implemented"
       end
     end
+
+    context "when job is canceled" do
+
+      it "does not update status of Run" do
+        @submittable.update_attribute(:status, :cancelled)
+        expect {
+          JobScriptUtil.update_run(@submittable)
+        }.to_not change { @submittable.reload.status }
+      end
+    end
   end
 end
 

--- a/spec/services/job_includer_spec.rb
+++ b/spec/services/job_includer_spec.rb
@@ -164,7 +164,7 @@ describe JobIncluder do
     # Even if .tar.bz2 is not found, try to include the files as much as possible
     describe "when archive file is not found but work_dir exists" do
 
-      context "if _status.json exists in downloded work_dir" do
+      context "if _status.json exists in downloaded work_dir" do
 
         before(:each) do
           make_valid_archive_file(@submittable)
@@ -190,7 +190,7 @@ describe JobIncluder do
         end
       end
 
-      context "if _status.json does not exist in downloded work_dir" do
+      context "if _status.json does not exist in downloaded work_dir" do
 
         before(:each) do
           make_valid_archive_file(@submittable)
@@ -202,6 +202,18 @@ describe JobIncluder do
 
         it "updates status to failed" do
           expect(@submittable.status).to eq :failed
+        end
+      end
+
+      context "when job is canceled" do
+
+        it "does not try to include work_dir" do
+          make_valid_archive_file(@submittable)
+          FileUtils.rm(@archive_full_path)
+          @submittable.update_attribute(:status, :cancelled)
+          expect {
+            JobIncluder.include_remote_job(@host, @submittable)
+          }.to_not change { @submittable.reload.status }
         end
       end
     end


### PR DESCRIPTION
CLIで多数（数百）のジョブ完了前のRunをreplaceしたときに、リモートのジョブがキャンセルされずに生き残るケースがあり、多数のRunが投入された状態になってしまう。
２件の異なるバグが存在。

１件は、CLIのコードについてのバグ。（こちらはあまり本質的なバグではない）
```
# runs = Run.where(:status, ...)  queryオブジェクト
runs.no_timeout.each do |run|
```
というコードが存在していたが、ループを回していくうちに新規のドキュメントが作成されるので、queryが新規のドキュメント対してもイテレートするケースがある。
例えば、"simulator_version:" というqueryの場合、新規ドキュメントはバージョンが空なのでイテレーションの対象になる場合がある。

２件目のバグは、workerがremote_statusの状態をチェックしている最中に、CLIまたはUIでRunのstatusがcancelledに変更されるが、workerがタイミングによってその変更を認識せずにstatusを:runningまたは:failedに上書きしてしまうという問題。
SSHの処理をしてリモートのステータスをチェックしている間にdestroyされるとこの問題が発生する。SSHの処理にはそれなりに時間がかかるので現実的にある程度の確率で発生する。
workerでstatusを更新するときに、その直前でcancelledに変更されていないか確認する処理を追加したところ問題が発生しなくなった。厳密に言えばまだ問題が発生する可能性はあるが、現実的にはこれで問題ないと思われる。


