### PR TITLE
Improve usability of datatable

### DIFF
--- a/app/assets/javascripts/analyses.js
+++ b/app/assets/javascripts/analyses.js
@@ -29,6 +29,7 @@ $(function() {
       serverSide: true,
       bFilter: false,
       destroy: true,
+      dom: 'C<"clear">lrtip',
       ajax: $('#analyses_list').data('source')
     });
     $('#analyses_list_length').append(

--- a/app/assets/javascripts/analyses.js
+++ b/app/assets/javascripts/analyses.js
@@ -28,13 +28,13 @@ $(function() {
       processing: true,
       serverSide: true,
       bFilter: false,
+      order: [[6, "desc"]],
       destroy: true,
       "columnDefs": [{
         "searchable": false,
         "orderable": false,
         "targets": [0, -1]
       }],
-      dom: 'C<"clear">lrtip',
       ajax: $('#analyses_list').data('source')
     });
     $('#analyses_list_length').append(

--- a/app/assets/javascripts/analyses.js
+++ b/app/assets/javascripts/analyses.js
@@ -29,6 +29,11 @@ $(function() {
       serverSide: true,
       bFilter: false,
       destroy: true,
+      "columnDefs": [{
+        "searchable": false,
+        "orderable": false,
+        "targets": [0, -1]
+      }],
       dom: 'C<"clear">lrtip',
       ajax: $('#analyses_list').data('source')
     });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,6 +23,7 @@
 //= require sortable.js
 //= require dataTables/jquery.dataTables
 //= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
+//= require dataTables/extras/dataTables.colVis
 //= require dynatree/jquery.dynatree
 
 // Handle back button issues with Twitter Bootstrap's tab component.

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,7 +23,6 @@
 //= require sortable.js
 //= require dataTables/jquery.dataTables
 //= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
-//= require dataTables/jquery.dataTables.api.fnReloadAjax
 //= require dynatree/jquery.dynatree
 
 // Handle back button issues with Twitter Bootstrap's tab component.

--- a/app/assets/javascripts/parameter_set.js
+++ b/app/assets/javascripts/parameter_set.js
@@ -6,6 +6,11 @@ function create_parameter_sets_list(selector, default_length) {
     order: [[ 3, "desc" ]],
     autoWidth: false,
     pageLength: default_length,
+    "columnDefs": [{
+      "searchable": false,
+      "orderable": false,
+      "targets": [0, -1]
+    }],
     dom: 'C<"clear">lrtip',
     ajax: $(selector).data('source')
   });

--- a/app/assets/javascripts/parameter_set.js
+++ b/app/assets/javascripts/parameter_set.js
@@ -12,6 +12,10 @@ function create_parameter_sets_list(selector, default_length) {
       "targets": [0, -1]
     }],
     dom: 'C<"clear">lrtip',
+    colVis: {
+      exclude: [0, ($("th", selector).size()-1)],
+      restore: "Show All Columns"
+    },
     ajax: $(selector).data('source')
   });
   $(selector+'_length').append(

--- a/app/assets/javascripts/parameter_set.js
+++ b/app/assets/javascripts/parameter_set.js
@@ -6,6 +6,7 @@ function create_parameter_sets_list(selector, default_length) {
     order: [[ 3, "desc" ]],
     autoWidth: false,
     pageLength: default_length,
+    dom: 'C<"clear">lrtip',
     ajax: $(selector).data('source')
   });
   $(selector+'_length').append(

--- a/app/assets/javascripts/runs.js
+++ b/app/assets/javascripts/runs.js
@@ -13,6 +13,11 @@ $(function() {
       searching: false,
       order: [[ 8, "desc" ]],
       destroy: true,
+      "columnDefs": [{
+        "searchable": false,
+        "orderable": false,
+        "targets": -1
+      }],
       dom: 'C<"clear">lrtip',
       ajax: $('#runs_list').data('source')
     });

--- a/app/assets/javascripts/runs.js
+++ b/app/assets/javascripts/runs.js
@@ -13,6 +13,7 @@ $(function() {
       searching: false,
       order: [[ 8, "desc" ]],
       destroy: true,
+      dom: 'C<"clear">lrtip',
       ajax: $('#runs_list').data('source')
     });
     $('#runs_list_length').append(

--- a/app/assets/javascripts/runs.js
+++ b/app/assets/javascripts/runs.js
@@ -18,7 +18,6 @@ $(function() {
         "orderable": false,
         "targets": -1
       }],
-      dom: 'C<"clear">lrtip',
       ajax: $('#runs_list').data('source')
     });
     $('#runs_list_length').append(

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -11,6 +11,7 @@
  *= require_self
  *= require_tree
  *= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
+ *= require dataTables/extras/dataTables.colVis
  *= require dynatree/skin
 */
 div.progress-tooltip {

--- a/app/datatables/analyses_list_datatable.rb
+++ b/app/datatables/analyses_list_datatable.rb
@@ -3,7 +3,7 @@ class AnalysesListDatatable
   HEADER  = ['<th style="min-width: 18px; width: 1%;"></th>',
              '<th>AnalysisID</th>', '<th>analyzer</th>', '<th>parameters</th>',
              '<th>status</th>',
-             '<th>version</th>', '<th>created_at</th>',
+             '<th>version</th>', '<th>updated_at</th>',
              '<th style="min-width: 18px; width: 1%;"></th>']
   SORT_BY = ["id", "id", "analyzer_id", "parameters", "status", "analyzer_version", "updated_at", "id"]
 

--- a/app/views/shared/_analyses.html.haml
+++ b/app/views/shared/_analyses.html.haml
@@ -7,14 +7,8 @@
 %table.table.table-condensed.table-striped#analyses_list.has_analysis_modal{:'data-source' => "#{path_to_analyses_list}"}
   %thead
     %tr
-      %th{style: "min-width: 18px; width: 1%;"}
-      %th AnalysisID
-      %th analyzer
-      %th parameters
-      %th status
-      %th version
-      %th created_at
-      %th{style: "min-width: 18px; width: 1%;"}
+      - AnalysesListDatatable::HEADER.each do |header|
+        = raw(header)
   %tbody
 
 :javascript


### PR DESCRIPTION
#238 に対応(fixedHeaderは未対応)
- 旧仕様のfnReloadAjaxを読み込まないようにした
- ColVis
    - parameter_set, run, analysisのテーブルで表示するカラムを選択可能
- アイコンのソート不可
    - テーブルに並ぶアイコン（子要素をModalで見るfa-search，子要素を削除するfa-trash)はソート不可に変更

- FixedHeader(テーブルのヘッダを画面トップに保持する)は機能しない
    - 原因は不明
    - 最新のソースと置き換えると機能するが，bootstrap3との相性が悪く，ソートアイコンがうまく表示されない

-  外観
![colvis2](https://cloud.githubusercontent.com/assets/5600507/12346592/35291a32-bb99-11e5-90e6-0d2674268563.png)
