### PR TITLE
improved the speed of unit tests

### DIFF
--- a/spec/lib/cli/oacis_cli_run_spec.rb
+++ b/spec/lib/cli/oacis_cli_run_spec.rb
@@ -100,7 +100,6 @@ describe OacisCli do
                                 parameter_sets_count: 2, runs_count: 0,
                                 support_mpi: true, support_omp: true)
       @sim.executable_on.push @host
-      @sim.save!
     end
 
     def create_parameter_set_ids_json(parameter_sets, path)
@@ -205,9 +204,13 @@ describe OacisCli do
 
       before(:each) do
         @ps1 = @sim.parameter_sets.first
-        FactoryGirl.create_list(:run, 5, parameter_set: @ps1)
+        FactoryGirl.create_list(:run, 5, parameter_set: @ps1, submitted_to: @host,
+                                host_parameters: {"param1" => "XXX", "param2" => "YYY"}
+                                )
         @ps2 = @sim.parameter_sets[1]
-        FactoryGirl.create_list(:run, 1, parameter_set: @ps2)
+        FactoryGirl.create_list(:run, 1, parameter_set: @ps2, submitted_to: @host,
+                                host_parameters: {"param1" => "XXX", "param2" => "YYY"}
+                                )
       end
 
       it "iterates creation of runs up to the specified number" do

--- a/spec/lib/job_script_util_spec.rb
+++ b/spec/lib/job_script_util_spec.rb
@@ -457,8 +457,9 @@ end
 context "for Run" do
 
   before(:each) do
-    sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1)
-    host = Host.where(name: "localhost").first
+    sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1,
+                             ssh_host: true)
+    host = sim.executable_on.first #Host.where(name: "localhost").first
     sim.update_attribute(:executable_on, [host])
     run = sim.parameter_sets.first.runs.first
     @executable = sim
@@ -481,10 +482,11 @@ context "for Analysis" do
   before(:each) do
     sim = FactoryGirl.create(:simulator,
       parameter_sets_count: 1, runs_count: 1,
-      analyzers_count: 1, run_analysis: false
+      analyzers_count: 1, run_analysis: false,
+      ssh_host: true
       )
     run = sim.parameter_sets.first.runs.first
-    host = Host.where(name: "localhost").first
+    host = sim.executable_on.first #Host.where(name: "localhost").first
     azr = sim.analyzers.first
     azr.update_attribute(:executable_on, [host])
     anl = run.analyses.create(analyzer: azr, submitted_to: host)

--- a/spec/services/job_includer_spec.rb
+++ b/spec/services/job_includer_spec.rb
@@ -212,7 +212,9 @@ describe JobIncluder do
     before(:each) do
       @executable = FactoryGirl.create(:simulator,
                                        parameter_sets_count: 1, runs_count: 0,
-                                       command: "echo")
+                                       command: "echo",
+                                       ssh_host: true
+                                       )
       @host = @executable.executable_on.where(name: "localhost").first
       @temp_dir = Pathname.new( Dir.mktmpdir )
       @host.update_attribute(:work_base_dir, @temp_dir.expand_path)
@@ -232,7 +234,9 @@ describe JobIncluder do
     before(:each) do
       sim = FactoryGirl.create(:simulator,
                                parameter_sets_count: 1, runs_count: 1,
-                               analyzers_count: 1, run_analysis: false)
+                               analyzers_count: 1, run_analysis: false,
+                               ssh_host: true
+                               )
       run = sim.parameter_sets.first.runs.first
       azr = sim.analyzers.first
       anl = run.analyses.build(analyzer: azr)

--- a/spec/services/remote_job_handler_spec.rb
+++ b/spec/services/remote_job_handler_spec.rb
@@ -347,7 +347,9 @@ describe "for Run" do
   before(:each) do
     sim = FactoryGirl.create(:simulator,
                               command: "echo",
-                              parameter_sets_count: 1, runs_count: 1)
+                              parameter_sets_count: 1, runs_count: 1,
+                              ssh_host: true
+                              )
     run = sim.parameter_sets.first.runs.first
     host = sim.executable_on.where(name: "localhost").first
     @temp_dir = Pathname.new( Dir.mktmpdir )
@@ -376,7 +378,8 @@ describe "for Analysis" do
     sim = FactoryGirl.create(:simulator,
                               command: "echo",
                               parameter_sets_count: 1, runs_count: 1,
-                              analyzers_count: 1, run_analysis: false
+                              analyzers_count: 1, run_analysis: false,
+                              ssh_host: true
                               )
     run = sim.parameter_sets.first.runs.first
     azr = sim.analyzers.first

--- a/spec/workers/job_observer_spec.rb
+++ b/spec/workers/job_observer_spec.rb
@@ -6,7 +6,9 @@ describe JobObserver do
 
     before(:each) do
       @sim = FactoryGirl.create(:simulator,
-                                parameter_sets_count: 1, runs_count: 1)
+                                parameter_sets_count: 1, runs_count: 1,
+                                ssh_host: true
+                                )
       @temp_dir = Pathname.new('__temp__')
       FileUtils.mkdir_p(@temp_dir)
       @host = @sim.executable_on.where(name: "localhost").first
@@ -41,7 +43,9 @@ describe JobObserver do
 
     before(:each) do
       @sim = FactoryGirl.create(:simulator,
-                                parameter_sets_count: 1, runs_count: 1)
+                                parameter_sets_count: 1, runs_count: 1,
+                                ssh_host: true
+                                )
       @temp_dir = Pathname.new('__temp__')
       FileUtils.mkdir_p(@temp_dir)
       @host = @sim.executable_on.where(name: "localhost").first

--- a/spec/workers/job_submitter_spec.rb
+++ b/spec/workers/job_submitter_spec.rb
@@ -11,7 +11,8 @@ describe JobSubmitter do
       @host.work_base_dir = @temp_dir.expand_path
       @host.save!
 
-      @sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1)
+      @sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1,
+                                ssh_host: true)
       @sim.executable_on.push @host
       @sim.save!
 


### PR DESCRIPTION
rspecの実行速度を改善

Factoryの中でhostを作るときにlocalhostにssh接続をしている点が問題だった。
ssh接続をしないhostを作る挙動をデフォルトにして、sshが必要なテストに対してのみssh接続をするhostを作るように変更。

全specの実行時間が20分前後から10分に短縮。
modelとcontrollerのテストが特に速くなっている。
