### PR TITLE
Add spec for gathering result of plot

### DIFF
--- a/spec/controllers/parameter_sets_controller_spec.rb
+++ b/spec/controllers/parameter_sets_controller_spec.rb
@@ -845,7 +845,7 @@ describe ParameterSetsController do
       expect(loaded["data"]).to match_array(expected_data)
     end
 
-    it "returns collect values when irrelevant keys are given" do
+    it "returns collected values when irrelevant keys are given" do
       get :_scatter_plot,
         {id: @ps_array.first, x_axis_key: "L", y_axis_key: "T", result: "cpu_time", irrelevants: "P", format: :json}
 
@@ -928,7 +928,7 @@ describe ParameterSetsController do
           expect(loaded["data"]).to match_array(expected_data)
       end
 
-      it "returns collect values when irrelevant keys are given" do
+      it "returns collected values when irrelevant keys are given" do
         get :_scatter_plot,
           {id: @ps_array.first, x_axis_key: "L", y_axis_key: "T", result: "#{@analyzer.name}.ResultKey1", irrelevants: "P", format: :json}
 
@@ -1010,7 +1010,7 @@ describe ParameterSetsController do
           expect(loaded["data"]).to match_array(expected_data)
       end
 
-      it "returns collect values when irrelevant keys are given" do
+      it "returns collected values when irrelevant keys are given" do
         get :_scatter_plot,
           {id: @ps_array.first, x_axis_key: "L", y_axis_key: "T", result: "#{@analyzer.name}.ResultKey1", irrelevants: "P", format: :json}
 


### PR DESCRIPTION
fixed #457

Add tests for gathering results on line plot and scatter plot
Note:
- The types of aggregated results are either "Integer" or "Float"
    - The type of aggregated `average` values is always "Float" like 99.0 and 999.0 regardless of the type of  target result.
    - The type of aggregated `first` value is depend on the type of target result.