### PR TITLE
Avoid conflict when destroying

### DIFF
--- a/app/controllers/analyses_controller.rb
+++ b/app/controllers/analyses_controller.rb
@@ -30,7 +30,7 @@ class AnalysesController < ApplicationController
 
   def destroy
     anl = Analysis.find(params[:id])
-    anl.destroy
+    anl.update_attribute(:to_be_destroyed, true)
 
     respond_to do |format|
       format.json { head :no_content }

--- a/app/controllers/analyzers_controller.rb
+++ b/app/controllers/analyzers_controller.rb
@@ -56,6 +56,7 @@ class AnalyzersController < ApplicationController
     analyzer = Analyzer.find(params[:id])
     simulator = analyzer.simulator
     analyzer.update_attribute(:to_be_destroyed, true)
+    analyzer.set_lower_submittable_to_be_destroyed
 
     respond_to do |format|
       format.json { head :no_content }

--- a/app/controllers/analyzers_controller.rb
+++ b/app/controllers/analyzers_controller.rb
@@ -55,7 +55,7 @@ class AnalyzersController < ApplicationController
   def destroy
     analyzer = Analyzer.find(params[:id])
     simulator = analyzer.simulator
-    analyzer.destroy
+    analyzer.update_attribute(:to_be_destroyed, true)
 
     respond_to do |format|
       format.json { head :no_content }

--- a/app/controllers/parameter_sets_controller.rb
+++ b/app/controllers/parameter_sets_controller.rb
@@ -131,6 +131,7 @@ class ParameterSetsController < ApplicationController
     @ps = ParameterSet.find(params[:id])
     simulator = Simulator.find(@ps.simulator_id)
     @ps.update_attribute(:to_be_destroyed, true)
+    @ps.set_lower_submittable_to_be_destroyed
 
     respond_to do |format|
       format.json { head :no_content }

--- a/app/controllers/parameter_sets_controller.rb
+++ b/app/controllers/parameter_sets_controller.rb
@@ -130,7 +130,7 @@ class ParameterSetsController < ApplicationController
   def destroy
     @ps = ParameterSet.find(params[:id])
     simulator = Simulator.find(@ps.simulator_id)
-    @ps.destroy
+    @ps.update_attribute(:to_be_destroyed, true)
 
     respond_to do |format|
       format.json { head :no_content }

--- a/app/controllers/runs_controller.rb
+++ b/app/controllers/runs_controller.rb
@@ -92,7 +92,7 @@ class RunsController < ApplicationController
   def destroy
     @run = Run.find(params[:id])
     @run.update_attribute(:to_be_destroyed, true)
-    @run.analyses.update_all(to_be_destroyed: true)
+    @run.set_lower_submittable_to_be_destroyed
 
     respond_to do |format|
       format.json { head :no_content }

--- a/app/controllers/runs_controller.rb
+++ b/app/controllers/runs_controller.rb
@@ -91,7 +91,8 @@ class RunsController < ApplicationController
 
   def destroy
     @run = Run.find(params[:id])
-    @run.destroy
+    @run.update_attribute(:to_be_destroyed, true)
+    @run.analyses.update_all(to_be_destroyed: true)
 
     respond_to do |format|
       format.json { head :no_content }

--- a/app/controllers/simulators_controller.rb
+++ b/app/controllers/simulators_controller.rb
@@ -97,6 +97,7 @@ class SimulatorsController < ApplicationController
   def destroy
     @simulator = Simulator.find(params[:id])
     @simulator.update_attribute(:to_be_destroyed, true)
+    @simulator.set_lower_submittable_to_be_destroyed
 
     respond_to do |format|
       format.html { redirect_to simulators_url }

--- a/app/controllers/simulators_controller.rb
+++ b/app/controllers/simulators_controller.rb
@@ -96,7 +96,7 @@ class SimulatorsController < ApplicationController
   # DELETE /simulators/1.json
   def destroy
     @simulator = Simulator.find(params[:id])
-    @simulator.destroy
+    @simulator.update_attribute(:to_be_destroyed, true)
 
     respond_to do |format|
       format.html { redirect_to simulators_url }

--- a/app/datatables/parameter_sets_list_datatable.rb
+++ b/app/datatables/parameter_sets_list_datatable.rb
@@ -39,7 +39,6 @@ private
       tmp = []
       tmp << @view.content_tag(:i, '', parameter_set_id: param.id.to_s, align: "center", class: "fa fa-search clickable")
       counts = param.runs_status_count
-      counts.delete(:cancelled)
       progress = @view.progress_bar( counts.values.inject(:+), counts[:finished], counts[:failed], counts[:running], counts[:submitted] )
       tmp << @view.raw(progress)
       tmp << @view.link_to( @view.shortened_id_monospaced(param.id), @view.parameter_set_path(param) )

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -117,6 +117,10 @@ class Analysis
     true
   end
 
+  def set_lower_submittable_to_be_destroyed
+    # do nothing
+  end
+
   private
   def cast_and_validate_parameter_values
     return unless analyzer

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -113,6 +113,10 @@ class Analysis
     return files
   end
 
+  def destroyable?
+    true
+  end
+
   private
   def cast_and_validate_parameter_values
     return unless analyzer
@@ -145,9 +149,5 @@ class Analysis
     if self.analyzable && !self.analyzable.destroyed? && File.directory?(self.dir)
       FileUtils.rm_r(self.dir)
     end
-  end
-
-  def destroyable?
-    true
   end
 end

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -9,6 +9,8 @@ class Analysis
   belongs_to :analyzable, polymorphic: true, autosave: false
   belongs_to :parameter_set
 
+  default_scope ->{ where(:to_be_destroyed.in => [nil,false]) }
+
   validates :analyzer, :presence => true
   validate :cast_and_validate_parameter_values
 
@@ -145,9 +147,7 @@ class Analysis
     end
   end
 
-  def cancel
-    super
-    delete_dir
-    self.update_attribute(:analyzable_id, nil)
+  def destroyable?
+    true
   end
 end

--- a/app/models/analyzer.rb
+++ b/app/models/analyzer.rb
@@ -77,6 +77,9 @@ class Analyzer
     analyses.unscoped.empty?
   end
 
+  def set_lower_submittable_to_be_destroyed
+    analyses.update_all(to_be_destroyed: true)
+  end
 
   private
   def auto_run_submitted_to_is_in_executable_on

