### PR TITLE
Create analysis by cli with job params

### DIFF
--- a/lib/cli/oacis_cli_analysis.rb
+++ b/lib/cli/oacis_cli_analysis.rb
@@ -213,14 +213,17 @@ class OacisCli < Thor
       anl_ids = analyses.only(:id).map(&:id)
       anl_ids.each do |anlid|
         anl = Analysis.find(anlid)
+        anl_attr = { analyzer: anl.analyzer,
+                     submitted_to: anl.submitted_to,
+                     mpi_procs: anl.mpi_procs,
+                     omp_threads: anl.omp_threads,
+                     host_parameters: anl.host_parameters,
+                     priority: anl.priority,
+                     parameters: anl.parameters }
         if anl.analyzable_type == "Run"
-          new_analysis = Run.find(anl.analyzable_id).analyses.build
-          new_analysis.parameters = anl.parameters
-          new_analysis.analyzer_id = anl.analyzer_id
+          new_analysis = Run.find(anl.analyzable_id).analyses.build(anl_attr)
         elsif anl.analyzable_type == "ParameterSet"
-          new_analysis = ParameterSet.find(anl.analyzable_id).analyses.build
-          new_analysis.parameters = anl.parameters
-          new_analysis.analyzer_id = anl.analyzer_id
+          new_analysis = ParameterSet.find(anl.analyzable_id).analyses.build(anl_attr)
         end
         if new_analysis.save
           anl.update_attribute(:to_be_destroyed, true)

--- a/lib/cli/oacis_cli_analysis.rb
+++ b/lib/cli/oacis_cli_analysis.rb
@@ -89,19 +89,7 @@ class OacisCli < Thor
     end
     created_analyses = analyses.select {|anl| anl.persisted? == false }
 
-    job_parameters = load_json_file_or_string(options[:job_parameters])
-    submitted_to = job_parameters["host_id"] ? Host.find(job_parameters["host_id"]) : nil
-    host_parameters = job_parameters["host_parameters"].to_hash
-    mpi_procs = job_parameters["mpi_procs"]
-    omp_threads = job_parameters["omp_threads"]
-    priority = job_parameters["priority"]
-    created_analyses.each do |anl|
-      anl.submitted_to = submitted_to
-      anl.host_parameters = host_parameters
-      anl.mpi_procs = mpi_procs
-      anl.omp_threads = omp_threads
-      anl.priority = priority
-    end
+    set_job_parameters(created_analyses, options[:job_parameters])
 
     progressbar = ProgressBar.create(total: created_analyses.size, format: "%t %B %p%% (%c/%C)")
     if options[:verbose]
@@ -137,6 +125,22 @@ class OacisCli < Thor
       io.puts "[", ids.join(",\n"), "]"
       io.flush
     }
+  end
+
+  def set_job_parameters(analyses, job_param_json_path)
+    job_parameters = load_json_file_or_string( job_param_json_path )
+    submitted_to = job_parameters["host_id"] ? Host.find(job_parameters["host_id"]) : nil
+    host_parameters = job_parameters["host_parameters"].to_hash
+    mpi_procs = job_parameters["mpi_procs"]
+    omp_threads = job_parameters["omp_threads"]
+    priority = job_parameters["priority"]
+    analyses.each do |anl|
+      anl.submitted_to = submitted_to
+      anl.host_parameters = host_parameters
+      anl.mpi_procs = mpi_procs
+      anl.omp_threads = omp_threads
+      anl.priority = priority
+    end
   end
 
   public

--- a/lib/cli/oacis_cli_run.rb
+++ b/lib/cli/oacis_cli_run.rb
@@ -73,7 +73,6 @@ class OacisCli < Thor
     mpi_procs = job_parameters["mpi_procs"]
     omp_threads = job_parameters["omp_threads"]
     priority = job_parameters["priority"]
-    puts "set job param"
 
     run_ids = create_runs_impl(parameter_sets, num_runs, submitted_to, host_parameters, mpi_procs, omp_threads, priority, seeds)
 

--- a/lib/cli/oacis_cli_run.rb
+++ b/lib/cli/oacis_cli_run.rb
@@ -223,7 +223,8 @@ class OacisCli < Thor
         run_attr = { submitted_to: run.submitted_to,
                      mpi_procs: run.mpi_procs,
                      omp_threads: run.omp_threads,
-                     host_parameters: run.host_parameters }
+                     host_parameters: run.host_parameters,
+                     priority: run.priority }
         new_run = run.parameter_set.runs.build(run_attr)
         if new_run.save
           run.update_attribute(:to_be_destroyed, true)

--- a/spec/lib/cli/oacis_cli_run_spec.rb
+++ b/spec/lib/cli/oacis_cli_run_spec.rb
@@ -497,7 +497,7 @@ describe OacisCli do
       @sim = FactoryGirl.create(:simulator,
                                 parameter_sets_count: 1, runs_count: 0)
       ps = @sim.parameter_sets.first
-      FactoryGirl.create(:finished_run, parameter_set: ps, mpi_procs: 8)
+      FactoryGirl.create(:finished_run, parameter_set: ps, mpi_procs: 8, priority: 0)
         .update_attribute(:simulator_version, "1.0.0")
       FactoryGirl.create(:finished_run, parameter_set: ps, mpi_procs: 4)
         .update_attribute(:simulator_version, "1.0.1")
@@ -509,7 +509,9 @@ describe OacisCli do
         expect {
           OacisCli.new.invoke(:replace_runs, [], options)
         }.to change { Run.where(status: :created).count }.by(1)
-        expect(Run.where(status: :created).first.mpi_procs).to eq 8
+        new_run = Run.where(status: :created).first
+        expect(new_run.mpi_procs).to eq 8
+        expect(new_run.priority).to eq 0
       }
     end
 


### PR DESCRIPTION
- create_analysesのCLIでjob_parameter (submitted_to, mpi_procs, omp_threads, host_parameters, priority) を指定する方法が提供されていなかったので実装
    - job_parameter_template のCLIで出力されるJSONを利用できるようにした
- replace_analyses でもこれらのパラメータが継承されるように実装

- また不具合修正も一緒に対応
    - Runでreplace_runsを実行した時にpriorityが継承されない
