### PR TITLE
remove seed option from cli

### DIFF
--- a/lib/cli/oacis_cli_parameter_set.rb
+++ b/lib/cli/oacis_cli_parameter_set.rb
@@ -91,7 +91,7 @@ class OacisCli < Thor
       priority = run_option["priority"] || 1
       parameter_sets = ParameterSet.in(id: parameter_set_ids)
 
-      create_runs_impl(parameter_sets, num_runs, submitted_to, host_parameters, mpi_procs, omp_threads, priority, [])
+      create_runs_impl(parameter_sets, num_runs, submitted_to, host_parameters, mpi_procs, omp_threads, priority)
     end
 
   ensure

--- a/lib/cli/oacis_cli_run.rb
+++ b/lib/cli/oacis_cli_run.rb
@@ -53,11 +53,6 @@ class OacisCli < Thor
     aliases:  '-n',
     desc:     'runs are created up to this number',
     default:  1
-  method_option :seeds,
-    type:     :string,
-    aliases:  '-s',
-    desc:     'runs are created with seeds',
-    required: false
   method_option :output,
     type:     :string,
     aliases:  '-o',
@@ -67,14 +62,13 @@ class OacisCli < Thor
     parameter_sets = get_parameter_sets(options[:parameter_sets])
     job_parameters = load_json_file_or_string(options[:job_parameters])
     num_runs = options[:number_of_runs]
-    seeds = options[:seeds] ? JSON.parse(options[:seeds]) : []
     submitted_to = job_parameters["host_id"] ? Host.find(job_parameters["host_id"]) : nil
     host_parameters = job_parameters["host_parameters"].to_hash
     mpi_procs = job_parameters["mpi_procs"]
     omp_threads = job_parameters["omp_threads"]
     priority = job_parameters["priority"]
 
-    run_ids = create_runs_impl(parameter_sets, num_runs, submitted_to, host_parameters, mpi_procs, omp_threads, priority, seeds)
+    run_ids = create_runs_impl(parameter_sets, num_runs, submitted_to, host_parameters, mpi_procs, omp_threads, priority)
 
   ensure
     return if options[:dry_run]
@@ -83,7 +77,7 @@ class OacisCli < Thor
   end
 
   private
-  def create_runs_impl(parameter_sets, num_runs, submitted_to, host_parameters, mpi_procs, omp_threads, priority, seeds)
+  def create_runs_impl(parameter_sets, num_runs, submitted_to, host_parameters, mpi_procs, omp_threads, priority)
     progressbar = ProgressBar.create(total: parameter_sets.size, format: "%t %B %p%% (%c/%C)")
     if options[:verbose]
       progressbar.log "Number of parameter_sets : #{parameter_sets.count}"
@@ -115,7 +109,6 @@ class OacisCli < Thor
                             omp_threads: omp_threads,
                             host_parameters: host_parameters,
                             priority: priority)
-        run.seed = seeds[i] if seeds[i]
         if run.valid?
           run.save! unless options[:dry_run]
           run_ids << run.id

--- a/spec/lib/cli/oacis_cli_run_spec.rb
+++ b/spec/lib/cli/oacis_cli_run_spec.rb
@@ -156,40 +156,6 @@ describe OacisCli do
       }
     end
 
-    context "with seeds option" do
-
-      def invoke_create_runs_with_seeds
-        create_parameter_set_ids_json(@sim.parameter_sets, 'parameter_set_ids.json')
-        create_job_parameters_json('job_parameters.json')
-        options = {
-          parameter_sets: 'parameter_set_ids.json',
-          job_parameters: 'job_parameters.json',
-          number_of_runs: 3,
-          seeds: "[0, 1, 2]",
-          output: 'run_ids.json'
-        }
-        OacisCli.new.invoke(:create_runs, [], options)
-      end
-
-      it "creates runs for each parameter_set" do
-        at_temp_dir {
-          expect {
-            invoke_create_runs_with_seeds
-          }.to change { Run.count }.by(6)
-        }
-      end
-
-      it "creates run having correct attributes" do
-        at_temp_dir {
-          invoke_create_runs_with_seeds
-          seeds = @sim.parameter_sets.first.reload.runs.map {|run| run.seed }
-          expect(seeds).to match_array([0,1,2])
-          seeds2 = @sim.parameter_sets.last.reload.runs.map {|run| run.seed }
-          expect(seeds2).to match_array([0,1,2])
-        }
-      end
-    end
-
     it "outputs ids of created runs in json" do
       at_temp_dir {
         invoke_create_runs


### PR DESCRIPTION
fixed #404 

- seed option for create_runs is nolonger unnecessary
- sequential_seed option was implemented in simulator model