### PR TITLE
Store log in db

### DIFF
--- a/app/controllers/worker_logs_controller.rb
+++ b/app/controllers/worker_logs_controller.rb
@@ -1,0 +1,5 @@
+class WorkerLogsController < ApplicationController
+  def index
+    @logs = WorkerLog.all.desc('$natural').limit(100)
+  end
+end

--- a/app/controllers/worker_logs_controller.rb
+++ b/app/controllers/worker_logs_controller.rb
@@ -2,4 +2,9 @@ class WorkerLogsController < ApplicationController
   def index
     @logs = WorkerLog.all.desc('$natural').where(l: {'$gt': 0}).limit(100)
   end
+
+  def _contents
+    @logs = WorkerLog.all.desc('$natural').where(l: {'$gt': 0}).limit(100)
+    render partial: 'table_contents', layout: false
+  end
 end

--- a/app/controllers/worker_logs_controller.rb
+++ b/app/controllers/worker_logs_controller.rb
@@ -1,5 +1,5 @@
 class WorkerLogsController < ApplicationController
   def index
-    @logs = WorkerLog.all.desc('$natural').limit(100)
+    @logs = WorkerLog.all.desc('$natural').where(l: {'$gt': 0}).limit(100)
   end
 end

--- a/app/helpers/worker_logs_helper.rb
+++ b/app/helpers/worker_logs_helper.rb
@@ -1,0 +1,2 @@
+module WorkerLogsHelper
+end

--- a/app/models/worker_log.rb
+++ b/app/models/worker_log.rb
@@ -1,0 +1,17 @@
+class WorkerLog
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :w, type: String, as: :worker
+  field :l, type: Integer, as: :level
+  field :m, type: String, as: :message
+
+  SEVERITY = {
+    4 => "FATAL",
+    3 => "ERROR",
+    2 => "WARN",
+    1 => "INFO",
+    0 => "DEBUG"
+  }
+
+end

--- a/app/models/worker_log.rb
+++ b/app/models/worker_log.rb
@@ -1,6 +1,6 @@
 class WorkerLog
   include Mongoid::Document
-  include Mongoid::Timestamps
+  include Mongoid::Timestamps::Created
 
   field :w, type: String, as: :worker
   field :l, type: Integer, as: :level

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -16,5 +16,7 @@
           = link_to 'Analyses', analyses_path
         %li
           = link_to 'Hosts', hosts_path
+        %li
+          = link_to 'Logs', worker_logs_path
       %ul.nav.navbar-nav.navbar-right
         %li= link_to 'Document', 'http://crest-cassia.github.io/oacis/', target: '_blank'

--- a/app/views/worker_logs/_table_contents.html.haml
+++ b/app/views/worker_logs/_table_contents.html.haml
@@ -1,0 +1,7 @@
+- @logs.each do |log|
+  - klass = log.level >= 3 ? :danger : (log.level==2 ? :warning : nil)
+  = content_tag_for :tr, log, class: klass do
+    %td= log.worker
+    %td= log.created_at
+    %td= WorkerLog::SEVERITY[log.level]
+    %td= log.message

--- a/app/views/worker_logs/index.html.haml
+++ b/app/views/worker_logs/index.html.haml
@@ -8,10 +8,4 @@
       %th Severity
       %th Message
   %tbody
-    - @logs.each do |log|
-      - klass = log.level >= 3 ? :danger : (log.level==2 ? :warning : nil)
-      = content_tag_for :tr, log, class: klass do
-        %td= log.worker
-        %td= log.created_at
-        %td= WorkerLog::SEVERITY[log.level]
-        %td= log.message
+    = render "table_contents"

--- a/app/views/worker_logs/index.html.haml
+++ b/app/views/worker_logs/index.html.haml
@@ -1,5 +1,5 @@
 .page-header
-  %h1 WorkerLogs
+  %h1 Logs
 %table.table.table-striped.table-condensed
   %thead
     %tr

