### PR TITLE
Bugfix create ps cli cast parameters

### DIFF
--- a/lib/cli/oacis_cli_parameter_set.rb
+++ b/lib/cli/oacis_cli_parameter_set.rb
@@ -162,7 +162,7 @@ class OacisCli < Thor
     end
     list_created_ps = {}
     ParameterSet.collection.aggregate(
-      { '$match' => {'v' => {'$in'=>input}} },
+      { '$match' => {'simulator_id' => simulator.id, 'v' => {'$in'=>input}} },
       { '$group' => {'_id' => '$_id', v: {'$first' => '$v'}} }
     ).each do |psid_v|
       list_created_ps[psid_v['v']]=psid_v['_id']

--- a/lib/cli/oacis_cli_parameter_set.rb
+++ b/lib/cli/oacis_cli_parameter_set.rb
@@ -60,7 +60,7 @@ class OacisCli < Thor
     end
 
     parameter_set_ids = []
-    input.each_with_index.map do |psid_value|
+    input.each do |psid_value|
       ps_value = psid_value[:value]
       progressbar.log "  parameter values : #{ps_value.inspect}" if options[:verbose]
       param_set = simulator.parameter_sets.build({v: ps_value, skip_check_uniquness: true})

--- a/spec/lib/cli/oacis_cli_parameter_set_spec.rb
+++ b/spec/lib/cli/oacis_cli_parameter_set_spec.rb
@@ -217,6 +217,22 @@ describe OacisCli do
       end
     end
 
+    context "when PS with identical v exists under a different simulator" do
+
+      before(:each) do
+        s2 = FactoryGirl.create(:simulator, parameter_sets_count: 0, analyzers_count: 0)
+        s2.parameter_sets.create(v: {"L" => 10, "T" => 0.1})
+      end
+
+      it "creates parameter sets" do
+        at_temp_dir {
+          expect {
+            invoke_create_parameter_sets
+          }.to change { @sim.parameter_sets.count }.by(6)
+        }
+      end
+    end
+
     context "when input parameter_sets is specified as object" do
 
       def create_parameter_sets_json2(path)


### PR DESCRIPTION
CLIでPSを作る時に、異なるSimulatorに同じvを持つPSが存在する場合に重複と誤判定されてPSが作られない。
ParameterSetの重複チェックのqueryが正しくなかった。
