### PR TITLE
List of psids and runids in json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'thin'
 gem "mongoid"
 gem "net-ssh"
 gem "net-sftp"
+gem "jbuilder", '2.4.0'
 
 # assets
 gem "haml-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,9 @@ GEM
       nokogiri (~> 1.6.0)
       ruby_parser (~> 3.5)
     i18n (0.7.0)
+    jbuilder (2.4.0)
+      activesupport (>= 3.0.0, < 5.1)
+      multi_json (~> 1.2)
     jquery-datatables-rails (3.2.0)
       actionpack (>= 3.1)
       jquery-rails
@@ -254,6 +257,7 @@ DEPENDENCIES
   factory_girl_rails
   faker
   haml-rails
+  jbuilder (= 2.4.0)
   jquery-datatables-rails
   jquery-rails
   jquery-ui-rails
@@ -278,3 +282,6 @@ DEPENDENCIES
   therubyracer
   thin
   twitter-bootstrap-rails (= 3.2.0)
+
+BUNDLED WITH
+   1.11.2

--- a/app/controllers/analyses_controller.rb
+++ b/app/controllers/analyses_controller.rb
@@ -4,8 +4,8 @@ class AnalysesController < ApplicationController
     @analysis = Analysis.find(params[:id])
 
     respond_to do |format|
-      format.html # show.html.erb
-      format.json { render json: @analysis }
+      format.html
+      format.json
     end
   end
 

--- a/app/controllers/analyzers_controller.rb
+++ b/app/controllers/analyzers_controller.rb
@@ -4,8 +4,8 @@ class AnalyzersController < ApplicationController
     @analyzer = Analyzer.find(params[:id])
 
     respond_to do |format|
-      format.html # show.html.erb
-      format.json { render json: @analyzers }
+      format.html
+      format.json
     end
   end
 
@@ -14,7 +14,7 @@ class AnalyzersController < ApplicationController
     @analyzer = simulator.analyzers.build
 
     respond_to do |format|
-      format.html # new.html.erb
+      format.html
       format.json { render json: @analyzer }
     end
   end

--- a/app/controllers/parameter_sets_controller.rb
+++ b/app/controllers/parameter_sets_controller.rb
@@ -3,8 +3,8 @@ class ParameterSetsController < ApplicationController
   def show
     @param_set = ParameterSet.find(params[:id])
     respond_to do |format|
-      format.html # show.html.erb
-      format.json { render json: @param_set }
+      format.html
+      format.json
     end
   end
 

--- a/app/controllers/runs_controller.rb
+++ b/app/controllers/runs_controller.rb
@@ -31,8 +31,8 @@ class RunsController < ApplicationController
     @run = Run.find(params[:id])
     @param_set = @run.parameter_set
     respond_to do |format|
-      format.html # show.html.erb
-      format.json { render json: @run }
+      format.html
+      format.json
     end
   end
 

--- a/app/controllers/simulators_controller.rb
+++ b/app/controllers/simulators_controller.rb
@@ -24,7 +24,7 @@ class SimulatorsController < ApplicationController
     end
 
     respond_to do |format|
-      format.html # show.html.erb
+      format.html
       format.json { render json: @simulator }
     end
   end
@@ -35,7 +35,7 @@ class SimulatorsController < ApplicationController
     @simulator = Simulator.new
 
     respond_to do |format|
-      format.html # new.html.erb
+      format.html
       format.json { render json: @simulator }
     end
   end

--- a/app/controllers/simulators_controller.rb
+++ b/app/controllers/simulators_controller.rb
@@ -25,7 +25,7 @@ class SimulatorsController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.json { render json: @simulator }
+      format.json
     end
   end
 

--- a/app/views/analyses/show.html.haml
+++ b/app/views/analyses/show.html.haml
@@ -14,3 +14,5 @@
 
 %h3 Script
 %pre~ @analysis.job_script
+
+= link_to 'Show in JSON', analysis_path(@analysis, format: :json), class: 'btn btn-default'

--- a/app/views/analyses/show.json.jbuilder
+++ b/app/views/analyses/show.json.jbuilder
@@ -1,0 +1,22 @@
+json.id @analysis.id.to_s
+json.analyzer do
+  json.id @analysis.analyzer.id.to_s
+  json.name @analysis.analyzer.name
+end
+json.extract! @analysis,
+              :status, :parameters, :job_script, :host_parameters, :mpi_procs, :omp_threads,
+              :priority, :job_id, :submitted_at, :error_messages,
+              :hostname, :cpu_time, :real_time, :started_at, :finished_at,
+              :included_at, :result
+json.submitted_to do
+  s = @analysis.submitted_to
+  if s
+    json.id s.id.to_s
+    json.name s.name
+  else
+    json.null!
+  end
+end
+json.analyzable do
+  json.id @analysis.analyzable.id.to_s
+end

--- a/app/views/analyzers/_about.html.haml
+++ b/app/views/analyzers/_about.html.haml
@@ -121,3 +121,5 @@
 - unless OACIS_READ_ONLY
   = link_to 'Edit', edit_analyzer_path(analyzer), class: 'btn btn-info'
   = link_to 'Destroy', analyzer, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-warning'
