### PR TITLE
implement auto_reload for progress over view

### DIFF
--- a/app/views/simulators/_progress.html.haml
+++ b/app/views/simulators/_progress.html.haml
@@ -71,7 +71,7 @@
     if( window.bEnableAutoReload ) {
       setInterval( function() {
       show_progress();
-      }, 5000);
+      }, 10000);
     }
   });
   $(function() {

--- a/app/views/simulators/_progress.html.haml
+++ b/app/views/simulators/_progress.html.haml
@@ -60,11 +60,19 @@
               %a.btn.btn-primary#show_progress_button Show
 :javascript
   var url = "#{_progress_simulator_path}" + ".json";
-  $('#show_progress_button').on('click', function () {
+  function show_progress() {
     var cp = $('#column_parameter option:selected').val();
     var rp = $('#row_parameter option:selected').val();
     var url_with_param = url + "?row_parameter=" + rp + "&column_parameter=" + cp;
     draw_progress_overview(url_with_param);
+  }
+  $('#show_progress_button').on('click', function() {
+    show_progress();
+    if( window.bEnableAutoReload ) {
+      setInterval( function() {
+      show_progress();
+      }, 5000);
+    }
   });
   $(function() {
       // in order to avoid 'position: relative' style of '.col-lg-12' tag, we put 'tooltip' before '.col-lg-12' tag


### PR DESCRIPTION
fixed #357 
# プログレスが自動的に再描画されるように変更 
- プログレスの描画ボタンが押されて初めて自動更新を開始
- 10秒間隔

# known issue
- プログレスの拡大表示中にも更新され最初のスケールに戻る(長めの更新間隔にすることで対応)