### PR TITLE
Idempotent apis

### DIFF
--- a/app/models/parameter_set.rb
+++ b/app/models/parameter_set.rb
@@ -73,6 +73,19 @@ class ParameterSet
     counts
   end
 
+  def find_or_create_runs_upto( num_runs, submitted_to: nil, host_param: {}, mpi_procs: 1, omp_threads: 1 )
+    found = runs.asc(:created_at).limit(num_runs).to_a
+    n = found.size
+    (num_runs - n).times do |i|
+      r = runs.create!(submitted_to: submitted_to,
+                       host_parameters: host_param,
+                       mpi_procs: mpi_procs,
+                       omp_threads: omp_threads)
+      found << r
+    end
+    found
+  end
+
   def discard
     update_attribute(:to_be_destroyed, true)
     set_lower_submittable_to_be_destroyed

--- a/app/models/parameter_set.rb
+++ b/app/models/parameter_set.rb
@@ -73,6 +73,7 @@ class ParameterSet
     counts
   end
 
+  # public APIs
   def find_or_create_runs_upto( num_runs, submitted_to: nil, host_param: {}, mpi_procs: 1, omp_threads: 1 )
     found = runs.asc(:created_at).limit(num_runs).to_a
     n = found.size

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -137,7 +137,7 @@ class Simulator
   end
 
   # used by APIs
-  def find_ps_with_param( parameters )
+  def find_ps_of_parameters( parameters )
     unknown_keys = parameters.keys.map(&:to_s) - default_parameters.keys
     raise "Unknown keys: #{unknown_keys}" unless unknown_keys.empty?
 
@@ -149,8 +149,8 @@ class Simulator
     parameter_sets.where(v: merged).first
   end
 
-  def find_or_create_ps_with_param( parameters )
-    find_ps_with_param( parameters ) or parameter_sets.create!(v: parameters)
+  def find_or_create_ps_of_parameters( parameters )
+    find_ps_of_parameters( parameters ) or parameter_sets.create!(v: parameters)
   end
 
   def default_parameters

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -137,7 +137,7 @@ class Simulator
   end
 
   # used by APIs
-  def find_ps_with_param(parameters)
+  def find_ps_with_param( parameters )
     unknown_keys = parameters.keys.map(&:to_s) - parameter_definitions.map(&:key)
     raise "Unknown keys: #{unknown_keys}" unless unknown_keys.empty?
 
@@ -147,6 +147,10 @@ class Simulator
       merged[pd.key] = (params[pd.key] or pd.default)
     end
     parameter_sets.where(v: merged).first
+  end
+
+  def find_or_create_ps_with_param( parameters )
+    find_ps_with_param( parameters ) or parameter_sets.create!(v: parameters)
   end
 
   def discard

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -136,6 +136,19 @@ class Simulator
     list
   end
 
+  # used by APIs
+  def find_ps_with_param(parameters)
+    unknown_keys = parameters.keys.map(&:to_s) - parameter_definitions.map(&:key)
+    raise "Unknown keys: #{unknown_keys}" unless unknown_keys.empty?
+
+    merged = {}
+    params = parameters.with_indifferent_access
+    parameter_definitions.each do |pd|
+      merged[pd.key] = (params[pd.key] or pd.default)
+    end
+    parameter_sets.where(v: merged).first
+  end
+
   def discard
     update_attribute(:to_be_destroyed, true)
     set_lower_submittable_to_be_destroyed

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -138,19 +138,27 @@ class Simulator
 
   # used by APIs
   def find_ps_with_param( parameters )
-    unknown_keys = parameters.keys.map(&:to_s) - parameter_definitions.map(&:key)
+    unknown_keys = parameters.keys.map(&:to_s) - default_parameters.keys
     raise "Unknown keys: #{unknown_keys}" unless unknown_keys.empty?
 
     merged = {}
     params = parameters.with_indifferent_access
-    parameter_definitions.each do |pd|
-      merged[pd.key] = (params[pd.key] or pd.default)
+    default_parameters.each do |key,default|
+      merged[key] = (params[key] or default)
     end
     parameter_sets.where(v: merged).first
   end
 
   def find_or_create_ps_with_param( parameters )
     find_ps_with_param( parameters ) or parameter_sets.create!(v: parameters)
+  end
+
+  def default_parameters
+    default = {}
+    parameter_definitions.each do |pd|
+      default[pd.key] = pd.default
+    end
+    default
   end
 
   def discard

