### PR TITLE
a bug is fixed: remove an unnecessary validation to get white parameters

### DIFF
--- a/app/controllers/analyzers_controller.rb
+++ b/app/controllers/analyzers_controller.rb
@@ -112,9 +112,5 @@ class AnalyzersController < ApplicationController
                                                parameter_definitions_attributes: [[:id, :key, :type, :default, :description]],
                                                executable_on_ids: []
                                               ) : {}
-    if analyzer_params.has_key?(:parameter_definitions_attributes) and analyzer_params[:parameter_definitions_attributes].is_a?(Hash)
-      analyzer_params[:parameter_definitions_attributes].select! {|pdef_id, pdef_val| pdef_val.has_key?(:key)} # remove empty hash
-    end
-    analyzer_params
   end
 end


### PR DESCRIPTION
fixed #413

# 現象
- analyzerのパラメータデフォルト値がアップデートできない

# 原因
- strong parameterを得る時に，不要なvalidationが入っていた

# 修正
- 不要なvalidationを削除