### PR TITLE
new CLI: destroy_parameter_sets

### DIFF
--- a/lib/cli/oacis_cli_parameter_set.rb
+++ b/lib/cli/oacis_cli_parameter_set.rb
@@ -98,6 +98,34 @@ class OacisCli < Thor
     write_parameter_set_ids_to_file(options[:output], parameter_set_ids)
   end
 
+  desc 'destroy_parameter_sets', "destroy parameter_sets"
+  method_option :simulator,
+    type:     :string,
+    aliases:  '-s',
+    desc:     'simulator ID or path to simulator_id.json',
+    required: true
+  def destroy_parameter_sets
+    simulator = get_simulator(options[:simulator])
+    pss = simulator.parameter_sets
+
+    if pss.empty?
+      say("No parameter sets are found.")
+      return
+    end
+
+    if options[:verbose]
+      say("Found parameter sets: #{pss.map(&:id).to_json}")
+    end
+
+    if options[:yes] or yes?("Destroy #{pss.count} parameter sets?")
+      progressbar = ProgressBar.create(total: pss.count, format: "%t %B %p%% (%c/%C)")
+      pss.no_timeout.each do |ps|
+        ps.discard
+        progressbar.increment
+      end
+    end
+  end
+
   private
   def expand_input(input)
     if input.is_a?(Array)

--- a/spec/lib/cli/oacis_cli_parameter_set_spec.rb
+++ b/spec/lib/cli/oacis_cli_parameter_set_spec.rb
@@ -395,5 +395,30 @@ describe OacisCli do
       end
     end
   end
+
+  describe "#destroy_parameter_sets" do
+
+    before(:each) do
+      @sim = FactoryGirl.create(:simulator, parameter_sets_count: 3)
+    end
+
+    it "destroys all the parameter sets under the specified simulator" do
+      options = {simulator: @sim.id.to_s, yes: true}
+      expect {
+        OacisCli.new.invoke(:destroy_parameter_sets, [], options)
+      }.to change { @sim.parameter_sets.count }.from(3).to(0)
+    end
+
+    context "if user say 'no'" do
+
+      it "does not destroy parameter sets" do
+        options = {simulator: @sim.id.to_s}
+        expect(Thor::LineEditor).to receive(:readline).with("Destroy 3 parameter sets? ", :add_to_history => false).and_return("n")
+        expect {
+          OacisCli.new.invoke(:destroy_parameter_sets, [], options)
+        }.not_to change { @sim.parameter_sets.count }
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
it destroys all the parameter sets in the simulator.
In future, we would like to add an option to specify the parameter sets to be destroyed.