### PR TITLE
Implement discard method

### DIFF
--- a/app/controllers/analyses_controller.rb
+++ b/app/controllers/analyses_controller.rb
@@ -30,7 +30,7 @@ class AnalysesController < ApplicationController
 
   def destroy
     anl = Analysis.find(params[:id])
-    anl.update_attribute(:to_be_destroyed, true)
+    anl.discard
 
     respond_to do |format|
       format.json { head :no_content }

--- a/app/controllers/analyzers_controller.rb
+++ b/app/controllers/analyzers_controller.rb
@@ -55,8 +55,7 @@ class AnalyzersController < ApplicationController
   def destroy
     analyzer = Analyzer.find(params[:id])
     simulator = analyzer.simulator
-    analyzer.update_attribute(:to_be_destroyed, true)
-    analyzer.set_lower_submittable_to_be_destroyed
+    analyzer.discard
 
     respond_to do |format|
       format.json { head :no_content }

--- a/app/controllers/parameter_sets_controller.rb
+++ b/app/controllers/parameter_sets_controller.rb
@@ -147,8 +147,7 @@ class ParameterSetsController < ApplicationController
   def destroy
     @ps = ParameterSet.find(params[:id])
     simulator = Simulator.find(@ps.simulator_id)
-    @ps.update_attribute(:to_be_destroyed, true)
-    @ps.set_lower_submittable_to_be_destroyed
+    @ps.discard
 
     respond_to do |format|
       format.json { head :no_content }

--- a/app/controllers/runs_controller.rb
+++ b/app/controllers/runs_controller.rb
@@ -91,8 +91,7 @@ class RunsController < ApplicationController
 
   def destroy
     @run = Run.find(params[:id])
-    @run.update_attribute(:to_be_destroyed, true)
-    @run.set_lower_submittable_to_be_destroyed
+    @run.discard
 
     respond_to do |format|
       format.json { head :no_content }

--- a/app/controllers/simulators_controller.rb
+++ b/app/controllers/simulators_controller.rb
@@ -96,8 +96,7 @@ class SimulatorsController < ApplicationController
   # DELETE /simulators/1.json
   def destroy
     @simulator = Simulator.find(params[:id])
-    @simulator.update_attribute(:to_be_destroyed, true)
-    @simulator.set_lower_submittable_to_be_destroyed
+    @simulator.discard
 
     respond_to do |format|
       format.html { redirect_to simulators_url }

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -94,6 +94,10 @@ class Analysis
     true
   end
 
+  def discard
+    update_attribute(:to_be_destroyed, true)
+  end
+
   def set_lower_submittable_to_be_destroyed
     # do nothing
   end

--- a/app/models/analyzer.rb
+++ b/app/models/analyzer.rb
@@ -74,6 +74,11 @@ class Analyzer
     anl_versions.map {|key,val| val['version'] = key; val }.sort_by {|a| a['latest_started_at']}
   end
 
+  def discard
+    update_attribute(:to_be_destroyed, true)
+    set_lower_submittable_to_be_destroyed
+  end
+
   def destroyable?
     analyses.unscoped.empty?
   end

--- a/app/models/parameter_set.rb
+++ b/app/models/parameter_set.rb
@@ -73,6 +73,11 @@ class ParameterSet
     counts
   end
 
+  def discard
+    update_attribute(:to_be_destroyed, true)
+    set_lower_submittable_to_be_destroyed
+  end
+
   def destroyable?
     if runs.unscoped.empty? and analyses.unscoped.empty?
       run_ids = runs.unscoped.map {|run| run.id }

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -82,6 +82,11 @@ class Run
     dir.join('..', "#{id}.tar.bz2")
   end
 
+  def discard
+    update_attribute(:to_be_destroyed, true)
+    set_lower_submittable_to_be_destroyed
+  end
+
   def destroyable?
     analyses.unscoped.empty?
   end

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -136,6 +136,11 @@ class Simulator
     list
   end
 