--- a/app/models/analyzer.rb
+++ b/app/models/analyzer.rb
@@ -7,13 +7,16 @@ class Analyzer
   field :type, type: Symbol
   field :auto_run, type: Symbol, default: :no
   field :description, type: String
+  field :to_be_destroyed, type: Boolean, default: false
 
   embeds_many :parameter_definitions
   belongs_to :simulator
-  has_many :analyses, dependent: :destroy
+  has_many :analyses
 
   ## fields for auto run
   belongs_to :auto_run_submitted_to, class_name: "Host"
+
+  default_scope ->{ where(:to_be_destroyed.in => [nil,false]) }
 
   validates :name, presence: true, uniqueness: {scope: :simulator}, format: {with: /\A\w+\z/}
   validates :type, presence: true, 
@@ -69,6 +72,11 @@ class Analyzer
 
     anl_versions.map {|key,val| val['version'] = key; val }.sort_by {|a| a['latest_started_at']}
   end
+
+  def destroyable?
+    analyses.unscoped.empty?
+  end
+
 
   private
   def auto_run_submitted_to_is_in_executable_on

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -89,7 +89,7 @@ class Host
   end
 
   def submitted_runs
-    Run.where(submitted_to: self).in(status: [:submitted, :running])
+    Run.unscoped.where(submitted_to: self).in(status: [:submitted, :running])
   end
 
   def submittable_analyses
@@ -97,7 +97,7 @@ class Host
   end
 
   def submitted_analyses
-    Analysis.where(submitted_to: self).in(status: [:submitted, :running])
+    Analysis.unscoped.where(submitted_to: self).in(status: [:submitted, :running])
   end
 
   def runs_status_count

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -89,7 +89,7 @@ class Host
   end
 
   def submitted_runs
-    Run.where(submitted_to: self).in(status: [:submitted, :running, :cancelled])
+    Run.where(submitted_to: self).in(status: [:submitted, :running])
   end
 
   def submittable_analyses
@@ -97,11 +97,11 @@ class Host
   end
 
   def submitted_analyses
-    Analysis.where(submitted_to: self).in(status: [:submitted, :running, :cancelled])
+    Analysis.where(submitted_to: self).in(status: [:submitted, :running])
   end
 
   def runs_status_count
