### PR TITLE
Copy specified files when analyzing

### DIFF
--- a/app/controllers/analyzers_controller.rb
+++ b/app/controllers/analyzers_controller.rb
@@ -101,6 +101,7 @@ class AnalyzersController < ApplicationController
                                                :command,
                                                :description,
                                                :auto_run,
+                                               :files_to_copy,
                                                :print_version_command,
                                                :simulator,
                                                :support_input_json,

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -70,24 +70,24 @@ class Analysis
     end
   end
 
-  # returns an array
-  #   array of run.results_paths or run.dir(s) to be linked to _input/
+  # returns an array of
+  #   [ absolute input path, destination relative path ]
   def input_files
-    files = []
-    case self.analyzer.type
+    pattern = analyzer.files_to_copy.chomp.gsub("\n", "\0")
+    case analyzer.type
     when :on_run
       run = self.analyzable
-      files = run.result_paths
-      # TODO: add directories of dependent analysis
+      matched = run.result_paths(pattern)
+      matched.map {|path| [ path, path.relative_path_from(run.dir) ] }
     when :on_parameter_set
       ps = self.analyzable
-      run_ids = ps.runs.where(status: :finished).only(:id).map {|run| run.id.to_s}
-      base_dir = ps.runs.where(status: :finished).first.dir.join('../')
-      files = run_ids.map {|run_id| base_dir.join(run_id)}
+      ps.runs.where(status: :finished).map do |run|
+        matched = run.result_paths(pattern)
+        matched.map {|path| [ path, path.relative_path_from(run.dir.join('..')) ] }
+      end.inject(:+)
     else
       raise "not supported type"
     end
-    return files
   end
 
   def destroyable?

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -73,7 +73,7 @@ class Analysis
   # returns an array of
   #   [ absolute input path, destination relative path ]
   def input_files
-    pattern = analyzer.files_to_copy.chomp.gsub("\n", "\0")
+    pattern = analyzer.files_to_copy.chomp.gsub(/(\r\n|\r|\n)/, "\0")
     case analyzer.type
     when :on_run
       run = self.analyzable

--- a/app/models/analyzer.rb
+++ b/app/models/analyzer.rb
@@ -6,6 +6,7 @@ class Analyzer
   field :name, type: String
   field :type, type: Symbol
   field :auto_run, type: Symbol, default: :no
+  field :files_to_copy, type: String, default: '*'
   field :description, type: String
   field :to_be_destroyed, type: Boolean, default: false
 

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -63,16 +63,18 @@ class Run
   end
 
   # returns result files and directories
+  #   sub-directories and files in them are not included
   # directories for Analysis are not included
