### PR TITLE
Set sequential seed

### DIFF
--- a/app/controllers/simulators_controller.rb
+++ b/app/controllers/simulators_controller.rb
@@ -183,6 +183,7 @@ class SimulatorsController < ApplicationController
                                                 :support_input_json,
                                                 :support_omp,
                                                 :support_mpi,
+                                                :sequential_seed,
                                                 :print_version_command,
                                                 parameter_definitions_attributes: [[:id, :key, :type, :default, :description]],
                                                 executable_on_ids: []

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -12,14 +12,10 @@ class Run
 
   default_scope ->{ where(:to_be_destroyed.in => [nil,false]) }
 
-  # validations
-  validates :seed, presence: true
-
   # do not write validations for the presence of association
   # because it can be slow. See http://mongoid.org/en/mongoid/docs/relations.html
 
-  before_validation :set_unique_seed
-  before_create :set_simulator
+  before_create :set_unique_seed, :set_simulator
   before_save :remove_runs_status_count_cache, :if => Proc.new {|run| run.status_changed? or run.to_be_destroyed_changed? }
   after_create :create_run_dir
   before_destroy :delete_run_dir, :delete_archived_result_file,

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -18,6 +18,7 @@ class Run
   # do not write validations for the presence of association
   # because it can be slow. See http://mongoid.org/en/mongoid/docs/relations.html
 
+  before_validation :set_unique_seed
   before_create :set_simulator
   before_save :remove_runs_status_count_cache, :if => Proc.new {|run| run.status_changed? or run.to_be_destroyed_changed? }
   after_create :create_run_dir
@@ -25,11 +26,6 @@ class Run
                  :remove_runs_status_count_cache
 
   public
-  def initialize(*arg)
-    super
-    set_unique_seed
-  end
-
   def simulator
     set_simulator if simulator_id.nil?
     if simulator_id

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -102,8 +102,15 @@ class Run
 
   def set_unique_seed
     unless seed
-      counter_epoch = self.id.to_s[-6..-1] + self.id.to_s[0..7]
-      self.seed = counter_epoch.hex % (2**31-1)
+      if simulator.sequential_seed
+        seeds = parameter_set.reload.runs.asc(:seed).only(:seed).map {|r| r.seed }
+        found = seeds.each_with_index.find {|seed,idx| seed != idx + 1 }
+        next_seed = found ? found[1] + 1 : seeds.last.to_i + 1
+        self.seed = next_seed
+      else
+        counter_epoch = self.id.to_s[-6..-1] + self.id.to_s[0..7]
+        self.seed = counter_epoch.hex % (2**31-1)
+      end
     end
   end
 

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -5,6 +5,7 @@ class Simulator
 
   field :name, type: String
   field :description, type: String
+  field :sequential_seed, type: Boolean, default: false
   field :position, type: Integer # position in the table. start from zero
   field :to_be_destroyed, type: Boolean, default: false
   embeds_many :parameter_definitions

--- a/app/views/simulators/_about.html.haml
+++ b/app/views/simulators/_about.html.haml
@@ -21,6 +21,9 @@
       %th Support OMP
       %td= simulator.support_omp ? "Yes" : "No"
     %tr
+      %th Sequential Seed
+      %td= simulator.sequential_seed ? "Yes" : "No"
+    %tr
       %th Executable On
       %td= raw( simulator.executable_on.map {|host| h(host.name) }.join('<br />') )
 

--- a/app/views/simulators/_form.html.haml
+++ b/app/views/simulators/_form.html.haml
@@ -52,6 +52,12 @@
         %label
           = f.check_box(:support_omp)
   .form-group
+    = f.label(:sequential_seed, class: ['col-md-2','control-label'])
+    .col-md-2
+      .checkbox
+        %label
+          = f.check_box(:sequential_seed)
+  .form-group
     = f.label(:description, class: ['col-md-2','control-label'])
     .col-md-6
       = f.text_area(:description, rows: 5, class: 'form-control')

--- a/spec/controllers/parameter_sets_controller_spec.rb
+++ b/spec/controllers/parameter_sets_controller_spec.rb
@@ -168,6 +168,18 @@ describe ParameterSetsController do
           }.to change { Run.count }.by(6)
         end
 
+        context "when sequential_seed is true" do
+
+          it "creates multiple parameter sets with sequential seeds" do
+            @valid_param.update(v: {"L" => "1", "T" => "1.0, 2.0"},
+                                num_runs: 3, run: {submitted_to: Host.first} )
+            post :create, @valid_param, valid_session
+            @sim.parameter_sets.each do |ps|
+              expect( ps.runs.map(&:seed) ).to match_array [1,2,3]
+            end
+          end
+        end
+
         describe "when some of parameter_sets are already created" do
 
           before(:each) do