-    count = {created: 0, submitted: 0, running: 0, failed: 0, finished: 0, cancelled: 0}
+    count = {created: 0, submitted: 0, running: 0, failed: 0, finished: 0}
     Run.collection.aggregate(
       { '$match' => Run.where(submitted_to: self).selector },
       { '$group' => {_id: '$status', count: {'$sum' => 1} } }

--- a/app/models/parameter_set.rb
+++ b/app/models/parameter_set.rb
@@ -59,7 +59,7 @@ class ParameterSet
     counts = Hash[ aggregated.map {|d| [d["_id"], d["count"]] } ]
 
     # merge default value because some 'counts' do not have keys whose count is zero.
-    default = {created: 0, submitted: 0, running: 0, failed: 0, finished: 0, cancelled: 0}
+    default = {created: 0, submitted: 0, running: 0, failed: 0, finished: 0}
     counts.merge!(default) {|key, self_val, other_val| self_val }
 
     # skip validation using update_attribute method in order to improve performance

--- a/app/models/parameter_set.rb
+++ b/app/models/parameter_set.rb
@@ -81,6 +81,13 @@ class ParameterSet
     end
   end
 
+  def set_lower_submittable_to_be_destroyed
+    runs.update_all(to_be_destroyed: true)
+    analyses.update_all(to_be_destroyed: true)
+    run_ids = runs.unscoped.map {|run| run.id }
+    Analysis.where(:analyzable_id.in => run_ids).update_all(to_be_destroyed: true)
+  end
+
   private
   def cast_parameter_values
     unless v.is_a?(Hash)

--- a/app/models/result_directory.rb
+++ b/app/models/result_directory.rb
@@ -19,18 +19,18 @@ module ResultDirectory
   end
 
   def self.parameter_set_path(param_set)
-    prm = ParameterSet.find(param_set)
+    prm = ParameterSet.unscoped.find(param_set)
     simulator_path(prm.simulator_id).join(prm.to_param)
   end
 
   def self.run_path(run)
-    run = Run.find(run)
+    run = Run.unscoped.find(run)
     prm = run.parameter_set_id
     parameter_set_path(run.parameter_set_id).join(run.to_param)
   end
 
   def self.run_script_path(run)
-    run = Run.find(run)
+    run = Run.unscoped.find(run)
     prm = run.parameter_set_id
     parameter_set_path(run.parameter_set_id).join(run.to_param + '.sh')
   end

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -91,6 +91,10 @@ class Run
     analyses.unscoped.empty?
   end
 
+  def set_lower_submittable_to_be_destroyed
+    analyses.update_all(to_be_destroyed: true)
+  end
+
   private
   def set_simulator
     if parameter_set

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -8,7 +8,7 @@ class Run
 
   belongs_to :parameter_set, autosave: false
   belongs_to :simulator, autosave: false  # for caching. do not edit this field explicitly
-  has_many :analyses, as: :analyzable, dependent: :destroy
+  has_many :analyses, as: :analyzable
 
   default_scope ->{ where(:to_be_destroyed.in => [nil,false]) }
 

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -144,6 +144,12 @@ class Simulator
     end
   end
 
+  def set_lower_submittable_to_be_destroyed
+    runs.update_all(to_be_destroyed: true)
+    azr_ids = analyzers.unscoped.map {|azr| azr.id }
+    Analysis.where(:analyzer_id.in => azr_ids).update_all(to_be_destroyed: true)
+  end
+
   private
   def domains(collection_class, query, result_keys)
     group = {_id: 0}

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -61,7 +61,7 @@ class Simulator
     counts = Hash[ aggregated.map {|d| [d["_id"], d["count"]] } ]
 
     # merge default value because some 'counts' do not have keys whose count is zero.
-    default = {created: 0, submitted: 0, running: 0, failed: 0, finished: 0, cancelled: 0}
+    default = {created: 0, submitted: 0, running: 0, failed: 0, finished: 0}
     counts.merge!(default) {|key, self_val, other_val| self_val }
   end
 
@@ -209,7 +209,6 @@ function() {
     var cache = this.runs_status_count_cache;
     var total_runs = 0;
     for(var stat in cache) {
-      if (stat == "cancelled") continue;
       total_runs += cache[stat];
     }
     var val = {finished: cache["finished"], total: total_runs };
@@ -247,7 +246,7 @@ EOS
       if d["value"]["ids"].present?
         target_runs = Run.in(parameter_set_id: d["value"]["ids"])
         runs_count[0] += target_runs.where(status: :finished).count
-        runs_count[1] += target_runs.ne(status: :cancelled).count
+        runs_count[1] += target_runs.count
       end
 
       parameters_to_runs_count[ casted_parameters ] = runs_count

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -6,11 +6,14 @@ class Simulator
   field :name, type: String
   field :description, type: String
   field :position, type: Integer # position in the table. start from zero
+  field :to_be_destroyed, type: Boolean, default: false
   embeds_many :parameter_definitions
   has_many :parameter_sets, dependent: :destroy
   has_many :runs
   has_many :parameter_set_queries, dependent: :destroy
   has_many :analyzers, dependent: :destroy, autosave: true #enable autosave to copy analyzers
+
+  default_scope ->{ where(:to_be_destroyed.in => [nil,false]) }
 
   validates :name, presence: true, uniqueness: true, format: {with: /\A\w+\z/}
   validates :parameter_definitions, presence: true
@@ -130,6 +133,15 @@ class Simulator
       end
     end
     list
+  end
+
+  def destroyable?
+    if runs.unscoped.empty?
+      azr_ids = analyzers.unscoped.map {|azr| azr.id }
+      Analysis.unscoped.where(:analyzer_id.in => azr_ids).empty?
+    else
+      false
+    end
   end
 
   private

--- a/app/services/job_includer.rb
+++ b/app/services/job_includer.rb
@@ -18,8 +18,6 @@ module JobIncluder
           include_archive(submittable)
         end
       else
-        # taking care of the case that a run is canceled during being included
-        return if submittable.class.find(submittable.id).status == :cancelled
         submittable.status = :failed
         submittable.save!
         download_work_dir_if_exists(host, submittable, ssh)

--- a/app/views/hosts/_info.html.haml
+++ b/app/views/hosts/_info.html.haml
@@ -17,7 +17,7 @@
   %tbody
     %tr
       - stat_count = @host.runs_status_count
-      - total = stat_count.reject {|status| status == :cancelled}.values.inject(:+)
+      - total = stat_count.values.inject(:+)
       %th= total
       %td= "#{stat_count[:finished]} (#{(100.0*stat_count[:finished]/total.to_f).round(1)} %)"
       %td= "#{stat_count[:failed]} (#{(100.0*stat_count[:failed]/total.to_f).round(1)} %)"

--- a/app/views/simulators/_progress.html.haml
+++ b/app/views/simulators/_progress.html.haml
@@ -17,7 +17,7 @@
   %tbody
     %tr
       - stat_count = @simulator.runs_status_count
-      - total = stat_count.reject {|status| status == :cancelled}.values.inject(:+)
+      - total = stat_count.values.inject(:+)
       %th= total
       %td= "#{stat_count[:finished]} (#{(100.0*stat_count[:finished]/total.to_f).round(1)} %)"
       %td= "#{stat_count[:failed]} (#{(100.0*stat_count[:failed]/total.to_f).round(1)} %)"

--- a/app/views/simulators/index.html.haml
+++ b/app/views/simulators/index.html.haml
@@ -13,7 +13,6 @@
         %td= link_to h(simulator.name), simulator_path(simulator)
         %td= distance_to_now_in_words(simulator.updated_at)
         - counts = simulator.runs_status_count
-        - counts.delete(:cancelled)
         %td#progress= progress_bar(counts.values.inject(:+), counts[:finished], counts[:failed], counts[:running], counts[:submitted])
 
 - unless OACIS_READ_ONLY

--- a/app/workers/document_destroyer.rb
+++ b/app/workers/document_destroyer.rb
@@ -1,7 +1,5 @@
 class DocumentDestroyer
 
-  MAX_COUNT_FOR_CHECK_SUB_DOCUMENTS = 10
-
   def self.perform(logger)
     @skip_count ||= {}
     @logger = logger
@@ -33,13 +31,6 @@ class DocumentDestroyer
         @skip_count.delete(obj.id)
       else
         @logger.info "Skip destroying #{obj.class} #{obj.id}. not destroyable yet."
-        @skip_count[obj.id] = @skip_count[obj.id].to_i + 1
-        if @skip_count[obj.id] >= MAX_COUNT_FOR_CHECK_SUB_DOCUMENTS
-          @logger.warn "#{obj.id} has not been destroyable for #{MAX_COUNT_FOR_CHECK_SUB_DOCUMENTS} times"
-          @logger.warn "trying to run :set_lower_submittable_to_be_destroyed"
-          obj.set_lower_submittable_to_be_destroyed
-          @skip_count[obj.id] = 0
-        end
       end
     end
   end

--- a/app/workers/document_destroyer.rb
+++ b/app/workers/document_destroyer.rb
@@ -1,0 +1,46 @@
+class DocumentDestroyer
+
+  MAX_COUNT_FOR_CHECK_SUB_DOCUMENTS = 10
+
+  def self.perform(logger)
+    @skip_count ||= {}
+    @logger = logger
+
+    @logger.info "looking for Simulator to be destroyed"
+    destroy_documents( Simulator.where(to_be_destroyed: true) )
+    @logger.info "looking for ParameterSet to be destroyed"
+    destroy_documents( ParameterSet.where(to_be_destroyed: true) )
+    @logger.info "looking for Analyzer to be destroyed"
+    destroy_documents( Analyzer.where(to_be_destroyed: true) )
+    @logger.info "looking for Run to be destroyed"
+    destroy_documents(
+      Run.where(:to_be_destroyed => true, :status.in => [:finished, :failed])
+    )
+    @logger.info "looking for Analysis to be destroyed"
+    destroy_documents(
+      Analysis.where(:to_be_destroyed => true, :status.in => [:finished, :failed])
+    )
+
+  rescue => ex
+    logger.error("Error in DocumentDestroyer: #{ex.inspect}")
+  end
+
+  def self.destroy_documents(query)
+    query.each do |obj|
+      if obj.destroyable?
+        @logger.info "Destroying #{obj.class} #{obj.id}"
+        obj.destroy
+        @skip_count.delete(obj.id)
+      else
+        @logger.info "Skip destroying #{obj.class} #{obj.id}. not destroyable yet."
+        @skip_count[obj.id] = @skip_count[obj.id].to_i + 1
+        if @skip_count[obj.id] >= MAX_COUNT_FOR_CHECK_SUB_DOCUMENTS
+          @logger.warn "#{obj.id} has not been destroyable for #{MAX_COUNT_FOR_CHECK_SUB_DOCUMENTS} times"
+          @logger.warn "trying to run :set_lower_submittable_to_be_destroyed"
+          obj.set_lower_submittable_to_be_destroyed
+          @skip_count[obj.id] = 0
+        end
+      end
+    end
+  end
+end

--- a/app/workers/job_observer.rb
+++ b/app/workers/job_observer.rb
@@ -40,7 +40,7 @@ class JobObserver
       handler.cancel_remote_job(job)
       logger.info("canceled remote job: #{job.class}:#{job.id} from #{host.name}")
       job.destroy
-      logger.info("destroyed from DB")
+      logger.info("Destroyed #{job.class} #{job.id}")
       return
     end
     case handler.remote_status(job)

--- a/app/workers/job_submitter.rb
+++ b/app/workers/job_submitter.rb
@@ -2,7 +2,7 @@ class JobSubmitter
 
   def self.perform(logger)
     @last_performed_at ||= {}
-    destroy_jobs_to_be_destroyed
+    destroy_jobs_to_be_destroyed(logger)
     Host.where(status: :enabled).each do |host|
       break if $term_received
       next if DateTime.now.to_i - @last_performed_at[host.id].to_i < host.polling_interval
@@ -48,8 +48,23 @@ class JobSubmitter
     end
   end
 
-  def self.destroy_jobs_to_be_destroyed
-    Run.where(status: :created, to_be_destroyed: true).destroy
-    Analysis.where(status: :created, to_be_destroyed: true).destroy
+  def self.destroy_jobs_to_be_destroyed(logger)
+    Run.where(status: :created, to_be_destroyed: true).each do |run|
+      if run.destroyable?
+        logger.info "Destroying Run #{run.id}"
+        run.destroy
+        run.set_lower_submittable_to_be_destroyed
+      else
+        logger.info "Run #{run.id} is not destroyable yet"
+      end
+    end
+    Analysis.where(status: :created, to_be_destroyed: true).each do |anl|
+      if anl.destroyable?
+        logger.info "Destroying Analysis #{anl.id}"
+        anl.destroy
+      else
+        logger.info "Analysis #{anl.id} is not destroyable yet"
+      end
+    end
   end
 end

--- a/app/workers/job_submitter.rb
+++ b/app/workers/job_submitter.rb
@@ -2,6 +2,7 @@ class JobSubmitter
 
   def self.perform(logger)
     @last_performed_at ||= {}
+    destroy_jobs_to_be_destroyed
     Host.where(status: :enabled).each do |host|
       break if $term_received
       next if DateTime.now.to_i - @last_performed_at[host.id].to_i < host.polling_interval
@@ -45,5 +46,10 @@ class JobSubmitter
         end
       end
     end
+  end
+
+  def self.destroy_jobs_to_be_destroyed
+    Run.where(status: :created, to_be_destroyed: true).destroy
+    Analysis.where(status: :created, to_be_destroyed: true).destroy
   end
 end

--- a/app/workers/service_worker.rb
+++ b/app/workers/service_worker.rb
@@ -7,7 +7,8 @@ class ServiceWorker < Worker
   WORKER_STDOUT_FILE = Rails.root.join('log', "service_worker_out.log")
 
   TASKS = [
-    lambda {|logger| CacheUpdater.perform(logger) }
+    lambda {|logger| CacheUpdater.perform(logger) },
+    lambda {|logger| DocumentDestroyer.perform(logger) }
   ]
 end
 

--- a/lib/cli/oacis_cli_analysis.rb
+++ b/lib/cli/oacis_cli_analysis.rb
@@ -160,7 +160,7 @@ class OacisCli < Thor
       progressbar = ProgressBar.create(total: analyses.count, format: "%t %B %p%% (%c/%C)")
       # no_timeout enables destruction of 10000 or more analyses
       analyses.no_timeout.each do |anl|
-        anl.destroy
+        anl.update_attribute(:to_be_destroyed, true)
         progressbar.increment
       end
     end
@@ -200,7 +200,7 @@ class OacisCli < Thor
           new_analysis.analyzer_id = anl.analyzer_id
         end
         if new_analysis.save
-          anl.destroy
+          anl.update_attribute(:to_be_destroyed, true)
         else
           progressbar.log "Failed to create Analysis #{new_analysis.errors.full_messages}"
         end

--- a/lib/cli/oacis_cli_job_include.rb
+++ b/lib/cli/oacis_cli_job_include.rb
@@ -22,7 +22,7 @@ class OacisCli < Thor
   def find_included_run(archive)
     run_id = File.basename(archive, '.tar.bz2')
     run = Run.find(run_id)
-    if [:finished, :failed, :cancelled].include?(run.status)
+    if [:finished, :failed].include?(run.status)
       raise "status of run #{run_id} is not valid"
     end
     run

--- a/lib/cli/oacis_cli_run.rb
+++ b/lib/cli/oacis_cli_run.rb
@@ -185,7 +185,8 @@ class OacisCli < Thor
       progressbar = ProgressBar.create(total: runs.count, format: "%t %B %p%% (%c/%C)")
       # no_timeout enables destruction of 10000 or more runs
       runs.no_timeout.each do |run|
-        run.destroy
+        run.update_attribute(:to_be_destroyed, true)
+        run.set_lower_submittable_to_be_destroyed
         progressbar.increment
       end
     end
@@ -226,7 +227,8 @@ class OacisCli < Thor
                      host_parameters: run.host_parameters }
         new_run = run.parameter_set.runs.build(run_attr)
         if new_run.save
-          run.destroy
+          run.update_attribute(:to_be_destroyed, true)
+          run.set_lower_submittable_to_be_destroyed
         else
           progressbar.log "Failed to create Run #{new_run.errors.full_messages}"
         end

--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -154,8 +154,7 @@ EOS
 
       if is_updated
         job.included_at = DateTime.now
-        job.save! if job.class.find(job.id).status != :cancelled
-        # do not update status when job is canceled
+        job.save!
       end
     }
   end