+  def discard
+    update_attribute(:to_be_destroyed, true)
+    set_lower_submittable_to_be_destroyed
+  end
+
   def destroyable?
     if runs.unscoped.empty?
       azr_ids = analyzers.unscoped.map {|azr| azr.id }

--- a/app/workers/document_destroyer.rb
+++ b/app/workers/document_destroyer.rb
@@ -1,7 +1,6 @@
 class DocumentDestroyer
 
   def self.perform(logger)
-    @skip_count ||= {}
     @logger = logger
 
     @logger.debug "looking for Simulator to be destroyed"
@@ -28,7 +27,6 @@ class DocumentDestroyer
       if obj.destroyable?
         @logger.info "destroying #{obj.class} #{obj.id}"
         obj.destroy
-        @skip_count.delete(obj.id)
       else
         obj.set_lower_submittable_to_be_destroyed
         @logger.info "skip destroying #{obj.class} #{obj.id}. not destroyable yet."

--- a/lib/cli/oacis_cli_analysis.rb
+++ b/lib/cli/oacis_cli_analysis.rb
@@ -181,7 +181,7 @@ class OacisCli < Thor
       progressbar = ProgressBar.create(total: analyses.count, format: "%t %B %p%% (%c/%C)")
       # no_timeout enables destruction of 10000 or more analyses
       analyses.no_timeout.each do |anl|
-        anl.update_attribute(:to_be_destroyed, true)
+        anl.discard
         progressbar.increment
       end
     end
@@ -200,8 +200,7 @@ class OacisCli < Thor
 
     progressbar = ProgressBar.create( total: found_ids.count, format: "%t %B %p%% (%c/%C)")
     anls.each do |anl|
-      anl.update_attribute(:to_be_destroyed, true)
-      anl.set_lower_submittable_to_be_destroyed
+      anl.discard
       progressbar.increment
     end
   end
@@ -279,7 +278,7 @@ class OacisCli < Thor
         new_analysis = ParameterSet.find(anl.analyzable_id).analyses.build(anl_attr)
       end
       if new_analysis.save
-        anl.update_attribute(:to_be_destroyed, true)
+        anl.discard
       else
         progressbar.log "Failed to create Analysis #{new_analysis.errors.full_messages}"
       end

--- a/lib/cli/oacis_cli_run.rb
+++ b/lib/cli/oacis_cli_run.rb
@@ -175,8 +175,7 @@ class OacisCli < Thor
       progressbar = ProgressBar.create(total: runs.count, format: "%t %B %p%% (%c/%C)")
       # no_timeout enables destruction of 10000 or more runs
       runs.no_timeout.each do |run|
-        run.update_attribute(:to_be_destroyed, true)
-        run.set_lower_submittable_to_be_destroyed
+        run.discard
         progressbar.increment
       end
     end
@@ -195,8 +194,7 @@ class OacisCli < Thor
 
     progressbar = ProgressBar.create( total: found_ids.count, format: "%t %B %p%% (%c/%C)")
     runs.each do |run|
-      run.update_attribute(:to_be_destroyed, true)
-      run.set_lower_submittable_to_be_destroyed
+      run.discard
       progressbar.increment
     end
   end
@@ -273,8 +271,7 @@ class OacisCli < Thor
                    priority: run.priority }
       new_run = run.parameter_set.runs.build(run_attr)
       if new_run.save
-        run.update_attribute(:to_be_destroyed, true)
-        run.set_lower_submittable_to_be_destroyed
+        run.discard
       else
         progressbar.log "Failed to create Run #{new_run.errors.full_messages}"
       end

--- a/spec/models/analysis_spec.rb
+++ b/spec/models/analysis_spec.rb
@@ -162,6 +162,25 @@ describe Analysis do
     end
   end
 