--- a/app/views/worker_logs/index.html.haml
+++ b/app/views/worker_logs/index.html.haml
@@ -1,0 +1,17 @@
+.page-header
+  %h1 WorkerLogs
+%table.table.table-striped.table-condensed
+  %thead
+    %tr
+      %th Worker
+      %th Date
+      %th Severity
+      %th Message
+  %tbody
+    - @logs.each do |log|
+      - klass = log.level >= 3 ? :danger : (log.level==2 ? :warning : nil)
+      = content_tag_for :tr, log, class: klass do
+        %td= log.worker
+        %td= log.created_at
+        %td= WorkerLog::SEVERITY[log.level]
+        %td= log.message

--- a/app/views/worker_logs/index.html.haml
+++ b/app/views/worker_logs/index.html.haml
@@ -7,5 +7,17 @@
       %th Date
       %th Severity
       %th Message
-  %tbody
+  %tbody#log_table_body
     = render "table_contents"
+
+:javascript
+  $(function() {
+    function reload_table() {
+      $.get("/worker_logs/_contents", function(data) {
+        $('#log_table_body').html(data);
+      });
+    };
+    setInterval( function() {
+      reload_table();
+    }, 5000 );
+  });

--- a/app/workers/cache_updater.rb
+++ b/app/workers/cache_updater.rb
@@ -2,9 +2,10 @@ class CacheUpdater
   MAX_PS_NUM_TO_UPDATE = 10
 
   def self.perform(logger)
-    logger.info "updating cache for parameter sets"
+    logger.debug "updating cache for parameter sets"
     ParameterSet.or(progress_rate_cache: nil).or(runs_status_count_cache: nil).order_by(:updated_at.asc).limit(MAX_PS_NUM_TO_UPDATE).each do |ps|
       ps.runs_status_count
+      logger.info "updated cache for ParameterSet: #{ps.id}"
     end
   rescue => ex
     logger.error("Error in CacheUpdater: #{ex.inspect}")

--- a/app/workers/document_destroyer.rb
+++ b/app/workers/document_destroyer.rb
@@ -4,17 +4,17 @@ class DocumentDestroyer
     @skip_count ||= {}
     @logger = logger
 
-    @logger.info "looking for Simulator to be destroyed"
+    @logger.debug "looking for Simulator to be destroyed"
     destroy_documents( Simulator.where(to_be_destroyed: true) )
-    @logger.info "looking for ParameterSet to be destroyed"
+    @logger.debug "looking for ParameterSet to be destroyed"
     destroy_documents( ParameterSet.where(to_be_destroyed: true) )
-    @logger.info "looking for Analyzer to be destroyed"
+    @logger.debug "looking for Analyzer to be destroyed"
     destroy_documents( Analyzer.where(to_be_destroyed: true) )
-    @logger.info "looking for Run to be destroyed"
+    @logger.debug "looking for Run to be destroyed"
     destroy_documents(
       Run.where(:to_be_destroyed => true, :status.in => [:finished, :failed])
     )
-    @logger.info "looking for Analysis to be destroyed"
+    @logger.debug "looking for Analysis to be destroyed"
     destroy_documents(
       Analysis.where(:to_be_destroyed => true, :status.in => [:finished, :failed])
     )
@@ -26,11 +26,11 @@ class DocumentDestroyer
   def self.destroy_documents(query)
     query.each do |obj|
       if obj.destroyable?
-        @logger.info "Destroying #{obj.class} #{obj.id}"
+        @logger.info "destroying #{obj.class} #{obj.id}"
         obj.destroy
         @skip_count.delete(obj.id)
       else
-        @logger.info "Skip destroying #{obj.class} #{obj.id}. not destroyable yet."
+        @logger.info "skip destroying #{obj.class} #{obj.id}. not destroyable yet."
       end
     end
   end

--- a/app/workers/job_observer.rb
+++ b/app/workers/job_observer.rb
@@ -5,8 +5,8 @@ class JobObserver
     Host.where(status: :enabled).each do |host|
       break if $term_received
       next if DateTime.now.to_i - @last_performed_at[host.id].to_i < host.polling_interval
