### PR TITLE
show tooltip to count runs

### DIFF
--- a/app/assets/javascripts/simulator.js
+++ b/app/assets/javascripts/simulator.js
@@ -334,3 +334,10 @@ function draw_progress_overview(url) {
     loading.remove();
   })
 };
+
+$(function() {
+  $(".progress").tooltip({
+      placement: 'bottom'
+  });
+});
+

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,7 +45,7 @@ module ApplicationHelper
     end
 
     tags = <<-EOS
-      <div class="progress">
+      <div class="progress" data-toggle="tooltip" title=#{{finished: num_success, running: num_danger, failed: num_warning, submitted: num_submitted}.to_json}>
         #{progress_bar_tag_for('success', percent_success)}
         #{progress_bar_tag_for('danger', percent_danger)}
         #{progress_bar_tag_for('warning', percent_warning)}


### PR DESCRIPTION
fixed #439 

- bootstrap3のtooltipを利用

![tooltip_on_progress-bar](https://cloud.githubusercontent.com/assets/5600507/12943237/4d14bb4e-d023-11e5-9da1-1cbbde60698f.png)