+  describe "#discard" do
+
+    before(:each) do
+      sim = FactoryGirl.create(:simulator,
+                               parameter_sets_count: 1,
+                               runs_count: 1,
+                               analyzers_count: 1,
+                               run_analysis: true
+                               )
+      @anl = sim.parameter_sets.first.runs.first.analyses.first
+    end
+
+    it "updates 'to_be_destroyed' to true" do
+      expect {
+        @anl.discard
+      }.to change { @anl.to_be_destroyed }.from(false).to(true)
+    end
+  end
+
   describe "#input" do
 
     describe "for :on_run type" do

--- a/spec/models/analyzer_spec.rb
+++ b/spec/models/analyzer_spec.rb
@@ -181,6 +181,25 @@ describe Analyzer do
     end
   end
 
+  describe "#discard" do
+
+    before(:each) do
+      sim = FactoryGirl.create(:simulator, analyzers_count: 1)
+      @azr = sim.analyzers.first
+    end
+
+    it "updates 'to_be_destroyed' to true" do
+      expect {
+        @azr.discard
+      }.to change { @azr.to_be_destroyed }.from(false).to(true)
+    end
+
+    it "should receive 'set_lower_submittable_to_be_destroyed'" do
+      expect(@azr).to receive(:set_lower_submittable_to_be_destroyed)
+      @azr.discard
+    end
+  end
+
   describe "#set_lower_submittable_to_be_destroyed" do
 
     before(:each) do

--- a/spec/models/parameter_set_spec.rb
+++ b/spec/models/parameter_set_spec.rb
@@ -298,6 +298,25 @@ describe ParameterSet do
     end
   end
 
+  describe "#discard" do
+
+    before(:each) do
+      sim = FactoryGirl.create(:simulator, parameter_sets_count: 1)
+      @ps = sim.parameter_sets.first
+    end
+
+    it "updates 'to_be_destroyed' to true" do
+      expect {
+        @ps.discard
+      }.to change { @ps.to_be_destroyed }.from(false).to(true)
+    end
+
+    it "should receive 'set_lower_submittable_to_be_destroyed'" do
+      expect(@ps).to receive(:set_lower_submittable_to_be_destroyed)
+      @ps.discard
+    end
+  end
+
   describe "#set_lower_submittable_to_be_destroyed" do
 
     before(:each) do

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -437,6 +437,25 @@ describe Run do
     end
   end
 
+  describe "#discard" do
+
+    before(:each) do
+      sim = FactoryGirl.create(:simulator, parameter_sets_count: 1, runs_count: 1)
+      @run = sim.parameter_sets.first.runs.first
+    end
+
+    it "updates 'to_be_destroyed' to true" do
+      expect {
+        @run.discard
+      }.to change { @run.to_be_destroyed }.from(false).to(true)
+    end
+
+    it "should receive 'set_lower_submittable_to_be_destroyed'" do
+      expect(@run).to receive(:set_lower_submittable_to_be_destroyed)
+      @run.discard
+    end
+  end
+
   describe "#set_lower_submittable_to_be_destroyed" do
 
     before(:each) do

--- a/spec/models/simulator_spec.rb
+++ b/spec/models/simulator_spec.rb
@@ -137,6 +137,24 @@ describe Simulator do
     end
   end
 
+  describe "#discard" do
+
+    before(:each) do
+      @sim = FactoryGirl.create(:simulator)
+    end
+
+    it "updates 'to_be_destroyed' to true" do
+      expect {
+        @sim.discard
+      }.to change { @sim.to_be_destroyed }.from(false).to(true)
+    end
+
+    it "should receive 'set_lower_submittable_to_be_destroyed'" do
+      expect(@sim).to receive(:set_lower_submittable_to_be_destroyed)
+      @sim.discard
+    end
+  end
+
   describe "#set_lower_submittable_to_be_destroyed" do
 
     before(:each) do


### PR DESCRIPTION
Implemented '#discard' method to Simulator, ParameterSets, Run, Analyzer, Analysis classes.
The method was introduced for the consistency of the APIs.
