### PR TITLE
set default number of runs to 1

### DIFF
--- a/app/views/parameter_sets/_form.html.haml
+++ b/app/views/parameter_sets/_form.html.haml
@@ -19,7 +19,7 @@
   .form-group
     = label_tag('num_runs', 'Target # of Runs', class: 'col-md-2 control-label')
     .col-md-3
-      = select_tag('num_runs', options_for_select([0,1,2,3,4,5,10,20], selected: @num_runs), class: 'form-control')
+      = select_tag('num_runs', options_for_select([0,1,2,3,4,5,10,20], selected: (@num_runs || 1)), class: 'form-control')
   #runs_fields
     = fields_for run do |builder|
       = render 'runs/fields', run: builder.object, f: builder


### PR DESCRIPTION
When creating a ParameterSet, the default number of runs was zero, which often leads to confusion of users.
The default number is set to 1 now.

![image](https://cloud.githubusercontent.com/assets/718731/19842525/332a77aa-9f5d-11e6-986d-03c6cb6cb577.png)