--- a/lib/tasks/update_schema.rake
+++ b/lib/tasks/update_schema.rake
@@ -29,5 +29,18 @@ namespace :db do
       host.timeless.update_attribute(:status, :enabled)
       progressbar.increment
     end
+
+    q = Run.where(status: :cancelled)
+    progressbar = ProgressBar.create(total: q.count, format: "%t %B %p%% (%c/%C)")
+    q.each do |run|
+      run.destroy
+      progressbar.increment
+    end
+    q = Analysis.where(status: :cancelled)
+    progressbar = ProgressBar.create(total: q.count, format: "%t %B %p%% (%c/%C)")
+    q.each do |anl|
+      anl.destroy
+      progressbar.increment
+    end
   end
 end

--- a/spec/controllers/analyses_controller_spec.rb
+++ b/spec/controllers/analyses_controller_spec.rb
@@ -272,18 +272,16 @@ describe AnalysesController do
 
   describe "DELETE 'destroy'" do
 
-    it "destroys the analysis when status is neither :failed nor :finished" do
+    it "destroys the number of analyses in default scope" do
       expect {
         delete :destroy, {id: @arn.to_param, format: 'json'}, valid_session
       }.to change(Analysis, :count).by(-1)
     end
 
-    it "cancels the analysis when status is either :created, :running" do
-      @arn.status = :running
-      @arn.save!
+    it "does not destroy the analysis" do
       expect {
         delete :destroy, {id: @arn.to_param, format: 'json'}, valid_session
-      }.to change { Analysis.where(status: :cancelled).count }.by(1)
+      }.to_not change { Analysis.unscoped.count }
     end
   end
 

