### PR TITLE
display html result in iframe

### DIFF
--- a/app/assets/javascripts/runs.js
+++ b/app/assets/javascripts/runs.js
@@ -24,3 +24,9 @@ $(function() {
 
   window.datatables_for_runs_table = datatables_for_runs_table;
 });
+
+// This function is used to adjust the size of iframe
+function resizeIframe(obj) {
+  obj.style.height = obj.contentWindow.document.body.scrollHeight + 'px';
+  obj.style.width = obj.contentWindow.document.body.scrollWidth + 'px';
+}

--- a/app/helpers/runs_helper.rb
+++ b/app/helpers/runs_helper.rb
@@ -47,6 +47,9 @@ module RunsHelper
         if result_path.to_s =~ /(\.png|\.jpg|\.bmp)$/i
           sio.puts '<br />'
           sio.puts image_tag( file_path_to_link_path(result_path) )
+        elsif result_path.to_s =~ /\.html$/
+          sio.puts '<br />'
+          sio.puts "<iframe src=#{file_path_to_link_path(result_path)} seamless sandbox=\"allow-same-origin allow-scripts\" onload=\"resizeIframe(this)\"></iframe>"
         end
         sio.puts '</a></li>'
       end


### PR DESCRIPTION
When a html file is included in the result files, it is displayed in iframe.
The size of the iframe is adjusted to the contents of the html file.
Users can access to another file from the inner html, which makes it possible to plot the result using d3.js for example.

![image](https://cloud.githubusercontent.com/assets/718731/15266248/fd673d96-19d9-11e6-9929-a263aa1b51c1.png)
