### PR TITLE
show results in PS#show analysis tab

### DIFF
--- a/app/views/parameter_sets/_analyses.html.haml
+++ b/app/views/parameter_sets/_analyses.html.haml
@@ -1,6 +1,5 @@
 = render partial: 'shared/analyses', locals: {parameter_set: parameter_set}
 
-
 - sim = parameter_set.simulator
 - azrs = sim.analyzers_on_parameter_set
 - unless OACIS_READ_ONLY or azrs.empty?
@@ -65,3 +64,13 @@
       analyzer_field.trigger('change');
     }
   });
+
+- if parameter_set.analyses.present?
+  %h2 Results
+- parameter_set.analyses.where(status: :finished).each do |anl|
+  %hr
+  %h3= "Result of Analysis: #{anl.analyzer.name}"
+  = link_to(anl.id,anl)
+  - if anl.parameters.present?
+    = render partial: "shared/parameters_table", locals: {parameters_hash: anl.parameters}
+  = render partial: "shared/results", locals: {result: anl.result, result_paths: anl.result_paths, archived_result_path: anl.archived_result_path }

--- a/app/views/parameter_sets/_inner_table.html.haml
+++ b/app/views/parameter_sets/_inner_table.html.haml
@@ -9,4 +9,13 @@
     .tab-pane.active#tab-list-runs
       = render "runs", parameter_set: parameter_set
     .tab-pane#tab-parameter-analyzers
-      = render "analyses", parameter_set: parameter_set
+      - if parameter_set.analyses.where(status: :finished).empty?
+        No finished analysis is found.
+      - else
+        - parameter_set.analyses.where(status: :finished).each do |anl|
+          %hr
+          %h3= "Result of Analysis: #{anl.analyzer.name}"
+          = link_to(anl.id,anl)
+          - if anl.parameters.present?
+            = render partial: "shared/parameters_table", locals: {parameters_hash: anl.parameters}
+          = render partial: "shared/results", locals: {result: anl.result, result_paths: anl.result_paths, archived_result_path: anl.archived_result_path }


### PR DESCRIPTION
PSAnalysisの結果をPS#showページで表示するようにする。RunAnalysisと同様の表示

after:
![image](https://cloud.githubusercontent.com/assets/718731/12193776/2b4d840a-b62e-11e5-9caa-2dbb5d4f0c30.png)

PSの横のルーペアイコンをクリックしたときのモーダルも変更し、リストではなく結果を表示するようにした。
![image](https://cloud.githubusercontent.com/assets/718731/12194030/0dd01aa8-b630-11e5-8185-f379d87b08e4.png)
