### PR TITLE
update net-ssh and set non_interactive to true

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
     multi_json (1.10.1)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
-    net-ssh (2.8.0)
+    net-ssh (3.0.1)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     optionable (0.2.0)

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -124,7 +124,7 @@ class Host
     if @ssh
       yield @ssh
     else
-      Net::SSH.start(hostname, user, password: "", timeout: 1, keys: ssh_key, port: port) do |ssh|
+      Net::SSH.start(hostname, user, password: "", timeout: 1, keys: ssh_key, port: port, non_interactive: true) do |ssh|
         @ssh = ssh
         begin
           yield ssh


### PR DESCRIPTION
non_interactive option is added by this PR
  https://github.com/net-ssh/net-ssh/pull/245/files

passphraseが要求されても端末に要求を表示せずに失敗させる。