+      logger.debug("observing #{host.name}")
       begin
-        logger.info("observing #{host.name}")
         observe_host(host, logger)
       rescue => ex
         logger.error("Error in JobObserver: #{ex.inspect}")
@@ -40,7 +40,7 @@ class JobObserver
       handler.cancel_remote_job(job)
       logger.info("canceled remote job: #{job.class}:#{job.id} from #{host.name}")
       job.destroy
-      logger.info("Destroyed #{job.class} #{job.id}")
+      logger.info("destroyed #{job.class} #{job.id}")
       return
     end
     case handler.remote_status(job)
@@ -63,9 +63,9 @@ class JobObserver
     b = true
     if rate > 0.95
       b = false
-      logger.error("Error: No enough space left on device.")
+      logger.error("no enough space left on device.")
     elsif rate > 0.9
-      logger.warn("Warn: Too little space left on device.")
+      logger.warn("little space left on device.")
     end
     b
   end

--- a/app/workers/job_observer_worker.rb
+++ b/app/workers/job_observer_worker.rb
@@ -2,6 +2,7 @@ class JobObserverWorker < Worker
 
   INTERVAL = 5
 
+  WORKER_ID = :observer
   WORKER_PID_FILE = Rails.root.join('tmp', 'pids', "job_observer_worker.pid")
   WORKER_LOG_FILE = Rails.root.join('log', "job_observer_worker.log")
   WORKER_STDOUT_FILE = Rails.root.join('log', "job_observer_worker_out.log")

--- a/app/workers/job_submitter.rb
+++ b/app/workers/job_submitter.rb
@@ -12,6 +12,7 @@ class JobSubmitter
           break if $term_received
           break unless num > 0
           analyses = host.submittable_analyses.where(priority: priority).limit(num)
+          WorkerLog.create({w: :submitter, l: 1, m: "submitting jobs to #{host.name}"} )
           logger.info("submitting jobs to #{host.name}: #{analyses.map do |r| r.id.to_s end.inspect}")
           num -= analyses.length  # [warining] analyses.length ignore 'limit', so 'num' can be negative.
           submit(analyses, host, logger) if analyses.present?

--- a/app/workers/job_submitter_worker.rb
+++ b/app/workers/job_submitter_worker.rb
@@ -2,6 +2,7 @@ class JobSubmitterWorker < Worker
 
   INTERVAL = 5
 
+  WORKER_ID = :submitter
   WORKER_PID_FILE = Rails.root.join('tmp', 'pids', "job_submitter_worker.pid")
   WORKER_LOG_FILE = Rails.root.join('log', "job_submitter_worker.log")
   WORKER_STDOUT_FILE = Rails.root.join('log', "job_submitter_worker_out.log")

--- a/app/workers/logger_for_worker.rb
+++ b/app/workers/logger_for_worker.rb
@@ -1,0 +1,33 @@
+class LoggerForWorker
+
+  def initialize(worker_type, logdev, shift_age=0, shift_size=1048576)
+    @type = worker_type
+    @logger = Logger.new(logdev, shift_age, shift_size)
+    @logger.formatter = LoggerFormatWithTime.new
+    @logger.level = Logger::INFO
+  end
+
+  def debug(message)
+    @logger.debug(message)
+  end
+
+  def info(message)
+    @logger.info(message)
+    WorkerLog.create({worker: @type, level: 1, message: message})
+  end
+
+  def warn(message)
+    @logger.warn(message)
+    WorkerLog.create({worker: @type, level: 2, message: message})
+  end
+
+  def error(message)
+    @logger.error(message)
+    WorkerLog.create({worker: @type, level: 3, message: message})
+  end
+
+  def fatal(message)
+    @logger.fatal(message)
+    WorkerLog.create({worker: @type, level: 4, message: message})
+  end
+end

