### PR TITLE
Refine apis

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -111,6 +111,10 @@ class Host
     count
   end
 
+  def default_host_parameters
+    host_parameter_definitions.map {|d| [d.key, d.default] }.to_h
+  end
+
   def work_base_dir_is_not_editable?
     self.persisted? and (submitted_runs.any? or submitted_analyses.any?)
   end

--- a/app/models/parameter_set.rb
+++ b/app/models/parameter_set.rb
@@ -87,6 +87,20 @@ class ParameterSet
     found
   end
 
+  def average_result(key, error: false)
+    results = runs.where(status: :finished).only(:result).map {|r| r.result[key].to_f }.compact
+    n = results.size
+    return ( error ? [nil,0,nil] : [nil,0] ) if n==0
+    avg = results.inject(:+) / n
+    if error
+      r2_sum = results.inject(0.0) {|sum,x| sum + (x-avg)**2}
+      err = n > 1 ? Math.sqrt(r2_sum/(n*(n-1.0))) : nil
+      return [avg, n, err]
+    else
+      return [avg, n]
+    end
+  end
+
   def discard
     update_attribute(:to_be_destroyed, true)
     set_lower_submittable_to_be_destroyed

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -149,7 +149,7 @@ class Simulator
     parameter_sets.where(v: merged).first
   end
 
-  def find_or_create_ps_of_parameters( parameters )
+  def find_or_create_parameter_set( parameters )
     find_parameter_set( parameters ) or parameter_sets.create!(v: parameters)
   end
 

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -138,15 +138,15 @@ class Simulator
 
   # used by APIs
   def find_parameter_set( parameters )
-    unknown_keys = parameters.keys.map(&:to_s) - default_parameters.keys
+    casted_parameters = parameters.map {|k,v| [k.to_s,v] }.to_h
+    expected_keys = default_parameters.keys
+    given_keys = casted_parameters.keys
+    unknown_keys = given_keys - expected_keys
     raise "Unknown keys: #{unknown_keys}" unless unknown_keys.empty?
+    missing_keys = expected_keys - given_keys
+    raise "Missing keys: #{missing_keys}" unless missing_keys.empty?
 
-    merged = {}
-    params = parameters.with_indifferent_access
-    default_parameters.each do |key,default|
-      merged[key] = (params[key] or default)
-    end
-    parameter_sets.where(v: merged).first
+    parameter_sets.where(v: casted_parameters).first
   end
 
   def find_or_create_parameter_set( parameters )

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -158,7 +158,7 @@ class Simulator
     parameter_definitions.each do |pd|
       default[pd.key] = pd.default
     end
-    default
+    default.with_indifferent_access
   end
 
   def discard

--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -137,7 +137,7 @@ class Simulator
   end
 
   # used by APIs
-  def find_ps_of_parameters( parameters )
+  def find_parameter_set( parameters )
     unknown_keys = parameters.keys.map(&:to_s) - default_parameters.keys
     raise "Unknown keys: #{unknown_keys}" unless unknown_keys.empty?
 
@@ -150,7 +150,7 @@ class Simulator
   end
 
   def find_or_create_ps_of_parameters( parameters )
-    find_ps_of_parameters( parameters ) or parameter_sets.create!(v: parameters)
+    find_parameter_set( parameters ) or parameter_sets.create!(v: parameters)
   end
 
   def default_parameters

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -329,6 +329,16 @@ describe Host do
     end
   end
 
+  describe "#default_host_parameters" do
+
+    it "returns default values of host parameters" do
+      hpd1 = HostParameterDefinition.new(key: "hp1", default: "foo")
+      hpd2 = HostParameterDefinition.new(key: "hp2", default: "bar")
+      host = FactoryGirl.create(:host, host_parameter_definitions: [hpd1,hpd2] )
+      expect( host.default_host_parameters ).to eq( {"hp1"=>"foo","hp2"=>"bar"} )
+    end
+  end
+
   describe "registering host_parameter_definitions" do
 
     it "gets host parameters by invoking 'get_host_parameters' when host status is changed into :enabled" do

--- a/spec/models/simulator_spec.rb
+++ b/spec/models/simulator_spec.rb
@@ -184,7 +184,7 @@ describe Simulator do
     end
   end
 
