### PR TITLE
bugfix: Analysis#input_files returns nil if PS has no finished runs

### DIFF
--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -84,7 +84,7 @@ class Analysis
       ps.runs.where(status: :finished).map do |run|
         matched = run.result_paths(pattern)
         matched.map {|path| [ path, path.relative_path_from(run.dir.join('..')) ] }
-      end.inject(:+)
+      end.inject([], :+)
     else
       raise "not supported type"
     end

--- a/spec/models/analysis_spec.rb
+++ b/spec/models/analysis_spec.rb
@@ -305,6 +305,11 @@ describe Analysis do
         ]
         expect( @arn2.input_files ).to match_array expected
       end
+
+      it "returns an empty array when PS has no finished runs" do
+        @ps.runs.destroy
+        expect( @arn2.input_files ).to eq []
+      end
     end
   end
 


### PR DESCRIPTION
PSに対するAnalysisの #input_files メソッドがnilを返し、workerで例外が発生する場合がある。
PSがfinishedのrunを持っていない時にnilになる。
PSに対するAnalysisが実行される前に、PS配下のrunがreplaceされた場合などで起きうる。
そのような場合Analysisを実行する意味は無いが、workerで失敗したanalysisを永遠に投げ続けようとしてしまうので修正する。