+= link_to 'Show in JSON', analyzer_path(analyzer, format: :json), class: 'btn btn-default'
+

--- a/app/views/analyzers/show.json.jbuilder
+++ b/app/views/analyzers/show.json.jbuilder
@@ -1,0 +1,16 @@
+json.id @analyzer.id.to_s
+json.extract! @analyzer,
+              :name, :description, :type, :command,
+              :auto_run, :files_to_copy,
+              :support_input_json, :support_mpi, :support_omp,
+              :pre_process_script, :print_version_command
+json.parameter_definitions do
+  json.array! @analyzer.parameter_definitions,
+              :key, :type, :default, :description
+end
+json.executable_on do
+  json.array! @analyzer.executable_on do |host|
+    json.id host.id.to_s
+    json.name host.name
+  end
+end

--- a/app/views/parameter_sets/show.html.haml
+++ b/app/views/parameter_sets/show.html.haml
@@ -22,6 +22,8 @@
       - unless OACIS_READ_ONLY
         = link_to("Duplicate", duplicate_parameter_set_path(@param_set), class: 'btn btn-primary')
         = link_to 'Destroy', @param_set, method: :delete, data: { confirm: 'Are you sure?'}, class: 'btn btn-warning'
+      = link_to 'Show in JSON', parameter_set_path(@param_set, format: :json), class: 'btn btn-default'
+
     .tab-pane.active#tab-list-runs
       = render "runs", parameter_set: @param_set
     .tab-pane#tab-analyses

--- a/app/views/parameter_sets/show.json.jbuilder
+++ b/app/views/parameter_sets/show.json.jbuilder
@@ -1,0 +1,18 @@
+json.id @param_set.id.to_s
+json.extract! @param_set, :v
+json.simulator do
+  json.id = @param_set.simulator.id.to_s
+  json.name = @param_set.simulator.name
+end
+json.runs do
+  json.array! @param_set.runs do |run|
+    json.id run.id.to_s
+    json.status run.status
+  end
+end
+json.analyses do
+  json.array! @param_set.analyses do |anl|
+    json.id anl.id.to_s
+    json.status anl.status
+  end
+end

--- a/app/views/runs/_about.html.haml
+++ b/app/views/runs/_about.html.haml
@@ -74,3 +74,5 @@
 - if @run.submitted_to
   %h3 Script
   %pre~ @run.job_script
+
+= link_to 'Show in JSON', run_path(@run, format: :json), class: 'btn btn-default'

--- a/app/views/runs/show.json.jbuilder
+++ b/app/views/runs/show.json.jbuilder
@@ -1,0 +1,21 @@
+json.id @run.id.to_s
+json.extract! @run,
+              :status, :seed, :job_script, :host_parameters, :mpi_procs, :omp_threads,
+              :priority, :job_id, :submitted_at, :error_messages,
+              :hostname, :cpu_time, :real_time, :started_at, :finished_at,
+              :included_at, :result
+json.submitted_to do
+  json.id @run.submitted_to.id.to_s
+  json.name @run.submitted_to.name
+end
+json.parameter_set do
+  json.id @run.parameter_set.id.to_s
+  json.v @run.parameter_set.v
+end
+json.analyses do
+  json.array! @run.analyses do |anl|
+    json.id anl.id.to_s
+    json.analyzer anl.analyzer.name
+    json.parameters anl.parameters
+  end
+end

--- a/app/views/runs/show.json.jbuilder
+++ b/app/views/runs/show.json.jbuilder
@@ -1,12 +1,21 @@
 json.id @run.id.to_s
+json.simulator do
+  json.id @run.simulator.id.to_s
+  json.name @run.simulator.name
+end
 json.extract! @run,
               :status, :seed, :job_script, :host_parameters, :mpi_procs, :omp_threads,
               :priority, :job_id, :submitted_at, :error_messages,
               :hostname, :cpu_time, :real_time, :started_at, :finished_at,
               :included_at, :result
 json.submitted_to do
-  json.id @run.submitted_to.id.to_s
-  json.name @run.submitted_to.name
+  s = @run.submitted_to
+  if s
+    json.id s.id.to_s
+    json.name s.name
+  else
+    json.null!
+  end
 end
 json.parameter_set do
   json.id @run.parameter_set.id.to_s

--- a/app/views/simulators/_about.html.haml
+++ b/app/views/simulators/_about.html.haml
@@ -4,6 +4,7 @@
   = link_to 'Duplicate', duplicate_simulator_path(simulator), class: 'btn btn-primary'
   = link_to 'Edit', edit_simulator_path(simulator), class: 'btn btn-info'
   = link_to 'Destroy', simulator, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-warning'
+= link_to 'Show in JSON', simulator_path(simulator, format: :json), class: 'btn btn-default'
 
 
 %h3 About