--- a/spec/controllers/simulators_controller_spec.rb
+++ b/spec/controllers/simulators_controller_spec.rb
@@ -138,6 +138,7 @@ describe SimulatorsController do
         simulator = {
           name: "simulatorA", command: "echo", support_input_json: "0",
           support_mpi: "0", support_omp: "1",
+          sequential_seed: "1",
           parameter_definitions_attributes: definitions,
           executable_on_ids: [host.id.to_s]
         }
@@ -160,6 +161,7 @@ describe SimulatorsController do
         expect(sim.parameter_definition_for("param2").type).to eq "Float"
         expect(sim.support_mpi).to be_falsey
         expect(sim.support_omp).to be_truthy
+        expect(sim.sequential_seed).to be_truthy
       end
 
       it "assigns a newly created simulator as @simulator" do
@@ -274,6 +276,7 @@ describe SimulatorsController do
         @valid_post_parameter = {
           name: "simulatorA", command: "echo", support_input_json: "0",
           support_mpi: "0", support_omp: "1",
+          sequential_seed: "1",
           parameter_definitions_attributes: definitions
         }
       end
@@ -292,6 +295,7 @@ describe SimulatorsController do
         expect(assigns(:simulator).support_input_json).to be_falsey
         expect(assigns(:simulator).support_mpi).to be_falsey
         expect(assigns(:simulator).support_omp).to be_truthy
+        expect(assigns(:simulator).sequential_seed).to be_truthy
       end
 
       it "redirects to the simulator" do

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -57,7 +57,7 @@ describe Run do
     end
 
     it "seeds must be less than 2**31-1" do
-      run = @param_set.runs.build
+      run = @param_set.runs.create
       expect( run.seed ).to be < 2**31
     end
 

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -37,30 +37,6 @@ describe Run do
       expect(run.status).to eq(:created)
     end
 
-    it "assigns a seed by default" do
-      run = @param_set.runs.create
-      expect(run.seed).to be_a(Integer)
-    end
-
-    it "automatically assigned seeds are unique" do
-      seeds = []
-      n = 10
-      n.times do |i|
-        run = @param_set.runs.create
-        seeds << run.seed
-      end
-      expect(seeds.uniq.size).to eq(n)
-    end
-
-    it "seed must be unique" do
-      skip "it is no longer needed because seed is defined by unique bson object id."
-    end
-
-    it "seeds must be less than 2**31-1" do
-      run = @param_set.runs.create
-      expect( run.seed ).to be < 2**31
-    end
-
     it "status must be either :created, :submitted, :running, :failed, or :finished" do
       run = @param_set.runs.build(@valid_attribute)
       run.status = :unknown
@@ -127,6 +103,54 @@ describe Run do
     it "automatically assigned priority is 1" do
       run = @param_set.runs.create
       expect(run.priority).to eq 1
+    end
+
+    describe "seed" do
+      it "assigns a seed by default" do
+        run = @param_set.runs.create
+        expect(run.seed).to be_a(Integer)
+      end
+
+      it "automatically assigned seeds are unique" do
+        seeds = []
+        n = 10
+        n.times do |i|
+          run = @param_set.runs.create
+          seeds << run.seed
+        end
+        expect(seeds.uniq.size).to eq(n)
+      end
+
+      it "seeds must be less than 2**31-1" do
+        run = @param_set.runs.create
+        expect( run.seed ).to be < 2**31
+      end
+
+      context "when Simulator#sequential_seed is true" do
+
+        before(:each) do
+          @simulator.update_attribute(:sequential_seed, true)
+          @param_set.runs.destroy
+        end
+
+        it "creates seed in sequential order starting from one" do
+          3.times do |i|
+            run = @param_set.runs.create
+            expect(run.seed).to eq i+1
+          end
+        end
+
+        it "does not override when seed is explicitly specified" do
+          run = @param_set.runs.create(seed: 2)
+          expect( run.seed ).to eq 2
+          seeds = []
+          3.times do |i|
+            r = @param_set.runs.create
+            seeds << r.seed
+          end
+          expect( seeds ).to eq [1,3,4]
+        end
+      end
     end
 
     describe "'host_parameters' field" do


### PR DESCRIPTION
### 概要
複数のParameterSetで同じseedを使って比較を行いたい場合がある。
Simulatorに sequential_seed フラグを追加し、そのフラグが立っている場合には乱数の種を1,2,3...というように自然数で順番に与えるようにする。

### 実装
- `Simulator#sequential_seed` フラグを追加
- Runの `before_create` callbackでseedをセットするようにする
  - その際にSimualtor#sequential_seedフラグによって挙動を変え、trueの場合は「そのPSで使用されていない最も小さい自然数（１以上）」の値をseedとしてセットするようにする
- PSをバッチで作る場合には、各Runの作成時にQueryが流れるのでパフォーマンス上の懸念がある。
  - Web UIからバッチ作成するときのみ少し対策をした。（効果はあまりちゃんと測定していない）
  - CLIの場合はプログレスバーが出力されるので、特に対策を行わない