--- a/spec/models/simulator_spec.rb
+++ b/spec/models/simulator_spec.rb
@@ -231,6 +231,15 @@ describe Simulator do
     end
   end
 
+  describe "#default_parameters" do
+
+    it "returns default parameters" do
+      sim = FactoryGirl.create(:simulator, parameter_sets_count: 0)
+      expected = {"L" => 50, "T" => 1.0}
+      expect( sim.default_parameters ).to eq expected
+    end
+  end
+
   describe "#discard" do
 
     before(:each) do

--- a/spec/models/simulator_spec.rb
+++ b/spec/models/simulator_spec.rb
@@ -137,6 +137,53 @@ describe Simulator do
     end
   end
 
+  describe "#find_ps_with_param" do
+
+    before(:each) do
+      @sim = FactoryGirl.create(:simulator, parameter_sets_count: 0)
+    end
+
+    it "returns PS with the given parameters" do
+      parameters = {"L"=>10, "T"=>2.0}
+      created = @sim.parameter_sets.create!(v: parameters)
+      found = @sim.find_ps_with_param( parameters )
+      expect(found).to eq created
+    end
+
+    it "returns nil if matching PS is not found" do
+      parameters = {"L"=>10, "T"=>2.0}
+      @sim.parameter_sets.create!(v: parameters)
+      found = @sim.find_ps_with_param( {"L"=>20, "T"=>1.0} )
+      expect(found).to be_nil
+    end
+
+    it "argument is complemented with the default value" do
+      t_default = @sim.parameter_definitions.where(key:"T").first.default
+      parameters = {"L"=>10, "T"=>t_default}
+      created = @sim.parameter_sets.create!(v: parameters)
+      found = @sim.find_ps_with_param( {"L"=>10} )
+      expect(found).to eq created
+
+      found2 = @sim.find_ps_with_param( {} )
+      expect(found2).to be_nil
+    end
+
+    it "arguments can be a hash with symbol-keys" do
+      parameters = {"L"=>10, "T"=>2.0}
+      created = @sim.parameter_sets.create!(v: parameters)
+      found = @sim.find_ps_with_param( L:10, T:2.0 )
+      expect(found).to eq created
+    end
+
+    it "raises an exception when unknown key is included in the argument" do
+      parameters = {"L"=>10, "T"=>2.0}
+      @sim.parameter_sets.create!(v: parameters)
+      expect {
+        @sim.find_ps_with_param( parameters.merge({"Q"=>1}) )
+      }.to raise_error(/^Unknown keys:/)
+    end
+  end
+
   describe "#discard" do
 
     before(:each) do

--- a/spec/models/simulator_spec.rb
+++ b/spec/models/simulator_spec.rb
@@ -137,7 +137,7 @@ describe Simulator do
     end
   end
 
-  describe "#find_ps_with_param" do
+  describe "#find_ps_of_parameters" do
 
     before(:each) do
       @sim = FactoryGirl.create(:simulator, parameter_sets_count: 0)
@@ -146,14 +146,14 @@ describe Simulator do
     it "returns PS with the given parameters" do
       parameters = {"L"=>10, "T"=>2.0}
       created = @sim.parameter_sets.create!(v: parameters)
-      found = @sim.find_ps_with_param( parameters )
+      found = @sim.find_ps_of_parameters( parameters )
       expect(found).to eq created
     end
 
     it "returns nil if matching PS is not found" do
       parameters = {"L"=>10, "T"=>2.0}
       @sim.parameter_sets.create!(v: parameters)
-      found = @sim.find_ps_with_param( {"L"=>20, "T"=>1.0} )
+      found = @sim.find_ps_of_parameters( {"L"=>20, "T"=>1.0} )
       expect(found).to be_nil
     end
 
@@ -161,17 +161,17 @@ describe Simulator do
       t_default = @sim.parameter_definitions.where(key:"T").first.default
       parameters = {"L"=>10, "T"=>t_default}
       created = @sim.parameter_sets.create!(v: parameters)
-      found = @sim.find_ps_with_param( {"L"=>10} )
+      found = @sim.find_ps_of_parameters( {"L"=>10} )
       expect(found).to eq created
 
-      found2 = @sim.find_ps_with_param( {} )
+      found2 = @sim.find_ps_of_parameters( {} )
       expect(found2).to be_nil
     end
 
     it "arguments can be a hash with symbol-keys" do
       parameters = {"L"=>10, "T"=>2.0}
       created = @sim.parameter_sets.create!(v: parameters)
