### PR TITLE
Validate unknown parameter keys

### DIFF
--- a/lib/parameters_util.rb
+++ b/lib/parameters_util.rb
@@ -6,6 +6,16 @@ module ParametersUtil
     casted = {}
     parameters = parameters.try(:with_indifferent_access) || {}
 
+    # check if an unknown key exists or not
+    residual_keys = parameters.keys.map(&:to_s) - definitions.map(&:key)
+    if residual_keys.present?
+      if errors
+        errors.add(:v, "Unknown keys are given: #{residual_keys.inspect}")
+      else
+        return nil
+      end
+    end
+
     definitions.each do |pdef|
       key = pdef.key
       type = pdef.type

--- a/spec/lib/parameters_util_spec.rb
+++ b/spec/lib/parameters_util_spec.rb
@@ -84,6 +84,21 @@ describe ParametersUtil do
         expect(casted["param3"]).to eq true
       end
     end
+
+    context "when unknown keys are given" do
+
+      it "returns nil" do
+        parameters = {
+          "param1" => "70",
+          "param2" => "3.0",
+          "param3" => "1",
+          "param4" => 12345,
+          "param5" => "abc"
+        }
+        casted = ParametersUtil.cast_parameter_values(parameters, @definitions)
+        expect(casted).to be_nil
+      end
+    end
   end
 
   describe ".cast_value" do

--- a/spec/models/analysis_spec.rb
+++ b/spec/models/analysis_spec.rb
@@ -83,6 +83,12 @@ describe Analysis do
       expect(arn.parameters["param2"]).to eq(default_val)
     end
 
+    it "is invalid if a parameter contains an unknown key" do
+      invalid_attr = @valid_attr.update(parameters: {"unknown" => "32"})
+      anl = @run.analyses.build(invalid_attr)
+      expect(anl).to_not be_valid
+    end
+
     it "adopts default values when parameter hash is not given" do
       updated_attr = @valid_attr
       updated_attr.delete(:parameters)

--- a/spec/models/parameter_set_spec.rb
+++ b/spec/models/parameter_set_spec.rb
@@ -55,6 +55,12 @@ describe ParameterSet do
       expect(built_param).not_to be_valid
     end
 
+    it "should not be valid when v contains an unknown key" do
+      invalid_attr = @valid_attr.update(v: {"l" => 32, "T" => 1.0} )  # key "l" does not exist in parameter_definitions
+      built = @sim.parameter_sets.build( invalid_attr )
+      expect( built ).to_not be_valid
+    end
+
     it "should not be valid when v is not unique" do
       @sim.parameter_sets.create!(@valid_attr)
       built = @sim.parameter_sets.build(@valid_attr)

--- a/spec/models/parameter_set_spec.rb
+++ b/spec/models/parameter_set_spec.rb
@@ -23,13 +23,13 @@ describe ParameterSet do
 
   describe "validation" do
 
-    it "should create a Parameter when valid attributes are given" do
+    it "should create a ParameterSet when valid attributes are given" do
       expect {
         @sim.parameter_sets.create!(@valid_attr)
       }.not_to raise_error
     end
 
-    it "should not be balid when simulator is not related" do
+    it "should not be valid when simulator is not related" do
       param = ParameterSet.new(@valid_attr)
       expect(param).not_to be_valid
     end


### PR DESCRIPTION
cause a validation error when PS.v or Analysis.parameters contains an unknown key.
This extension is intended to make debugging that uses an OACIS APIs easier.