### PR TITLE
A previous host is selected in Host for Auto Run field

### DIFF
--- a/app/views/analyzers/_form.html.haml
+++ b/app/views/analyzers/_form.html.haml
@@ -66,7 +66,8 @@
   .form-group
     = f.label(:auto_run_submitted_to, "Host for Auto Run", class: ['col-md-2','control-label'])
     .col-md-3
-      - host_options = options_for_select( Host.all.map {|h| [h.name, h.id]}.push(["(manual submission)", '']) )
+      - selected_id = analyzer.auto_run_submitted_to ? analyzer.auto_run_submitted_to.id.to_s : nil
+      - host_options = options_for_select( Host.all.map {|h| [h.name, h.id]}.push(["(manual submission)", '']), selected: selected_id)
       = f.select(:auto_run_submitted_to, host_options, {}, {class: 'form-control'})
   .form-group
     .col-md-3.col-md-offset-2


### PR DESCRIPTION
fixed #393 

# 問題
- Host for Auto Runフィールドに以前してしたホストが選択されて表示されない

# 修正
- app/view/runs/_fields.html.hamlを参考に初期値をセット