### PR TITLE
improved the style of .form-control for firefox

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -118,4 +118,12 @@ pre {
 .tooltip-inner {
   max-width: unset;
 }
+// See http://stackoverflow.com/questions/19982651
+//     http://stackoverflow.com/questions/24448991
+//     https://github.com/crest-cassia/oacis/issues/455
+//     http://stackoverflow.com/questions/7229568
+.form-control {
+  padding-top: 0;
+  padding-bottom: 0;
+}
 


### PR DESCRIPTION
fixed #455 

firefoxでformの表示が乱れる問題。

大元の原因は
https://github.com/crest-cassia/oacis/commit/d13ef9ac0e24e311ea89eab15842a0b8ff22b8ab
のコミットで入ったbootstra_and_override.css で line-height-base=1 が指定されていることが原因。
しかしこの指定を取ると、他のページのすべてが大きく表示されるようにない影響が大きい。

調べるとheightをauto, line-height: normal に指定する方法が提示されていたが、そうするとchromeとfirefoxで見た目が大きく変わってしまう。
http://stackoverflow.com/questions/7229568

そこで回避策として.form-control クラスの上下のpaddingを0にすることにした。
修正後のスクリーンショット
firefox
![image](https://cloud.githubusercontent.com/assets/718731/15136239/839cba1c-16ba-11e6-8532-ab1c86b80727.png)

chrome
![image](https://cloud.githubusercontent.com/assets/718731/15136264/ba38ebc2-16ba-11e6-8653-4b19f74ef167.png)