--- a/spec/controllers/analyzers_controller_spec.rb
+++ b/spec/controllers/analyzers_controller_spec.rb
@@ -260,10 +260,16 @@ describe AnalyzersController do
       @azr = @sim.analyzers.first
     end
 
-    it "destroys the requested analyzer" do
+    it "reduces the number of analyzers in default scope" do
       expect {
         delete :destroy, {id: @azr.to_param, format: 'json'}, valid_session
       }.to change { @sim.reload.analyzers.count }.by(-1)
+    end
+
+    it "does not destroy the analyzer" do
+      expect {
+        delete :destroy, {id: @azr.to_param, format: 'json'}, valid_session
+      }.to_not change { @sim.reload.analyzers.unscoped.count }
     end
   end
 

--- a/spec/controllers/parameter_sets_controller_spec.rb
+++ b/spec/controllers/parameter_sets_controller_spec.rb
@@ -338,10 +338,16 @@ describe ParameterSetsController do
       @ps = @sim.parameter_sets.first
     end
 
-    it "destroys the parameter set" do
+    it "reduces the number of parameter_sets in default scope" do
       expect {
         delete :destroy, {id: @ps.to_param}, valid_session
       }.to change(ParameterSet, :count).by(-1)
+    end
+
+    it "does not destroy ParameterSet" do
+      expect {
+        delete :destroy, {id: @ps.to_param}, valid_session
+      }.to_not change{ ParameterSet.unscoped.count }
     end
 
     context "called by remote:true" do

--- a/spec/controllers/runs_controller_spec.rb
+++ b/spec/controllers/runs_controller_spec.rb
@@ -136,18 +136,16 @@ describe RunsController do
 
   describe "DELETE destroy" do
 
-    it "destroys the run when status is neither submitted nor running" do
+    it "reduces the number of runs in default scope" do
       expect {
         delete :destroy, {id: @run.to_param, format: 'json'}, valid_session
       }.to change(Run, :count).by(-1)
     end
 
-    it "cancels the run when status is either submitted or running" do
-      @run.status = :running
-      @run.save!
+    it "does not destroy the run" do
       expect {
         delete :destroy, {id: @run.to_param, format: 'json'}, valid_session
-      }.to change { Run.where(status: :cancelled).count }.by(1)
+      }.to_not change { Run.unscoped.count }
     end
   end
 end

--- a/spec/controllers/simulators_controller_spec.rb
+++ b/spec/controllers/simulators_controller_spec.rb
@@ -355,10 +355,16 @@ describe SimulatorsController do
       @sim = FactoryGirl.create(:simulator, parameter_sets_count: 0)
     end
 
-    it "destroys the requested simulator" do
+    it "reduces the number of simulators in default scope" do
       expect {
         delete :destroy, {id: @sim.to_param}, valid_session
       }.to change(Simulator, :count).by(-1)
+    end
+
+    it "does not destroy simulator" do
+      expect {
+        delete :destroy, {id: @sim.to_param}, valid_session
+      }.to_not change { Simulator.unscoped.count }
     end
 
     it "redirects to the simulators list" do

--- a/spec/lib/job_script_util_spec.rb
+++ b/spec/lib/job_script_util_spec.rb
@@ -451,16 +451,6 @@ EOS
         skip "not yet implemented"
       end
     end
-
-    context "when job is canceled" do
-
-      it "does not update status of Run" do
-        @submittable.update_attribute(:status, :cancelled)
-        expect {
-          JobScriptUtil.update_run(@submittable)
-        }.to_not change { @submittable.reload.status }
-      end
-    end
   end
 end
 

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -324,7 +324,7 @@ describe Host do
     end
 
     it "returns the number of runs for each status" do
-      expected = {created: 5, submitted: 4, running: 3, finished: 2, failed: 1, cancelled: 0}
+      expected = {created: 5, submitted: 4, running: 3, finished: 2, failed: 1}
       expect(@host.runs_status_count).to eq expected
     end
   end

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -286,18 +286,17 @@ describe Host do
                               parameter_set: ps, status: :submitted, submitted_to: @host)
       FactoryGirl.create_list(:run, 1,
                               parameter_set: ps, status: :running, submitted_to: @host)
-      ps.runs.where(status: :submitted).first.__send__(:cancel)
       FactoryGirl.create_list(:run, 1,
                               parameter_set: ps, status: :finished, submitted_to: @host)
       FactoryGirl.create_list(:run, 2,
                               parameter_set: ps, status: :submitted, submitted_to: host2)
     end
 
-    it "returns the number of runs submitted to the host" do
+    it "returns a query" do
       expect(@host.submitted_runs).to be_a(Mongoid::Criteria)
     end
 
-    it "returns runs whose status is ['submitted','running','cancelled'] and 'submitted_to' is the host" do
+    it "returns runs whose status is 'submitted' or 'running', and 'submitted_to' is the host" do
       expect(@host.submitted_runs.size).to eq 4
     end
   end

--- a/spec/models/parameter_set_query_spec.rb
+++ b/spec/models/parameter_set_query_spec.rb
@@ -79,7 +79,7 @@ describe ParameterSetQuery do
     end
 
     it "has valid selector" do