-  describe "#find_or_create_ps_of_parameters" do
+  describe "#find_or_create_parameter_set" do
 
     before(:each) do
       @sim = FactoryGirl.create(:simulator, parameter_sets_count: 0)
@@ -193,14 +193,14 @@ describe Simulator do
     it "returns PS if there exists a PS with given parameters" do
       parameters = {"L"=>10, "T"=>2.0}
       created = @sim.parameter_sets.create!(v: parameters)
-      found = @sim.find_or_create_ps_of_parameters( parameters )
+      found = @sim.find_or_create_parameter_set( parameters )
       expect(found).to eq created
     end
 
     it "creates a new PS with given parameters if no matching PS exists" do
       parameters = {"L"=>10, "T"=>2.0}
       expect {
-        found = @sim.find_or_create_ps_of_parameters( parameters )
+        found = @sim.find_or_create_parameter_set( parameters )
         expect(found.v).to eq parameters
       }.to change { ParameterSet.count }.by(1)
     end
@@ -209,24 +209,24 @@ describe Simulator do
       t_default = @sim.parameter_definitions.where(key:"T").first.default
       parameters = {"L"=>10, "T"=>t_default}
       created = @sim.parameter_sets.create!(v: parameters)
-      found = @sim.find_or_create_ps_of_parameters( {"L"=>10} )
+      found = @sim.find_or_create_parameter_set( {"L"=>10} )
       expect(found).to eq created
 
       expect {
-        default_ps = @sim.find_or_create_ps_of_parameters( {} )
+        default_ps = @sim.find_or_create_parameter_set( {} )
         expect(default_ps.v["T"]).to eq t_default
       }.to change { ParameterSet.count }.by(1)
     end
 
     it "arguments can be a hash with symbol-keys" do
-      created = @sim.find_or_create_ps_of_parameters( L:10, T:2.0 )
+      created = @sim.find_or_create_parameter_set( L:10, T:2.0 )
       expect(created.v).to eq({"L"=>10,"T"=>2.0})
     end
 
     it "raises an exception when unknown key is included in the argument" do
       parameters = {"L"=>10, "T"=>2.0}
       expect {
-        @sim.find_or_create_ps_of_parameters( parameters.merge({"Q"=>1}) )
+        @sim.find_or_create_parameter_set( parameters.merge({"Q"=>1}) )
       }.to raise_error(/^Unknown keys:/)
     end
   end

--- a/spec/models/simulator_spec.rb
+++ b/spec/models/simulator_spec.rb
@@ -137,7 +137,7 @@ describe Simulator do
     end
   end
 
-  describe "#find_ps_of_parameters" do
+  describe "#find_parameter_set" do
 
     before(:each) do
       @sim = FactoryGirl.create(:simulator, parameter_sets_count: 0)
@@ -146,14 +146,14 @@ describe Simulator do
     it "returns PS with the given parameters" do
       parameters = {"L"=>10, "T"=>2.0}
       created = @sim.parameter_sets.create!(v: parameters)
-      found = @sim.find_ps_of_parameters( parameters )
+      found = @sim.find_parameter_set( parameters )
       expect(found).to eq created
     end
 
     it "returns nil if matching PS is not found" do
       parameters = {"L"=>10, "T"=>2.0}
       @sim.parameter_sets.create!(v: parameters)
-      found = @sim.find_ps_of_parameters( {"L"=>20, "T"=>1.0} )
+      found = @sim.find_parameter_set( {"L"=>20, "T"=>1.0} )
       expect(found).to be_nil
     end
 
@@ -161,17 +161,17 @@ describe Simulator do
       t_default = @sim.parameter_definitions.where(key:"T").first.default
       parameters = {"L"=>10, "T"=>t_default}
       created = @sim.parameter_sets.create!(v: parameters)
-      found = @sim.find_ps_of_parameters( {"L"=>10} )
+      found = @sim.find_parameter_set( {"L"=>10} )
       expect(found).to eq created
 
-      found2 = @sim.find_ps_of_parameters( {} )
+      found2 = @sim.find_parameter_set( {} )
       expect(found2).to be_nil
     end
 
     it "arguments can be a hash with symbol-keys" do
       parameters = {"L"=>10, "T"=>2.0}
       created = @sim.parameter_sets.create!(v: parameters)