--- a/app/views/simulators/show.json.jbuilder
+++ b/app/views/simulators/show.json.jbuilder
@@ -1,0 +1,26 @@
+json.id @simulator.id.to_s
+json.extract! @simulator,
+              :name, :description, :command, :sequential_seed,
+              :support_input_json, :support_mpi, :support_omp,
+              :pre_process_script, :print_version_command
+json.parameter_definitions do
+  json.array! @simulator.parameter_definitions, :key, :type, :default, :description
+end
+json.executable_on do
+  json.array! @simulator.executable_on do |host|
+    json.id host.id.to_s
+    json.name host.name
+  end
+end
+json.analyzers do
+  json.array! @simulator.analyzers do |azr|
+    json.id azr.id.to_s
+    json.name azr.name
+  end
+end
+json.parameter_sets do
+  json.array! @simulator.parameter_sets do |ps|
+    json.id ps.id.to_s
+    json.v ps.v
+  end
+end

--- a/spec/controllers/analyses_controller_spec.rb
+++ b/spec/controllers/analyses_controller_spec.rb
@@ -54,6 +54,11 @@ describe AnalysesController do
         get 'show', {id: @arn}, valid_session
         expect(assigns(:analysis)).to eq(@arn)
       end
+
+      it "returns success for json format" do
+        get :show, {id: @arn, format: :json}, valid_session
+        expect(response).to be_success
+      end
     end
 
     describe "for :on_parameter_set type" do
@@ -66,6 +71,11 @@ describe AnalysesController do
       it "assigns instance variables" do
         get 'show', {id: @arn2}, valid_session
         expect(assigns(:analysis)).to eq(@arn2)
+      end
+
+      it "returns success for json format" do
+        get :show, {id: @arn2, format: :json}, valid_session
+        expect(response).to be_success
       end
     end
   end

--- a/spec/controllers/analyzers_controller_spec.rb
+++ b/spec/controllers/analyzers_controller_spec.rb
@@ -18,13 +18,18 @@ describe AnalyzersController do
     end
 
     it "returns http success" do
-      get 'show', {id: @azr.id }
+      get 'show', {id: @azr }
       expect(response).to be_success
     end
 
     it "assigns the requested analyzer to @analyzer" do
-      get 'show', {id: @azr.id }
+      get 'show', {id: @azr }
       expect(assigns(:analyzer)).to eq(@azr)
+    end
+
+    it "returns success for json format" do
+      get :show, {id: @azr, format: :json}, valid_session
+      expect(response).to be_success
     end
   end
 

--- a/spec/controllers/parameter_sets_controller_spec.rb
+++ b/spec/controllers/parameter_sets_controller_spec.rb
@@ -11,25 +11,28 @@ describe ParameterSetsController do
   
   describe "GET 'show'" do
 
+    before(:each) do
+      @sim = FactoryGirl.create(:simulator,
+                                parameter_sets_count: 1,
+                                runs_count: 1,
+                                analyzers_count: 1,
+                                run_analysis: true)
+    end
+
     it "returns http success" do
-      sim = FactoryGirl.create(:simulator,
-                               parameter_sets_count: 1,
-                               runs_count: 1,
-                               analyzers_count: 1,
-                               run_analysis: true)
-      get 'show', {id: sim.parameter_sets.first}, valid_session
+      get 'show', {id: @sim.parameter_sets.first}, valid_session
       expect(response).to be_success
     end
 
     it "assigns instance variables" do
-      sim = FactoryGirl.create(:simulator,
-                               parameter_sets_count: 1,
-                               runs_count: 1,
-                               analyzers_count: 1,
-                               run_analysis: true)
-      prm = sim.parameter_sets.first
+      prm = @sim.parameter_sets.first
       get 'show', {id: prm}, valid_session
       expect(assigns(:param_set)).to eq(prm)
+    end
+
+    it "returns success for json format" do
+      get :show, {id: @sim.parameter_sets.first, format: :json}, valid_session
+      expect(response).to be_success
     end
   end
 

--- a/spec/controllers/runs_controller_spec.rb
+++ b/spec/controllers/runs_controller_spec.rb
@@ -41,6 +41,11 @@ describe RunsController do
       expect(assigns(:run)).to eq(@run)
       expect(assigns(:param_set)).to eq(@par)
     end
+
+    it "returns success for json format" do
+      get :show, {id: @run, format: :json}, valid_session
+      expect(response).to be_success
+    end
   end
 
   describe "POST 'create'" do

--- a/spec/controllers/simulators_controller_spec.rb
+++ b/spec/controllers/simulators_controller_spec.rb
@@ -78,6 +78,11 @@ describe SimulatorsController do
       expect(assigns(:query_id)).to be_nil
       expect(assigns(:query_list).size).to eq 5
     end
+
+    it "returns success for json format" do
+      get :show, {id: @simulator, format: :json}, valid_session
+      expect(response).to be_success
+    end
   end
 
   describe "GET new" do


### PR DESCRIPTION
Fixed #354 

Simulator, Analyzer, PS, Run, Analysis の各showページにjsonフォーマットでの表示を追加した。
配下の要素のIDの一覧が取れるようになっている。
jsonの表示にはjbuilder gemを利用しているのでbundleしてください。