### PR TITLE
Validate uniqueness of name only for not being destroyed

### DIFF
--- a/app/models/analyzer.rb
+++ b/app/models/analyzer.rb
@@ -17,7 +17,7 @@ class Analyzer
   ## fields for auto run
   belongs_to :auto_run_submitted_to, class_name: "Host"
 
-  default_scope ->{ where(:to_be_destroyed.in => [nil,false]) }
+  default_scope ->{ where(to_be_destroyed: false) }
 
   validates :name, presence: true, uniqueness: {scope: :simulator}, format: {with: /\A\w+\z/}
   validates :type, presence: true, 

--- a/app/models/analyzer.rb
+++ b/app/models/analyzer.rb
@@ -19,7 +19,7 @@ class Analyzer
 
   default_scope ->{ where(to_be_destroyed: false) }
 
-  validates :name, presence: true, uniqueness: {scope: :simulator}, format: {with: /\A\w+\z/}
+  validates :name, presence: true, uniqueness: {scope: [:simulator, :to_be_destroyed] }, format: {with: /\A\w+\z/}, unless: :to_be_destroyed
   validates :type, presence: true, 
                    inclusion: {in: [:on_run, :on_parameter_set]}
   validates :auto_run, inclusion: {in: [:yes, :no, :first_run_only]}

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -14,7 +14,7 @@ class Simulator
   has_many :parameter_set_queries, dependent: :destroy
   has_many :analyzers, dependent: :destroy, autosave: true #enable autosave to copy analyzers
 
-  default_scope ->{ where(:to_be_destroyed.in => [nil,false]) }
+  default_scope ->{ where(to_be_destroyed: false) }
 
   validates :name, presence: true, uniqueness: true, format: {with: /\A\w+\z/}
   validates :parameter_definitions, presence: true

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -16,7 +16,7 @@ class Simulator
 
   default_scope ->{ where(to_be_destroyed: false) }
 
-  validates :name, presence: true, uniqueness: true, format: {with: /\A\w+\z/}
+  validates :name, presence: true, uniqueness: {scope: :to_be_destroyed}, format: {with: /\A\w+\z/}, unless: :to_be_destroyed
   validates :parameter_definitions, presence: true
 
   accepts_nested_attributes_for :parameter_definitions, allow_destroy: true

--- a/lib/tasks/update_schema.rake
+++ b/lib/tasks/update_schema.rake
@@ -50,5 +50,19 @@ namespace :db do
       session.command(create: "worker_logs", capped: true, size: 1048576)
       $stderr.puts "capped collection worker_logs was created"
     end
+
+    q = Simulator.where(to_be_destroyed: nil)
+    progressbar = ProgressBar.create(total: q.count, format: "%t %B %p%% (%c/%C)")
+    q.each do |sim|
+      sim.update_attribute(:to_be_destroyed, false)
+      progressbar.increment
+    end
+
+    q = Analyzer.where(to_be_destroyed: nil)
+    progressbar = ProgressBar.create(total: q.count, format: "%t %B %p%% (%c/%C)")
+    q.each do |azr|
+      azr.update_attribute(:to_be_destroyed, false)
+      progressbar.increment
+    end
   end
 end

--- a/spec/models/analyzer_spec.rb
+++ b/spec/models/analyzer_spec.rb
@@ -65,6 +65,18 @@ describe Analyzer do
         analyzer = @sim.analyzers.build(@valid_fields.update({name:"b l a n k"}))
         expect(analyzer).not_to be_valid
       end
+
+      it "is valid when name is identical to an analyzer being destroyed" do
+        azr = @sim.analyzers.create!(@valid_fields)
+        azr.update_attribute(:to_be_destroyed, true)
+        expect( @sim.analyzers.build(@valid_fields) ).to be_valid
+      end
+
+      it "can take identical name for simulators being destroyed" do
+        attr = @valid_fields.update(to_be_destroyed: true)
+        azr = @sim.analyzers.create!(attr)
+        expect( @sim.analyzers.build(attr) ).to be_valid
+      end
     end
 
     describe "'type' field" do

--- a/spec/models/simulator_spec.rb
+++ b/spec/models/simulator_spec.rb
@@ -52,6 +52,18 @@ describe Simulator do
       sim.name = "AnotherSimulator"
       expect(sim).to be_valid
     end
+
+    it "is valid when name is identical to a simulator being destroyed" do
+      sim = Simulator.create!(@valid_fields)
+      sim.update_attribute(:to_be_destroyed, true)
+      expect( Simulator.new(@valid_fields) ).to be_valid
+    end
+
+    it "can take identical name for simulators being destroyed" do
+      attr = @valid_fields.update(to_be_destroyed: true)
+      Simulator.create!(attr)
+      expect( Simulator.new(attr) ).to be_valid
+    end
   end
 
   describe "'command' field" do


### PR DESCRIPTION
fixed #427

uniquenessのcheckにdefault_scopeが適用されないため問題が起きる。
`to_be_destroyed` をuniquenessのscopeに加える。
このままだと、`to_be_destroyed=true`のドキュメント内で重複した名前を持つことができないので、`to_be_destroyed=false`のドキュメントに対してのみvalidationを行うようにする。

また、`to_be_destroyed=nil` と `to_be_destroyed=false` それぞれで同じ名前を持つことができてしまうので、nilのドキュメントをfalseに更新する。