-      expect(@query.selector).to eq ({"simulator_id" => @sim.id, "v.L" => {"$lte" => 123}, "v.T" => {"$gte" => 456.0}})
+      expect(@query.selector).to eq @sim.parameter_sets.where("v.L" => {"$lte" => 123}, "v.T" => {"$gte" => 456.0}).selector
     end
   end
 

--- a/spec/models/parameter_set_spec.rb
+++ b/spec/models/parameter_set_spec.rb
@@ -277,7 +277,6 @@ describe ParameterSet do
       expect(prm.runs_status_count[:running]).to eq prm.runs.where(status: :running).count
       expect(prm.runs_status_count[:finished]).to eq prm.runs.where(status: :finished).count
       expect(prm.runs_status_count[:failed]).to eq prm.runs.where(status: :failed).count
-      expect(prm.runs_status_count[:cancelled]).to eq prm.runs.where(status: :cancelled).count
     end
 
     it "save the result into runs_status_count_cache field" do

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -118,7 +118,7 @@ describe Run do
       expect(run.priority).to eq 1
     end
 
-   describe "'host_parameters' field" do
+    describe "'host_parameters' field" do
 
       before(:each) do
         hpds = [ HostParameterDefinition.new(key: "node", default: "x", format: '\w+') ]

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -15,6 +15,17 @@ describe Run do
     }
   end
 
+  describe "default_scope" do
+
+    it "ignores Run of to_be_destroyed=true by default" do
+      run = Run.first
+      expect {
+        run.update_attribute(:to_be_destroyed, true)
+      }.to change { Run.count }.by(-1)
+      expect( Run.all.to_a ).to_not include(run)
+    end
+  end
+
   describe "validations" do
 
     it "creates a Run with a valid attribute" do
@@ -50,7 +61,7 @@ describe Run do
       expect( run.seed ).to be < 2**31
     end
 
-    it "status must be either :created, :submitted, :running, :failed, :finished, or :cancelled" do
+    it "status must be either :created, :submitted, :running, :failed, or :finished" do
       run = @param_set.runs.build(@valid_attribute)
       run.status = :unknown
       expect(run).not_to be_valid
@@ -196,10 +207,10 @@ describe Run do
       expect(run.simulator).to be_a(Simulator)
     end
 
-    it "destroys including analyses when destroyed" do
+    it "does not destroy including analyses" do
       expect {
         @run.destroy
-      }.to change { Analysis.all.count }.by(-2)
+      }.to_not change { Analysis.all.count }
     end
   end
 
@@ -350,7 +361,7 @@ describe Run do
       @run = sim.parameter_sets.first.runs.first
     end
 
-    it "calls destroy if status is either :created, :failed, or :finished" do
+    it "deletes the document" do
       expect {
         @run.destroy
       }.to change { Run.count }.by(-1)
@@ -383,52 +394,62 @@ describe Run do
       expect(pre_process_script_path).not_to be_exist
       expect(pre_process_executor_path).not_to be_exist
     end
+  end
 
-    context "when status is :submitted or :running" do
+  describe "#set_lower_submittable_to_be_destroyed" do
 
-      before(:each) do
-        @run.status = :submitted
-      end
+    before(:each) do
+      @sim = FactoryGirl.create(:simulator,
+                                parameter_sets_count: 1,
+                                runs_count: 1,
+                                analyzers_count: 2,
+                                run_analysis: true
+                                )
+    end
 
-      it "calls cancel if status is :submitted or :running" do
-        expect(@run).to receive(:cancel)
-        @run.destroy
-      end
+    it "sets to_be_destroyed of analyses" do
+      run = @sim.runs.first
+      expect {
+        run.set_lower_submittable_to_be_destroyed
+      }.to change { run.analyses.all.all?(&:to_be_destroyed?) }.from(false).to(true)
+    end
 
-      it "does not destroy run if status is :submitted or :running" do
-        expect {
-          @run.destroy
-        }.to_not change { Run.count }
-        expect(@run.status).to eq :cancelled
-        expect(@run.parameter_set).to be_nil
-      end
+    it "makes analyses empty" do
+      run = @sim.runs.first
+      expect {
+        run.set_lower_submittable_to_be_destroyed
+      }.to change { run.analyses.empty? }.from(false).to(true)
+    end
 
-      it "deletes run_directory and archived_result_file when cancel is called" do
-        run_dir = @run.dir
-        archive = @run.archived_result_path
-        FileUtils.touch(archive)
-        @run.destroy
-        expect(File.exist?(run_dir)).to be_falsey
-        expect(File.exist?(archive)).to be_falsey
-      end
+    it "does not destroy analyses" do
+      run = @sim.runs.first
+      expect {
+        run.set_lower_submittable_to_be_destroyed
+      }.to_not change { run.analyses.unscoped.count }
+    end
+  end
 
-      it "does not destroy run even if #destroy is called twice" do
-        expect {
-          @run.destroy
-          @run.destroy
-        }.to_not change { Run.count }
-        expect(@run.status).to eq :cancelled
-      end
+  describe "#destroyable?" do
 
-      it "does not call cancel but destroy when true is given as argument" do
-        ps = @run.parameter_set
-        ps.runs_status_count  # this saves runs_status_count_cache
-        expect {
-          expect(@run).to_not receive(:cancel)
-          expect(@run).to receive(:remove_runs_status_count_cache).and_call_original
-          @run.destroy(true)
-        }.to change { ps.reload.runs_status_count_cache }.to(nil)
-      end
+    before(:each) do
+      @sim = FactoryGirl.create(:simulator,
+                                parameter_sets_count: 1,
+                                runs_count: 1,
+                                analyzers_count: 2,
+                                run_analysis: true
+                                )
+    end
+
+    it "returns false when analyses exists" do
+      run = @sim.runs.first
+      run.set_lower_submittable_to_be_destroyed
+      expect( run.destroyable? ).to be_falsey
+    end
+
+    it "returns true when analyses does not exist" do
+      run = @sim.runs.first
+      run.analyses.unscoped.destroy
+      expect( run.destroyable? ).to be_truthy
     end
   end
 
@@ -541,6 +562,13 @@ describe Run do
       run = @param_set.runs.first
       expect {
         run.update_attribute(:status, :finished)
+      }.to change { @param_set.reload.runs_status_count_cache }.to(nil)
+    end
+
+    it "removes runs_status_count_cache when to_be_destroyed flag is set" do
+      run = @param_set.runs.first
+      expect {
+        run.update_attribute(:to_be_destroyed, true)
       }.to change { @param_set.reload.runs_status_count_cache }.to(nil)
     end
 

