### PR TITLE
introduced pry-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "quiet_assets"
 
 # utility tool
 gem "pry"
+gem "pry-rails"
 gem "rspec-rails", '~>3.5' # must be in :development group to use the rake task 'spec'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,8 @@ GEM
     pry-byebug (1.3.2)
       byebug (~> 2.7)
       pry (~> 0.9.12)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     quiet_assets (1.0.2)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
@@ -267,6 +269,7 @@ DEPENDENCIES
   parallel
   pry
   pry-byebug
+  pry-rails
   quiet_assets
   rails (~> 4.2.0)
   redcarpet


### PR DESCRIPTION
To let users easily operate on an interactive environment, pry-rails gem is introduced.
Users can call pry REPL by executing `bundle exec rails c`
