### PR TITLE
fix the bug that field 'h' is created

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -193,7 +193,7 @@ class Host
     self.executable_simulators.each do |sim|
       [:default_host_parameters, :default_mpi_procs, :default_omp_threads].each do |h|
         modified = sim.send(h).delete_if{|key, value| key == id.to_s}
-        sim.timeless.update_attribute(:h, modified)
+        sim.timeless.update_attribute(h, modified)
       end
     end
   end

--- a/lib/tasks/update_schema.rake
+++ b/lib/tasks/update_schema.rake
@@ -64,5 +64,20 @@ namespace :db do
       azr.update_attribute(:to_be_destroyed, false)
       progressbar.increment
     end
+
+    # to fix issue #460
+    q = Simulator.where(:h.exists => true)
+    progressbar = ProgressBar.create(total: q.count, format: "%t %B %p%% (%c/%C)")
+    q.each do |sim|
+      sim.unset(:h)
+      progressbar.increment
+    end
+
+    q = Analyzer.where(:h.exists => true)
+    progressbar = ProgressBar.create(total: q.count, format: "%t %B %p%% (%c/%C)")
+    q.each do |azr|
+      azr.unset(:h)
+      progressbar.increment
+    end
   end
 end


### PR DESCRIPTION
fixed #460 

'h' というフィールドがSimulatorに作成されてしまう。

Mongoid ではフィールドを変更してから update_attribute を呼ぶと、指定したフィールドでなくても保存されてしまうようだ。つまり、今の実装だと既存のフィールドは正しく更新されるが、どうじに:hという新しいフィールドも余分に追加されていた。
そのため、テストはとくに問題なく通過していた。

update_schemaでそのような不要な属性を削除する
