### PR TITLE
Analysis is not destroyed properly

### DIFF
--- a/app/workers/document_destroyer.rb
+++ b/app/workers/document_destroyer.rb
@@ -30,6 +30,7 @@ class DocumentDestroyer
         obj.destroy
         @skip_count.delete(obj.id)
       else
+        obj.set_lower_submittable_to_be_destroyed
         @logger.info "skip destroying #{obj.class} #{obj.id}. not destroyable yet."
       end
     end

--- a/app/workers/job_submitter.rb
+++ b/app/workers/job_submitter.rb
@@ -61,8 +61,8 @@ class JobSubmitter
       if run.destroyable?
         logger.info "Destroying Run #{run.id}"
         run.destroy
-        run.set_lower_submittable_to_be_destroyed
       else
+        run.set_lower_submittable_to_be_destroyed
         logger.info "Run #{run.id} is not destroyable yet"
       end
     end

--- a/app/workers/job_submitter.rb
+++ b/app/workers/job_submitter.rb
@@ -62,8 +62,8 @@ class JobSubmitter
         logger.info "Destroying Run #{run.id}"
         run.destroy
       else
+        logger.warn("should not happen: #{job.class}:#{job.id} is not destroyable")
         run.set_lower_submittable_to_be_destroyed
-        logger.info "Run #{run.id} is not destroyable yet"
       end
     end
     Analysis.where(status: :created, to_be_destroyed: true).each do |anl|

--- a/spec/workers/job_observer_spec.rb
+++ b/spec/workers/job_observer_spec.rb
@@ -44,6 +44,7 @@ describe JobObserver do
     before(:each) do
       @sim = FactoryGirl.create(:simulator,
                                 parameter_sets_count: 1, runs_count: 1,
+                                analyzers_count: 1, run_analysis: false,
                                 ssh_host: true
                                 )
       @temp_dir = Pathname.new('__temp__')


### PR DESCRIPTION
JobObserver.observe_job でincludeを行ってauto-runのanalysisを作成している最中に、他のプロセス（UI or CLI）から該当のrunがto_be_destroyedに変更された場合、配下のanalysisのto_be_destroyedがfalseのまま進んでいってしまう。

```
- run (to_be_destroyed: true)
  - analysis (to_be_destroyed: false)
```

結果としてrunもその配下のanalysisも、永遠に削除されなくなる。

### 対策
to_be_destroyed=true かつ destroyable?=fales のものは、workerから定期的にset_lower_submittable_to_be_destroyed を呼ぶようにする。