--- a/app/workers/logger_for_worker.rb
+++ b/app/workers/logger_for_worker.rb
@@ -4,7 +4,7 @@ class LoggerForWorker
     @type = worker_type
     @logger = Logger.new(logdev, shift_age, shift_size)
     @logger.formatter = LoggerFormatWithTime.new
-    @logger.level = Logger::INFO
+    @logger.level = Logger::DEBUG
   end
 
   def debug(message)

--- a/app/workers/service_worker.rb
+++ b/app/workers/service_worker.rb
@@ -2,6 +2,7 @@ class ServiceWorker < Worker
 
   INTERVAL = 5
 
+  WORKER_ID = :service
   WORKER_PID_FILE = Rails.root.join('tmp', 'pids', "service_worker.pid")
   WORKER_LOG_FILE = Rails.root.join('log', "service_worker.log")
   WORKER_STDOUT_FILE = Rails.root.join('log', "service_worker_out.log")

--- a/app/workers/worker.rb
+++ b/app/workers/worker.rb
@@ -14,7 +14,7 @@ class Worker < DaemonSpawn::Base
     $term_received = false
     trap('TERM') {
       $term_received = true
-      @logger.info("TERM received. stopping")
+      puts "TERM received. stopping"
     }
 
     loop do

--- a/app/workers/worker.rb
+++ b/app/workers/worker.rb
@@ -8,9 +8,7 @@ class Worker < DaemonSpawn::Base
   #   - TASKS
 
   def start(args)
-    @logger = Logger.new(self.class::WORKER_LOG_FILE, 7)
-    @logger.formatter = LoggerFormatWithTime.new
-    @logger.level = Logger::INFO
+    @logger = LoggerForWorker.new(self.class::WORKER_ID, self.class::WORKER_LOG_FILE, 7)
     @logger.info("starting #{self.class}")
 
     $term_received = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 AcmProto::Application.routes.draw do
 
-  resources :worker_logs, only: ['index']
+  resources :worker_logs, only: ['index'] do
+    collection do
+      get "_contents"
+    end
+  end
 
   resources :runs, only: ["index"] do
     collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 AcmProto::Application.routes.draw do
 
+  resources :worker_logs, only: ['index']
+
   resources :runs, only: ["index"] do
     collection do
       get "_jobs_table" # for ajax, datatables

--- a/lib/tasks/update_schema.rake
+++ b/lib/tasks/update_schema.rake
@@ -42,5 +42,13 @@ namespace :db do
       anl.destroy
       progressbar.increment
     end
+
+    session = Mongoid::Sessions.default
+    if session.collections.find {|col| col.name== "worker_logs" }
+      raise "collection is not capped" unless session["worker_logs"].capped?
+    else
+      session.command(create: "worker_logs", capped: true, size: 1048576)
+      $stderr.puts "capped collection worker_logs was created"
+    end
   end
 end

--- a/spec/controllers/worker_logs_controller_spec.rb
+++ b/spec/controllers/worker_logs_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require 'spec_helper'
 
 RSpec.describe WorkerLogsController, type: :controller do
 

--- a/spec/controllers/worker_logs_controller_spec.rb
+++ b/spec/controllers/worker_logs_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe WorkerLogsController, type: :controller do
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
Runを作ったときに裏側で何が起きているか心理的に不安になるので、workerのログをウェブのUIから確認できるようにした。

workerのログをログファイルに加えてDBにも保存するようにした。
cappedコレクションを用いてログを保存するようにした。ログ保存用途のコレクションで、ログの容量が溢れるのを防ぎ、単純な追加であればパフォーマンスも良い。

update_schema内で、worker_logsというコレクションを作成する。以後は通常のコレクションと同様にWorkerLogクラスを利用して参照することができる。

![image](https://cloud.githubusercontent.com/assets/718731/11553162/71594c52-99cf-11e5-8f82-98d3d8ddba37.png)

テーブルの中身は定期的にajaxで更新される。
