### PR TITLE
sets default_host_param if host_param option is not given

### DIFF
--- a/app/models/parameter_set.rb
+++ b/app/models/parameter_set.rb
@@ -74,9 +74,10 @@ class ParameterSet
   end
 
   # public APIs
-  def find_or_create_runs_upto( num_runs, submitted_to: nil, host_param: {}, mpi_procs: 1, omp_threads: 1 )
+  def find_or_create_runs_upto( num_runs, submitted_to: nil, host_param: nil, mpi_procs: 1, omp_threads: 1 )
     found = runs.asc(:created_at).limit(num_runs).to_a
     n = found.size
+    host_param ||= submitted_to.try(:default_host_parameters)
     (num_runs - n).times do |i|
       r = runs.create!(submitted_to: submitted_to,
                        host_parameters: host_param,

--- a/spec/models/parameter_set_spec.rb
+++ b/spec/models/parameter_set_spec.rb
@@ -349,6 +349,17 @@ describe ParameterSet do
         end
       end
 
+      it "sets default host parameters if host_param option is not given" do
+        host_param_defs = [
+          HostParameterDefinition.new(key:"hp1",default:"aaa"),
+          HostParameterDefinition.new(key:"hp2"),
+        ]
+        h = FactoryGirl.create(:host, host_parameter_definitions: host_param_defs)
+
+        runs = @ps.find_or_create_runs_upto(1, submitted_to: h)
+        expect( runs.first.host_parameters ).to eq ( {"hp1"=>"aaa","hp2"=>nil} )
+      end
+
       it "does not set host_param to existing runs" do
         run1 = @ps.runs.create!
 


### PR DESCRIPTION
`ParameterSet#find_or_create_runs_upto` method sets default host parameters if `host_param` option is not given.