--- a/spec/services/job_includer_spec.rb
+++ b/spec/services/job_includer_spec.rb
@@ -204,18 +204,6 @@ describe JobIncluder do
           expect(@submittable.status).to eq :failed
         end
       end
-
-      context "when job is canceled" do
-
-        it "does not try to include work_dir" do
-          make_valid_archive_file(@submittable)
-          FileUtils.rm(@archive_full_path)
-          @submittable.update_attribute(:status, :cancelled)
-          expect {
-            JobIncluder.include_remote_job(@host, @submittable)
-          }.to_not change { @submittable.reload.status }
-        end
-      end
     end
   end
 

--- a/spec/workers/document_destroyer_spec.rb
+++ b/spec/workers/document_destroyer_spec.rb
@@ -23,15 +23,6 @@ describe JobSubmitter do
         DocumentDestroyer.perform(logger)
       }.to_not change { Simulator.unscoped.count }
     end
-
-    it "calls set_lower_submittable_to_be_destroyed when it's not destroyable for 10 times" do
-      sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1)
-      sim.update_attribute(:to_be_destroyed, true)
-      expect_any_instance_of(Simulator).to receive(:set_lower_submittable_to_be_destroyed).once
-      10.times do |t|
-        DocumentDestroyer.perform(logger)
-      end
-    end
   end
 
   describe "destroying Runs" do

--- a/spec/workers/document_destroyer_spec.rb
+++ b/spec/workers/document_destroyer_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+describe JobSubmitter do
+
+  let(:logger) { Logger.new($stderr) }
+
+  describe "destroying Simulator" do
+
+    it "destroys Simulator if it is destroyable" do
+      sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 0)
+
+      sim.update_attribute(:to_be_destroyed, true)
+      expect {
+        DocumentDestroyer.perform(logger)
+      }.to change { Simulator.unscoped.count }.from(1).to(0)
+    end
+
+    it "does not destroy Simulator if it is not destroyable" do
+      sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1)
+
+      sim.update_attribute(:to_be_destroyed, true)
+      expect {
+        DocumentDestroyer.perform(logger)
+      }.to_not change { Simulator.unscoped.count }
+    end
+
+    it "calls set_lower_submittable_to_be_destroyed when it's not destroyable for 10 times" do
+      sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1)
+      sim.update_attribute(:to_be_destroyed, true)
+      expect_any_instance_of(Simulator).to receive(:set_lower_submittable_to_be_destroyed).once
+      10.times do |t|
+        DocumentDestroyer.perform(logger)
+      end
+    end
+  end
+
+  describe "destroying Runs" do
+
+    it "destroys runs if its status is finished or failed and to_be_destroyed" do
+      sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1,
+                               analyzers_count: 0)
+      run = sim.parameter_sets.first.runs.first
+      run.status = :finished
+      run.to_be_destroyed = true
+      run.save!
+      expect {
+        DocumentDestroyer.perform(logger)
+      }.to change { Run.unscoped.count }.by(-1)
+    end
+
+    it "does not destroy if it is not finished or failed" do
+      sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1,
+                               analyzers_count: 0)
+      run = sim.parameter_sets.first.runs.first
+      run.status = :created
+      run.to_be_destroyed = true
+      run.save!
+      expect {
+        DocumentDestroyer.perform(logger)
+      }.to_not change { Run.unscoped.count }
+    end
+  end
+
+  describe "destroying Analysis" do
+
+    it "destroys analyses if its status is finished or failed and to_be_destroyed" do
+      sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1,
+                               analyzers_count: 1, run_analysis: true)
+      anl = sim.parameter_sets.first.runs.first.analyses.first
+      anl.status = :finished
+      anl.to_be_destroyed = true
+      anl.save!
+      expect {
+        DocumentDestroyer.perform(logger)
+      }.to change { Analysis.unscoped.count }.by(-1)
+    end
+
+    it "does not destroy if it is not finished or failed" do
+      sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1,
+                               analyzers_count: 1, run_analysis: true)
+      anl = sim.parameter_sets.first.runs.first.analyses.first
+      anl.status = :created
+      anl.to_be_destroyed = true
+      anl.save!
+      expect {
+        DocumentDestroyer.perform(logger)
+      }.to_not change { Analysis.unscoped.count }
+    end
+  end
+end

--- a/spec/workers/job_observer_spec.rb
+++ b/spec/workers/job_observer_spec.rb
@@ -84,14 +84,13 @@ describe JobObserver do
       skip "not yet implemented"
     end
 
-    context "when run is cancelled" do
+    context "when to_be_destroyed is true" do
 
       before(:each) do
-        @run.status = :cancelled
-        @run.save!
+        @run.update_attribute(:to_be_destroyed, true)
       end
 
-      it "cancelles a remote job" do
+      it "cancels a remote job" do
         expect_any_instance_of(RemoteJobHandler).to receive(:cancel_remote_job) # do nothing
         JobObserver.__send__(:observe_host, @host, @logger)
       end
@@ -100,13 +99,7 @@ describe JobObserver do
         allow_any_instance_of(RemoteJobHandler).to receive(:remote_status) { :includable }
         expect {
           JobObserver.__send__(:observe_host, @host, @logger)
-        }.to change { Run.count }.by(-1)
-      end
-
-      it "does not include remote data even if remote status is 'includable'" do
-        allow_any_instance_of(RemoteJobHandler).to receive(:remote_status) { :includable }
-        expect(JobIncluder).not_to receive(:include_remote_job)
-        JobObserver.__send__(:observe_host, @host, @logger)
+        }.to change { Run.unscoped.count }.by(-1)
       end
     end
 

--- a/spec/workers/job_submitter_spec.rb
+++ b/spec/workers/job_submitter_spec.rb
@@ -64,4 +64,37 @@ describe JobSubmitter do
       skip "not yet implemented"
     end
   end