-      found = @sim.find_ps_with_param( L:10, T:2.0 )
+      found = @sim.find_ps_of_parameters( L:10, T:2.0 )
       expect(found).to eq created
     end
 
@@ -179,12 +179,12 @@ describe Simulator do
       parameters = {"L"=>10, "T"=>2.0}
       @sim.parameter_sets.create!(v: parameters)
       expect {
-        @sim.find_ps_with_param( parameters.merge({"Q"=>1}) )
+        @sim.find_ps_of_parameters( parameters.merge({"Q"=>1}) )
       }.to raise_error(/^Unknown keys:/)
     end
   end
 
-  describe "#find_or_create_ps_with_param" do
+  describe "#find_or_create_ps_of_parameters" do
 
     before(:each) do
       @sim = FactoryGirl.create(:simulator, parameter_sets_count: 0)
@@ -193,14 +193,14 @@ describe Simulator do
     it "returns PS if there exists a PS with given parameters" do
       parameters = {"L"=>10, "T"=>2.0}
       created = @sim.parameter_sets.create!(v: parameters)
-      found = @sim.find_or_create_ps_with_param( parameters )
+      found = @sim.find_or_create_ps_of_parameters( parameters )
       expect(found).to eq created
     end
 
     it "creates a new PS with given parameters if no matching PS exists" do
       parameters = {"L"=>10, "T"=>2.0}
       expect {
-        found = @sim.find_or_create_ps_with_param( parameters )
+        found = @sim.find_or_create_ps_of_parameters( parameters )
         expect(found.v).to eq parameters
       }.to change { ParameterSet.count }.by(1)
     end
@@ -209,24 +209,24 @@ describe Simulator do
       t_default = @sim.parameter_definitions.where(key:"T").first.default
       parameters = {"L"=>10, "T"=>t_default}
       created = @sim.parameter_sets.create!(v: parameters)
-      found = @sim.find_or_create_ps_with_param( {"L"=>10} )
+      found = @sim.find_or_create_ps_of_parameters( {"L"=>10} )
       expect(found).to eq created
 
       expect {
-        default_ps = @sim.find_or_create_ps_with_param( {} )
+        default_ps = @sim.find_or_create_ps_of_parameters( {} )
         expect(default_ps.v["T"]).to eq t_default
       }.to change { ParameterSet.count }.by(1)
     end
 
     it "arguments can be a hash with symbol-keys" do
-      created = @sim.find_or_create_ps_with_param( L:10, T:2.0 )
+      created = @sim.find_or_create_ps_of_parameters( L:10, T:2.0 )
       expect(created.v).to eq({"L"=>10,"T"=>2.0})
     end
 
     it "raises an exception when unknown key is included in the argument" do
       parameters = {"L"=>10, "T"=>2.0}
       expect {
-        @sim.find_or_create_ps_with_param( parameters.merge({"Q"=>1}) )
+        @sim.find_or_create_ps_of_parameters( parameters.merge({"Q"=>1}) )
       }.to raise_error(/^Unknown keys:/)
     end
   end


### PR DESCRIPTION
Added an idempotent APIs to improve the usability of APIs.

The specification of the new APIs are the following.

## New APIs

### Simulator#default_parameters

- returns a hash of default parameters

```rb
sim.default_parameters    # => {"p1"=>1, "p2"=>2.0, "p3"=>"c"}
```

### Simulator#find_ps_of_parameters( parameters )

- find a parameter set by parameters
- returns nil if matching PS is not found
- if the argument does not contain all the parameters, the missing values are substituted by the default one

```rb
sim.find_ps_of_parameters( {"p1"=>1, "p2"=>2.0} )   # => parameter_set or nil
```

### Simulator#find_or_create_ps_of_parameters( parameters )

- find a parameter set by parameters if it exists.
- create a new PS when a PS of the given parameters does not exist.
- if the argument does not contain all the parameters, the missing values are substituted by the default one

```rb
sim.find_or_create_ps_of_parameters( {"p1"=>1, "p2"=>2.0} )
# => parameter_set of {"p1"=>1, "p2"=>2.0, "p3" => "c"} is created and returned
```

### find_or_create_runs_upto( num_runs, submitted_to: nil, host_param: {}, mpi_procs: 1, omp_threads: 1 )

- create runs until the number of runs becomes "num_runs"
- host_parameters for newly created runs are specified by the second arguments.
- returns an array of Runs

```rb
ps.find_or_create_runs_upto( 10, submitted_to: host )
```
