### PR TITLE
daemon fails to start or stop

### DIFF
--- a/lib/tasks/daemon.rake
+++ b/lib/tasks/daemon.rake
@@ -24,15 +24,15 @@ namespace :daemon do
     else
       here = File.dirname(__FILE__)
       threads << Thread.new do
-        cmd = "bundle exec ruby -r #{Rails.root.join('config','environment.rb')} #{File.join(here, 'boot_job_submitter_worker.rb')} start"
+        cmd = "bundle exec ruby -r '#{Rails.root.join('config','environment.rb')}' '#{File.join(here, 'boot_job_submitter_worker.rb')}' start"
         system(cmd)
       end
       threads << Thread.new do
-        cmd = "bundle exec ruby -r #{Rails.root.join('config','environment.rb')} #{File.join(here, 'boot_job_observer_worker.rb')} start"
+        cmd = "bundle exec ruby -r '#{Rails.root.join('config','environment.rb')}' '#{File.join(here, 'boot_job_observer_worker.rb')}' start"
         system(cmd)
       end
       threads << Thread.new do
-        cmd = "bundle exec ruby -r #{Rails.root.join('config','environment.rb')} #{File.join(here, 'boot_service_worker.rb')} start"
+        cmd = "bundle exec ruby -r '#{Rails.root.join('config','environment.rb')}' '#{File.join(here, 'boot_service_worker.rb')}' start"
         system(cmd)
       end
     end
@@ -59,17 +59,17 @@ namespace :daemon do
 
     here = File.dirname(__FILE__)
     threads << Thread.new do
-      cmd = "bundle exec ruby -r #{Rails.root.join('config','environment.rb')} #{File.join(here, 'boot_job_submitter_worker.rb')} stop"
+      cmd = "bundle exec ruby -r '#{Rails.root.join('config','environment.rb')}' '#{File.join(here, 'boot_job_submitter_worker.rb')}' stop"
       system(cmd)
     end
 
     threads << Thread.new do
-      cmd = "bundle exec ruby -r #{Rails.root.join('config','environment.rb')} #{File.join(here, 'boot_job_observer_worker.rb')} stop"
+      cmd = "bundle exec ruby -r '#{Rails.root.join('config','environment.rb')}' '#{File.join(here, 'boot_job_observer_worker.rb')}' stop"
       system(cmd)
     end
 
     threads << Thread.new do
-      cmd = "bundle exec ruby -r #{Rails.root.join('config','environment.rb')} #{File.join(here, 'boot_service_worker.rb')} stop"
+      cmd = "bundle exec ruby -r '#{Rails.root.join('config','environment.rb')}' '#{File.join(here, 'boot_service_worker.rb')}' stop"
       system(cmd)
     end
 


### PR DESCRIPTION
when the path to Rails.root include white space, it fails to start or
stop as the command line option is not correctly specified.