-  def result_paths
-    paths = Dir.glob( dir.join('*') ).map {|x|
-      Pathname(x)
+  def result_paths( pattern = '*' )
+    paths = nil
+    Dir.chdir(dir) {
+      paths = Dir.glob(pattern).map {|x| Pathname.new(x).expand_path }
     }
     # remove directories of Analysis
-    paths -= analyses.map {|x| x.dir}
-
-    # return all files and directories on result path (these do not include sub-dirs and files in sub-dirs)
-    return paths
+    anl_dirs = analyses.map {|anl| /^#{anl.dir.to_s}/ }
+    paths.reject do |path|
+      anl_dirs.find {|anl_dir| anl_dir =~ path.to_s }
+    end
   end
 
   def archived_result_path

--- a/app/services/remote_job_handler.rb
+++ b/app/services/remote_job_handler.rb
@@ -93,6 +93,10 @@ class RemoteJobHandler
     # expand_path is necessary to copy file using FileUtils
     FileUtils.mkdir_p(mounted_remote_path)
     job.input_files.each do |origin,dest|
+      unless File.dirname(dest) == "."
+        d = File.dirname( mounted_remote_path.join(dest) )
+        FileUtils.mkdir_p( d )
+      end
       FileUtils.cp_r(origin, mounted_remote_path.join(dest) )
     end
   end
@@ -106,6 +110,11 @@ class RemoteJobHandler
       raise RemoteOperationError, "\"#{cmd}\" failed: rc:#{rc}, #{out}, #{err}" unless rc == 0
       job.input_files.each do |origin,dest|
         remote_path = remote_input_dir.join( dest )
+        unless File.dirname(dest) == "."
+          remote_dir = File.dirname( remote_path )
+          out, err, rc, sig = SSHUtil.execute2(ssh, "mkdir -p #{remote_dir}")
+          raise RemoteOperationError, "\"#{cmd}\" failed: rc:#{rc}, #{out}, #{err}" unless rc == 0
+        end
         SSHUtil.upload(ssh, origin, remote_path)
       end
     end

--- a/app/services/remote_job_handler.rb
+++ b/app/services/remote_job_handler.rb
@@ -92,8 +92,8 @@ class RemoteJobHandler
     mounted_remote_path = Pathname.new(@host.mounted_work_base_dir).join(relative_path).expand_path
     # expand_path is necessary to copy file using FileUtils
     FileUtils.mkdir_p(mounted_remote_path)
-    job.input_files.each do |file|
-      FileUtils.cp_r(file, mounted_remote_path)
+    job.input_files.each do |origin,dest|
+      FileUtils.cp_r(origin, mounted_remote_path.join(dest) )
     end
   end
 
@@ -104,9 +104,9 @@ class RemoteJobHandler
     @host.start_ssh do |ssh|
       out, err, rc, sig = SSHUtil.execute2(ssh, cmd)
       raise RemoteOperationError, "\"#{cmd}\" failed: rc:#{rc}, #{out}, #{err}" unless rc == 0
-      job.input_files.each do |file|
-        remote_path = remote_input_dir.join( File.basename(file) )
-        SSHUtil.upload(ssh, file, remote_path)
+      job.input_files.each do |origin,dest|
+        remote_path = remote_input_dir.join( dest )
+        SSHUtil.upload(ssh, origin, remote_path)
       end
     end
   end

--- a/app/views/analyzers/_about.html.haml
+++ b/app/views/analyzers/_about.html.haml
@@ -14,6 +14,9 @@
       %th Parameter Input Type
       %td= analyzer.support_input_json ? "JSON" : "Arguments"
     %tr
+      %th Files to Copy
+      %td= raw( analyzer.files_to_copy.chomp.gsub("\n", '<br />') )
+    %tr
       %th Support MPI
       %td= analyzer.support_mpi ? "Yes" : "No"
     %tr

--- a/app/views/analyzers/_form.html.haml
+++ b/app/views/analyzers/_form.html.haml
@@ -34,6 +34,10 @@
     .col-md-3
       = f.select(:support_input_json, {"Argument" => false, "JSON" => true}, {},{class: 'form-control'})
   .form-group
+    = f.label(:files_to_copy, class: 'col-md-2 control-label')
+    .col-md-6
+      = f.text_area(:files_to_copy, rows:2, class: 'form-control')
+  .form-group
     = f.label(:support_mpi, class: ['col-md-2','control-label'])
     .col-md-2
       .checkbox

--- a/spec/controllers/analyzers_controller_spec.rb
+++ b/spec/controllers/analyzers_controller_spec.rb
@@ -74,7 +74,9 @@ describe AnalyzersController do
         analyzer = {
           name: "analyzerA", type: "on_run", command: "echo",
           parameter_definitions_attributes: definitions,
-          auto_run: "no", description: "xxx yyy",
+          auto_run: "no",
+          files_to_copy: "abc.txt\ndef.txt",
+          description: "xxx yyy",
           support_input_json: "1", support_mpi: "1", support_omp: "0",
           pre_process_script: "echo preprocess",
           executable_on_ids: [@host.id.to_s],
@@ -96,6 +98,7 @@ describe AnalyzersController do
         expect(azr.type).to eq :on_run
         expect(azr.command).to eq "echo"
         expect(azr.auto_run).to eq :no
+        expect(azr.files_to_copy).to eq "abc.txt\ndef.txt"
         expect(azr.description).to eq "xxx yyy"
         expect(azr.parameter_definition_for("param1").type).to eq "Integer"
         expect(azr.parameter_definition_for("param2").type).to eq "Float"
@@ -183,7 +186,9 @@ describe AnalyzersController do
         analyzer = {
           name: "analyzerA", type: "on_run", command: "echo",
           parameter_definitions_attributes: definitions,
-          auto_run: "no", description: "xxx yyy",
+          auto_run: "no",
+          files_to_copy: "abc.txt\ndef.txt",
+          description: "xxx yyy",
           support_input_json: "1", support_mpi: "1", support_omp: "0",
           pre_process_script: "echo preprocess",
           executable_on: [],

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -116,6 +116,7 @@ FactoryGirl.define do
         { key: "param2", type: "Float", default: 1.0, description: "param2 desc" })
       ]
     }
+    files_to_copy { '*' }
     description { Faker::Lorem.paragraphs.join("\n") }
 
     ignore do

--- a/spec/models/analysis_spec.rb
+++ b/spec/models/analysis_spec.rb
@@ -217,11 +217,6 @@ describe Analysis do
         FileUtils.mkdir_p(@dummy_dir)
       end
 
-      after(:each) do
-        FileUtils.rm( @dummy_path ) if File.exist?(@dummy_path)
-        FileUtils.rm_r(@dummy_dir) if File.directory?(@dummy_dir)
-      end
-
       it "returns file entries in run directory" do
         paths = @arn.input_files
         expected = [
@@ -277,11 +272,6 @@ describe Analysis do
         @dummy_dirs = [@run2.dir.join('__dummy_dir__'), @run3.dir.join('__dummy_dir__')]
         @dummy_files.each {|path| FileUtils.touch(path) }
         @dummy_dirs.each {|dir| FileUtils.mkdir_p(dir) }
-      end
-
-      after(:each) do
-        @dummy_files.each {|file| FileUtils.rm(file) if File.exist?(file) }
-        @dummy_dirs.each {|dir| FileUtils.rm_r(dir) if File.directory?(dir) }
       end
 
       it "returns files of finished runs" do

--- a/spec/models/analysis_spec.rb
+++ b/spec/models/analysis_spec.rb
@@ -222,10 +222,8 @@ describe Analysis do
         FileUtils.rm_r(@dummy_dir) if File.directory?(@dummy_dir)
       end
 
-      it "returns a file entries in run directory" do
+      it "returns file entries in run directory" do
         paths = @arn.input_files
-        expect(paths).to be_a(Array)
-        expect(paths.size).to eq 2
         expect(paths).to match_array([@dummy_path, @dummy_dir])
       end
 
@@ -234,7 +232,7 @@ describe Analysis do
         expect(paths).not_to include(@arn.dir)
       end
 
-      it "does not include directories of other Analyses by defualt" do
+      it "does not include directories of other Analyses by default" do
         another_arn = @run.analyses.create!(analyzer: @azr, parameters: {})
         paths = @arn.input_files
         expect(paths).not_to include(another_arn.dir)

--- a/spec/models/analysis_spec.rb
+++ b/spec/models/analysis_spec.rb
@@ -237,6 +237,7 @@ describe Analysis do
         before(:each) do
           FileUtils.touch( @run.dir.join('TO_NOT_MATCH.txt') )
           FileUtils.touch( @dummy_dir.join('subfile.txt') )
+          FileUtils.touch( @dummy_dir.join('subfile2.txt') )
         end
 
         it "returns files which matches pattern" do
@@ -253,6 +254,18 @@ describe Analysis do
           @arn.analyzer.update_attribute(:files_to_copy, another_anl.id.to_s)
           expect( @run.dir.join(another_anl.id) ).to be_exist
           expect( @arn.input_files ).to be_empty
+        end
+
+        it "accepts multiple patterns separated by new line characters" do
+          @arn.analyzer.update_attribute(:files_to_copy,
+                                         "__dummy_dir__/subfile.txt\r\n__dummy_dir__/subfile2.txt")
+          paths = @arn.input_files
+          expected = [
+            [@dummy_dir.join('subfile.txt'), Pathname.new('__dummy_dir__/subfile.txt') ],
+            [@dummy_dir.join('subfile2.txt'), Pathname.new('__dummy_dir__/subfile2.txt') ],
+          ]
+          expect(paths).to match_array expected
+
         end
       end
     end

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -352,8 +352,25 @@ describe Run do
       entries_in_run_dir = Dir.glob(@run.dir.join('*'))
       expect(entries_in_run_dir.size).to eq(4)
       expect(@run.result_paths.size).to eq(3)
-      arn_dir = @run.analyses.first.dir
-      expect(@run.result_paths).not_to include(arn_dir)
+      anl_dir = @run.analyses.first.dir
+      expect(@run.result_paths).not_to include(anl_dir)
+    end
+
+    context "when pattern is given" do
+
+      it "returns matched files" do
+        pattern = "result1.txt\0result_dir/result3.txt"
+        paths = @run.result_paths(pattern)
+        expected = %w(result1.txt result_dir/result3.txt).map {|f| @run.dir.join(f) }
+        expect(paths).to match_array expected
+      end
+
+      it "does not include analysis directories even if it matches the pattern" do
+        pattern = "*"
+        paths = @run.result_paths(pattern)
+        expected = %w(result1.txt result2.txt result_dir).map {|f| @run.dir.join(f) }
+        expect(paths).to match_array expected
+      end
     end
   end
 

--- a/spec/services/remote_job_handler_spec.rb
+++ b/spec/services/remote_job_handler_spec.rb
@@ -18,27 +18,30 @@ shared_examples_for RemoteJobHandler do
       shared_examples_for "prepare input directory" do
 
         it "creates _input/ directory and copy input files on remote host" do
-          if @submittable.is_a?(Analysis)
-            input_file = @submittable.analyzable.dir.join('dummy.txt')
-            FileUtils.touch(input_file)
-            RemoteJobHandler.new(@host).submit_remote_job(@submittable)
-            input_dir_path = @temp_dir.join(@submittable.id.to_s, '_input')
-            expect( File.directory?(input_dir_path) ).to be_truthy
-            expect( File.exist?(input_dir_path.join('dummy.txt')) ).to be_truthy
-          end
+          next unless @submittable.is_a?(Analysis)
+          # preparing input files as follows
+          # run
+          #  |- f1.txt
+          input_file = @submittable.analyzable.dir.join('f1.txt')
+          FileUtils.touch(input_file)
+
+          RemoteJobHandler.new(@host).submit_remote_job(@submittable)
+          copied = @temp_dir.join(@submittable.id.to_s, '_input', 'f1.txt')
+          expect( copied ).to be_exist
         end
 
         it "creates _input/ directory recursively for input directory" do
-          if @submittable.is_a?(Analysis)
-            input_dir = @submittable.analyzable.dir.join('dir1/dir2')
-            FileUtils.mkdir_p(input_dir)
-            input_file = input_dir.join('file1')
-            FileUtils.touch(input_file)
-            RemoteJobHandler.new(@host).submit_remote_job(@submittable)
-            input_dir_path = @temp_dir.join(@submittable.id.to_s, '_input')
-            remote_input_file_path = input_dir_path.join('dir1/dir2/file1')
-            expect( File.exist?(remote_input_file_path) ).to be_truthy
-          end
+          next unless @submittable.is_a?(Analysis)
+          # preparing input files as follows
+          # run
+          #  |- dir1/dir2/f1.txt
+          input_dir = @submittable.analyzable.dir.join('dir1/dir2')
+          FileUtils.mkdir_p( input_dir )
+          FileUtils.touch( input_dir.join('f1.txt') )
+
+          RemoteJobHandler.new(@host).submit_remote_job(@submittable)
+          copied = @temp_dir.join(@submittable.id.to_s, '_input/dir1/dir2/f1.txt' )
+          expect( copied ).to be_exist
         end
 
         context "when Analyzer#files_to_copy is specified" do


### PR DESCRIPTION
指定されたAnalyzerのファイルのみコピーする

仕様
- Analyzerに files_to_copy というフィールドを追加
  - 文字列
  - デフォルトはワイルドカード
  - 複数パターンは改行文字(\r\n)で区切るという仕様
- files_to_copy で指定されたファイルのみAnalyzer実行時に_input以下にコピーされる

例えばRunの出力結果に以下のようになっているとする。

```
a
 |-- b
 |   |-- c
 |   |   `-- d.txt
 |   `-- c2.txt
 `-- b2.txt
```

files_to_copyで `a/b2.txt\r\na/b/c/d.txt` と指定したとすると _inputディレクトリの中身は

```
_input
  |-- a
      |-- b
      |   `-- c
      |       `-- d.txt
      `-- b2.txt
```

となる。
PSに対するanalysisの場合には、_inputの直下にrunのidのディレクトリが作成され以下は同じ構造になる。