+
+  describe ".destroy_jobs_to_be_destroyed" do
+
+    before(:each) do
+      @sim = FactoryGirl.create(:simulator,
+                                parameter_sets_count: 1, runs_count: 3
+                                )
+    end
+
+    it "destroys runs whose status is created and to_be_destroyed is true" do
+      @sim.parameter_sets.first.runs.update_all( status: :created, to_be_destroyed: true )
+      expect {
+        JobSubmitter.destroy_jobs_to_be_destroyed
+      }.to change { Run.unscoped.count }.to(0)
+    end
+
+    it "does not destroy if the status is not created" do
+      ps = @sim.parameter_sets.first
+      ps.runs.update_all(status: :finished)
+      ps.reload.runs.first.update_attribute(:status, :created)
+      ps.runs.update_all(to_be_destroyed: true)
+      expect {
+        JobSubmitter.destroy_jobs_to_be_destroyed
+      }.to change { Run.unscoped.count }.from(3).to(2)
+    end
+
+    it "does not destroy if to_be_destroyed is false" do
+      @sim.parameter_sets.first.runs.update_all( status: :created )
+      expect {
+        JobSubmitter.destroy_jobs_to_be_destroyed
+      }.to_not change { Run.unscoped.count }
+    end
+  end
 end

--- a/spec/workers/job_submitter_spec.rb
+++ b/spec/workers/job_submitter_spec.rb
@@ -69,31 +69,33 @@ describe JobSubmitter do
 
     before(:each) do
       @sim = FactoryGirl.create(:simulator,
-                                parameter_sets_count: 1, runs_count: 3
+                                parameter_sets_count: 1, runs_count: 3,
+                                analyzers_count: 0
                                 )
+      @logger = Logger.new($stderr)
     end
 
     it "destroys runs whose status is created and to_be_destroyed is true" do
       @sim.parameter_sets.first.runs.update_all( status: :created, to_be_destroyed: true )
       expect {
-        JobSubmitter.destroy_jobs_to_be_destroyed
+        JobSubmitter.destroy_jobs_to_be_destroyed(@logger)
       }.to change { Run.unscoped.count }.to(0)
     end
 
     it "does not destroy if the status is not created" do
       ps = @sim.parameter_sets.first
       ps.runs.update_all(status: :finished)
-      ps.reload.runs.first.update_attribute(:status, :created)
+      ps.runs.first.update_attribute(:status, :created)
       ps.runs.update_all(to_be_destroyed: true)
       expect {
-        JobSubmitter.destroy_jobs_to_be_destroyed
+        JobSubmitter.destroy_jobs_to_be_destroyed(@logger)
       }.to change { Run.unscoped.count }.from(3).to(2)
     end
 
     it "does not destroy if to_be_destroyed is false" do
       @sim.parameter_sets.first.runs.update_all( status: :created )
       expect {
-        JobSubmitter.destroy_jobs_to_be_destroyed
+        JobSubmitter.destroy_jobs_to_be_destroyed(@logger)
       }.to_not change { Run.unscoped.count }
     end
   end


### PR DESCRIPTION
Runのステータスの更新のタイミングによってRunが適切にdestroyされない問題の修正

### 問題点１
Runのstatusを複数のプロセス（UIまたはCLIとworker）で同時に更新している。cancelledを使ってユーザーによって破棄リクエストが来たという情報を保持しているが、statusの更新のタイミングによって挙動が不安定になる。
解決策としてdestroyのリクエストがあったことをstatusには保持しないようにする。代わりにto_be_destroyed: true というフラグをRunに付与するようにしてUIからはそのフラグをtrueに変更する処理だけを行う。workerでto_be_destroyedのRunを見て、実際にdestroyの処理を行う。
Runのstatusに応じて、それぞれsubmitter, observer, service workerがdestroyするようにする。
実際にdestroy処理をするのはworkerだけに限定することで複数プロセスの競合を防ぐようにする。 

### 問題点２
階層が上のドキュメントがdestroyされた時の挙動について。
PSが削除された時にcallbackでRunやさらに配下のAnalysisのdestroyメソッドが呼ばれる。
現状の仕様ではRunはcancelされた段階でparameter_set: nilをセットし、run_dirを削除している。そのようにしてdirectoryをクリアにした後に、workerによって削除処理をするようにしている。
しかし、ここでも複数プロセスの競合の問題が発生しうる。
workerでRunを処理中にParameterSetが削除された場合、parameter_setを取得しようとしたところで例外が発生する。さらにディレクトリも削除された状態になり、ダウンロード中だった場合に不整合が起きうる。
解決策としてParameterSet, Simulatorなどの上位の要素にもto_be_destroyedフラグをつけて、workerで処理させる。配下のRunまたはAnalysisが削除されたのちに上位の要素を削除する。

## 仕様

### 原則
submittableのstatusに応じて状態を更新できるworkerを分ける。
- created -> Submitter
- submitted, running -> Observer
- finished -> Service Worker
UI,CLIのプロセスはドキュメントの削除を直接行うことはできない。to_be_destroyedをセットして後はworkerに任せる。
statusは必ずcreated -> submitted -> running -> finished or failed の順に更新されていくことになる。

submittable を保持する上位のドキュメント(Simulator,PS,Analyzer,Run) については下層のsubmittableドキュメントが全て削除されてからdestroyを呼ぶ
これらのドキュメントにdestroyable? メソッドを追加し、trueの場合のみ削除。
Simulator,PS,Analyzerの削除はservice workerの仕事とする。

to_be_destroyedフラグをSimulator,ParameterSet,Run,Analysisにつける。削除できるdocumentをまとめると
- submitter : Run(created)
- observer : Run(submitted, running)
- service : Run(finished, failed), ParameterSet, Simulator, Analyzer
となる。

### 処理フロー
- Simulator(PS,Analyzer)の削除がリクエストされた時
  - Controller
    - Simulatorのto_be_destroyedをtrueにする
    - 配下のRun,Analysisが存在すればto_be_destroyedをtrueにする
  - workerが配下のRun,Analysisを順番に削除していく
  - 配下のRun,Analysisが全て削除し終わった段階で、workerがSimulator#destroyで削除。
    - 配下のPSやAnalyzerも削除される。
- Run(Analysis)の削除がリクエストされた時
  - Controllerが
    - Runのto_be_destroyedをtrueにする
    - Analysisのto_be_destroyedもtrueにする
  - 各workerが自分の担当するRunがto_be_destroyedかどうかを判定して削除する

### 実装詳細
- `default_scope ->{ where(:to_be_destroyed.in => [nil,false]) }` を各モデルに導入。
  - 既存のコードから見ると、to_be_destroyed=trueの要素はすでに削除されたように見える
- ある要素の配下の要素すべてにフラグをセットする時は、 `uppdate_all` を使って最適化