-      found = @sim.find_ps_of_parameters( L:10, T:2.0 )
+      found = @sim.find_parameter_set( L:10, T:2.0 )
       expect(found).to eq created
     end
 
@@ -179,7 +179,7 @@ describe Simulator do
       parameters = {"L"=>10, "T"=>2.0}
       @sim.parameter_sets.create!(v: parameters)
       expect {
-        @sim.find_ps_of_parameters( parameters.merge({"Q"=>1}) )
+        @sim.find_parameter_set( parameters.merge({"Q"=>1}) )
       }.to raise_error(/^Unknown keys:/)
     end
   end

--- a/spec/models/simulator_spec.rb
+++ b/spec/models/simulator_spec.rb
@@ -238,6 +238,12 @@ describe Simulator do
       expected = {"L" => 50, "T" => 1.0}
       expect( sim.default_parameters ).to eq expected
     end
+
+    it "returns hash which is accessible also with symbol" do
+      sim = FactoryGirl.create(:simulator, parameter_sets_count: 0)
+      expect( sim.default_parameters[:L] ).to_not be_nil
+      expect( sim.default_parameters[:T] ).to_not be_nil
+    end
   end
 
   describe "#discard" do

--- a/spec/models/simulator_spec.rb
+++ b/spec/models/simulator_spec.rb
@@ -157,17 +157,6 @@ describe Simulator do
       expect(found).to be_nil
     end
 
-    it "argument is complemented with the default value" do
-      t_default = @sim.parameter_definitions.where(key:"T").first.default
-      parameters = {"L"=>10, "T"=>t_default}
-      created = @sim.parameter_sets.create!(v: parameters)
-      found = @sim.find_parameter_set( {"L"=>10} )
-      expect(found).to eq created
-
-      found2 = @sim.find_parameter_set( {} )
-      expect(found2).to be_nil
-    end
-
     it "arguments can be a hash with symbol-keys" do
       parameters = {"L"=>10, "T"=>2.0}
       created = @sim.parameter_sets.create!(v: parameters)
@@ -181,6 +170,12 @@ describe Simulator do
       expect {
         @sim.find_parameter_set( parameters.merge({"Q"=>1}) )
       }.to raise_error(/^Unknown keys:/)
+    end
+
+    it "raises an exception when the given parameter has a missing key" do
+      expect {
+        @sim.find_parameter_set( "L" => 10 )
+      }.to raise_error(/^Missing keys:/)
     end
   end
 
@@ -205,19 +200,6 @@ describe Simulator do
       }.to change { ParameterSet.count }.by(1)
     end
 
-    it "argument is complemented with the default values" do
-      t_default = @sim.parameter_definitions.where(key:"T").first.default
-      parameters = {"L"=>10, "T"=>t_default}
-      created = @sim.parameter_sets.create!(v: parameters)
-      found = @sim.find_or_create_parameter_set( {"L"=>10} )
-      expect(found).to eq created
-
-      expect {
-        default_ps = @sim.find_or_create_parameter_set( {} )
-        expect(default_ps.v["T"]).to eq t_default
-      }.to change { ParameterSet.count }.by(1)
-    end
-
     it "arguments can be a hash with symbol-keys" do
       created = @sim.find_or_create_parameter_set( L:10, T:2.0 )
       expect(created.v).to eq({"L"=>10,"T"=>2.0})
@@ -228,6 +210,12 @@ describe Simulator do
       expect {
         @sim.find_or_create_parameter_set( parameters.merge({"Q"=>1}) )
       }.to raise_error(/^Unknown keys:/)
+    end
+
+    it "raises an exception when the given parameter has a missing key" do
+      expect {
+      @sim.find_or_create_parameter_set( {"L"=>10} )
+      }.to raise_error(/^Missing keys:/)
     end
   end
 


### PR DESCRIPTION
refine interface of APIs.

- renamed the following APIs
    - from Simulator#find_ps_of_parameters to Simulator#find_parameter_set
    - from Simulator#find_or_create_ps_of_parameters to Simulator#find_or_create_parameter_set
- changed the behavior of "find_parameter_set" and "find_or_create_parameter_set" such that it raises an exception when the argument has an unspecified parameter
- added a new APIs
    - Host#default_host_parameters
        - returns the default host parameters
    - ParameterSet#average_result
        - returns the average of the result and the number of elements. Optionally, standard error is also returned.