### PR TITLE
irrelevant keys are not working in scatter plot and figure viewer

### DIFF
--- a/app/views/parameter_sets/_plot.html.haml
+++ b/app/views/parameter_sets/_plot.html.haml
@@ -75,6 +75,12 @@
   $(show_form_for_plots);
   $('#plot-type').change(show_form_for_plots);
 
+  function get_irrelevants() {
+    var irrelevants = $('#irrelevant-params').find("input:checkbox:checked").map(function() {
+      return $(this).data('key');
+    }).get().join(',');
+    return irrelevants;
+  }
   function add_line_plot(x, y, series, irrelevants) {
     var url = "#{_line_plot_parameter_set_path(@param_set)}" + ".json";
     var url_with_param = url + 
@@ -89,10 +95,7 @@
     var x = $('#line-plot-form #x_axis_key').val();
     var y = $('#line-plot-form #y_axis_key').val();
     var series = $('#line-plot-form #series').val();
-    var irrelevants = $('#irrelevant-params').find("input:checkbox:checked").map(function() {
-      return $(this).data('key');
-      }).get().join(',');
-
+    var irrelevants = get_irrelevants();
     if( x == "" ) {
       x = new Array();
       $('#x_axis_key').children('option').each(function() {
@@ -137,10 +140,7 @@
     var x = $('#scatter-plot-form #x_axis_key').val();
     var y = $('#scatter-plot-form #y_axis_key').val();
     var result = $('#scatter-plot-form #result').val();
-    var irrelevants = $('#irrelevant-params').children("input:checkbox:checked").map(function() {
-      return this.id;
-      }).get().join(',');
-
+    var irrelevants = get_irrelevants();
     add_scatter_plot(x, y, result, irrelevants);
   });
 
@@ -158,10 +158,7 @@
     var x = $('#figure-viewer-form #x_axis_key').val();
     var y = $('#figure-viewer-form #y_axis_key').val();
     var result = $('#figure-viewer-form #result').val();
-    var irrelevants = $('#irrelevant-params').children("input:checkbox:checked").map(function() {
-      return this.id;
-      }).get().join(',');
-
+    var irrelevants = get_irrelevants();
     add_figure_viewer(x, y, result, irrelevants);
   });
 


### PR DESCRIPTION
Irrelevant keys are not working in scatter plot and figure viewer. (Line plot are working...)
Parsing checkbox was incorrect.

You can confirm the fix by seeing the irrelevant keys shown next to the plot.
![image](https://cloud.githubusercontent.com/assets/718731/19617099/ec5a6364-9861-11e6-9ab0-dc2cfe1d7506.png)

