### PR TITLE
Suppress stdout stderr during tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ group :test do
   gem "simplecov", :require => false
   gem "simplecov-rcov", :require => false
   gem "ci_reporter", '~> 1.9'
-  gem "spork"
   gem "faker"
   if RUBY_VERSION >= '2.0.0'
     gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,6 @@ GEM
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
     slop (3.6.0)
-    spork (0.9.2)
     sprockets (3.6.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -274,7 +273,6 @@ DEPENDENCIES
   sass-rails
   simplecov
   simplecov-rcov
-  spork
   sprockets (= 3.6.3)
   sys-filesystem
   therubyracer

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -120,7 +120,7 @@ class Analysis
     elsif analyzable.is_a?(ParameterSet)
       self.parameter_set = analyzable
     else
-      raise "must not happen"
+      raise "no parent document"
     end
   end
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,7 @@
+development:
+  secret_key_base: fbb496445759e688a254b88f69b4daebe7c458bf7301b01d9ac0e483d9917fabae180c51190c7fff356dcac9443e2c9b3680ef887c669858eb6fc6406c958c52
+test:
+  secret_key_base: fbb496445759e688a254b88f69b4daebe7c458bf7301b01d9ac0e483d9917fabae180c51190c7fff356dcac9443e2c9b3680ef887c669858eb6fc6406c958c52
+production:
+  secret_key_base: fbb496445759e688a254b88f69b4daebe7c458bf7301b01d9ac0e483d9917fabae180c51190c7fff356dcac9443e2c9b3680ef887c669858eb6fc6406c958c52
+  # secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>, tentatively 'secret_key_base' is fixed

--- a/lib/cli/oacis_cli_analysis.rb
+++ b/lib/cli/oacis_cli_analysis.rb
@@ -117,7 +117,7 @@ class OacisCli < Thor
 
   private
   def write_analysis_ids_to_file(path, analyses)
-    return if analyses.empty?
+    return if analyses.blank?
     File.open(path, 'w') {|io|
       ids = analyses.map {|anl| "  #{{'analysis_id' => anl.id.to_s}.to_json}"}
       io.puts "[", ids.join(",\n"), "]"

--- a/lib/scheduler_wrapper.rb
+++ b/lib/scheduler_wrapper.rb
@@ -1,6 +1,7 @@
 class SchedulerWrapper
 
   def initialize(host)
+    raise "Not a host : #{host}" unless host.is_a?(Host)
     @work_base_dir = Pathname.new(host.work_base_dir)
   end
 

--- a/spec/controllers/runs_controller_spec.rb
+++ b/spec/controllers/runs_controller_spec.rb
@@ -84,7 +84,7 @@ describe RunsController do
         @req_param.update(parameter_set_id: 1234)
         expect {
           post 'create', @req_param, valid_session
-        }.to raise_error
+        }.to raise_error Mongoid::Errors::DocumentNotFound
       end
     end
 

--- a/spec/lib/cli/oacis_cli_common_spec.rb
+++ b/spec/lib/cli/oacis_cli_common_spec.rb
@@ -6,9 +6,9 @@ describe OacisCli do
   describe "#usage" do
 
     it "prints usage" do
-      expect(capture(:stdout) {
+      expect {
         OacisCli.new.invoke(:usage)
-      }).not_to be_empty
+      }.to output(/usage:/).to_stdout
     end
   end
 

--- a/spec/lib/cli/oacis_cli_parameter_set_spec.rb
+++ b/spec/lib/cli/oacis_cli_parameter_set_spec.rb
@@ -54,7 +54,7 @@ describe OacisCli do
           option = {simulator: 'simulator_id.json', output: 'parameter_sets.json'}
           expect {
             OacisCli.new.invoke(:parameter_sets_template, [], option)
-          }.to raise_error
+          }.to raise_error Mongoid::Errors::DocumentNotFound
         }
       end
     end
@@ -313,7 +313,7 @@ describe OacisCli do
           option = {simulator: 'simulator_id.json', input: 'parameter_sets.json', output: "parameter_set_ids.json"}
           expect {
             OacisCli.new.invoke(:create_parameter_sets, [], option)
-          }.to raise_error
+          }.to raise_error(/No such file or directory/)
         }
       end
 
@@ -331,7 +331,7 @@ describe OacisCli do
           option = {simulator: 'simulator_id.json', input: 'parameter_sets.json', output: "parameter_set_ids.json"}
           expect {
             OacisCli.new.invoke(:create_parameter_sets, [], option)
-          }.to raise_error
+          }.to raise_error Mongoid::Errors::DocumentNotFound
         }
       end
     end
@@ -361,7 +361,7 @@ describe OacisCli do
         at_temp_dir {
           expect {
             invoke_create_parameter_sets_with_invalid_parameter_sets_json
-          }.to raise_error
+          }.to raise_error(/invalid type/)
         }
       end
     end

--- a/spec/lib/cli/oacis_cli_simulator_spec.rb
+++ b/spec/lib/cli/oacis_cli_simulator_spec.rb
@@ -154,8 +154,10 @@ describe OacisCli do
           }
           option = {input: 'simulator.json', output: 'simulator_id.json'}
           expect {
-            OacisCli.new.invoke(:create_simulator, [], option)
-          }.to raise_error
+            capture_stdout_stderr {
+              OacisCli.new.invoke(:create_simulator, [], option)
+            }
+          }.to raise_error(/validation of simulator failed/)
         }
       end
     end
@@ -237,7 +239,7 @@ describe OacisCli do
             option = {simulator: "INVALID", name: 'NEW_PARAM', type: "Float", default: 0.5}
             expect {
               OacisCli.new.invoke(:append_parameter_definition, [], option)
-            }.to raise_error
+            }.to raise_error(/No such file or directory/)
           }
         end
       end
@@ -248,8 +250,10 @@ describe OacisCli do
           at_temp_dir {
             option = {simulator: @sim.id.to_s, name: 'L', type: "Float", default: 0.5}
             expect {
-              OacisCli.new.invoke(:append_parameter_definition, [], option)
-            }.to raise_error
+              capture_stdout_stderr {
+                OacisCli.new.invoke(:append_parameter_definition, [], option)
+              }
+            }.to raise_error(/validation of new parameter definition failed/)
           }
         end
       end
@@ -260,8 +264,10 @@ describe OacisCli do
           at_temp_dir {
             option = {simulator: @sim.id.to_s, name: 'L', type: "Float", default: 0.5}
             expect {
-              OacisCli.new.invoke(:append_parameter_definition, [], option)
-            }.to raise_error
+              capture_stdout_stderr {
+                OacisCli.new.invoke(:append_parameter_definition, [], option)
+              }
+            }.to raise_error(/validation of new parameter definition failed/)
           }
         end
       end
@@ -272,8 +278,10 @@ describe OacisCli do
           at_temp_dir {
             option = {simulator: @sim.id.to_s, name: 'L', type: "Double", default: 0.5}
             expect {
-              OacisCli.new.invoke(:append_parameter_definition, [], option)
-            }.to raise_error
+              capture_stdout_stderr {
+                OacisCli.new.invoke(:append_parameter_definition, [], option)
+              }
+            }.to raise_error(/validation of new parameter definition failed/)
           }
         end
       end
@@ -284,8 +292,10 @@ describe OacisCli do
           at_temp_dir {
             option = {simulator: @sim.id.to_s, name: 'L', type: "Integer", default: 0.5}
             expect {
-              OacisCli.new.invoke(:append_parameter_definition, [], option)
-            }.to raise_error
+              capture_stdout_stderr {
+                OacisCli.new.invoke(:append_parameter_definition, [], option)
+              }
+            }.to raise_error(/validation of new parameter definition failed/)
           }
         end
       end

--- a/spec/lib/job_script_util_spec.rb
+++ b/spec/lib/job_script_util_spec.rb
@@ -144,7 +144,7 @@ shared_examples_for JobScriptUtil do
         expect($?).to receive(:to_i).and_return(1)
         expect {
           JobScriptUtil.expand_result_file(@submittable)
-        }.to raise_error
+        }.to raise_error "failed to extract the archive"
       end
 
       it "update submittable.error_messages" do

--- a/spec/lib/scheduler_wrapper_spec.rb
+++ b/spec/lib/scheduler_wrapper_spec.rb
@@ -10,7 +10,7 @@ describe SchedulerWrapper do
   it "raises an exception with an invalid type" do
     expect {
       SchedulerWrapper.new("invalid")
-    }.to raise_error
+    }.to raise_error(/Not a host/)
   end
 
   describe "#submit_command" do

--- a/spec/models/analysis_spec.rb
+++ b/spec/models/analysis_spec.rb
@@ -57,7 +57,7 @@ describe Analysis do
       arn = Analysis.new(@valid_attr)
       expect {
         arn.save!
-      }.to raise_error
+      }.to raise_error(/no parent document/)
     end
 
     it "is invalid when status is not an allowed value" do

--- a/spec/models/parameter_set_spec.rb
+++ b/spec/models/parameter_set_spec.rb
@@ -45,7 +45,7 @@ describe ParameterSet do
       invalid_attr = @valid_attr.update({v: "xxx"})
       expect {
         @sim.parameter_sets.build(invalid_attr)
-      }.to raise_error
+      }.to raise_error Mongoid::Errors::InvalidValue
     end
 
     it "should not be valid when keys of v are not consistent with its Simulator" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,4 @@
 require 'rubygems'
-require 'spork'
-#uncomment the following line to use spork with the debugger
-#require 'spork/ext/ruby-debug'
 
 module SpecHelper
   def at_temp_dir
@@ -23,124 +20,81 @@ module SpecHelper
   end
 end
 
+ENV["RAILS_ENV"] ||= 'test'
+if ENV['RAILS_ENV'] == 'test'
+  require 'simplecov'
+  require 'simplecov-rcov'
+  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+  SimpleCov.start 'rails'
+end
+require File.expand_path("../../config/environment", __FILE__)
+require 'rspec/rails'
 
+# Requires supporting ruby files with custom matchers and macros, etc,
+# in spec/support/ and its subdirectories.
+Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
-Spork.prefork do
-  # Loading more in this block will cause your tests to run faster. However,
-  # if you change any configuration or code from libraries loaded here, you'll
-  # need to restart spork for it take effect.
-  # This file is copied to spec/ when you run 'rails generate rspec:install'
-
-  ENV["RAILS_ENV"] ||= 'test'
-  if ENV['RAILS_ENV'] == 'test'
-    require 'simplecov'
-    require 'simplecov-rcov'
-    SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-    SimpleCov.start 'rails'
-  end
-  require File.expand_path("../../config/environment", __FILE__)
-  require 'rspec/rails'
-
-  # Requires supporting ruby files with custom matchers and macros, etc,
-  # in spec/support/ and its subdirectories.
-  Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
-
-  # redirect stdout and stderr
-  ProgressBar::Output.class_eval {  # suppress output of progress bar
-    unless defined? org_init
-      alias :org_init :initialize
-      def initialize( options )
-        opts = {output: File.open('/dev/null','w') }.merge(options)
-        org_init(opts)
-      end
-    end
-  }
-
-  RSpec.configure do |config|
-    config.infer_spec_type_from_file_location! # this line is added when updating rspec3
-    config.include SpecHelper
-    # ## Mock Framework
-    #
-    # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:
-    #
-    # config.mock_with :mocha
-    # config.mock_with :flexmock
-    # config.mock_with :rr
-
-    # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-    # config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
-    # If you're not using ActiveRecord, or you'd prefer not to run each of your
-    # examples within a transaction, remove the following line or assign false
-    # instead of true.
-    # config.use_transactional_fixtures = true
-
-    # If true, the base class of anonymous controllers will be inferred
-    # automatically. This will be the default behavior in future versions of
-    # rspec-rails.
-    config.infer_base_class_for_anonymous_controllers = false
-
-    # Run specs in random order to surface order dependencies. If you find an
-    # order dependency and want to debug it, you can fix the order by providing
-    # the seed, which is printed after each run.
-    #     --seed 1234
-    config.order = "random"
-
-    config.before(:suite) do
-      DatabaseCleaner.strategy = :truncation
-
-      root_dir = ResultDirectory.root
-      FileUtils.rm_r(root_dir) if FileTest.directory?(root_dir)
-      system('bundle exec rake db:mongoid:create_indexes RAILS_ENV=test')
-    end
-    config.after(:suite) do
-      system('bundle exec rake db:mongoid:remove_indexes RAILS_ENV=test')
-    end
-
-    config.before(:each) do
-      DatabaseCleaner.start
-    end
-    config.after(:each) do
-      DatabaseCleaner.clean
-    end
-
-    config.after(:all) do
-      root_dir = ResultDirectory.root
-      FileUtils.rm_r(root_dir) if FileTest.directory?(root_dir)
+# redirect stdout and stderr
+ProgressBar::Output.class_eval {  # suppress output of progress bar
+  unless defined? org_init
+    alias :org_init :initialize
+    def initialize( options )
+      opts = {output: File.open('/dev/null','w') }.merge(options)
+      org_init(opts)
     end
   end
+}
+
+RSpec.configure do |config|
+  config.infer_spec_type_from_file_location! # this line is added when updating rspec3
+  config.include SpecHelper
+  # ## Mock Framework
+  #
+  # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:
+  #
+  # config.mock_with :mocha
+  # config.mock_with :flexmock
+  # config.mock_with :rr
+
+  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
+  # config.fixture_path = "#{::Rails.root}/spec/fixtures"
+
+  # If you're not using ActiveRecord, or you'd prefer not to run each of your
+  # examples within a transaction, remove the following line or assign false
+  # instead of true.
+  # config.use_transactional_fixtures = true
+
+  # If true, the base class of anonymous controllers will be inferred
+  # automatically. This will be the default behavior in future versions of
+  # rspec-rails.
+  config.infer_base_class_for_anonymous_controllers = false
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = "random"
+
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :truncation
+
+    root_dir = ResultDirectory.root
+    FileUtils.rm_r(root_dir) if FileTest.directory?(root_dir)
+    system('bundle exec rake db:mongoid:create_indexes RAILS_ENV=test')
+  end
+  config.after(:suite) do
+    system('bundle exec rake db:mongoid:remove_indexes RAILS_ENV=test')
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+
+  config.after(:all) do
+    root_dir = ResultDirectory.root
+    FileUtils.rm_r(root_dir) if FileTest.directory?(root_dir)
+  end
 end
-
-Spork.each_run do
-  # This code will be run each time you run your specs.
-
-end
-
-# --- Instructions ---
-# Sort the contents of this file into a Spork.prefork and a Spork.each_run
-# block.
-#
-# The Spork.prefork block is run only once when the spork server is started.
-# You typically want to place most of your (slow) initializer code in here, in
-# particular, require'ing any 3rd-party gems that you don't normally modify
-# during development.
-#
-# The Spork.each_run block is run each time you run your specs.  In case you
-# need to load files that tend to change during development, require them here.
-# With Rails, your application modules are loaded automatically, so sometimes
-# this block can remain empty.
-#
-# Note: You can modify files loaded *from* the Spork.each_run block without
-# restarting the spork server.  However, this file itself will not be reloaded,
-# so if you change any of the code inside the each_run block, you still need to
-# restart the server.  In general, if you have non-trivial code in this file,
-# it's advisable to move it into a separate file so you can easily edit it
-# without restarting spork.  (For example, with RSpec, you could move
-# non-trivial code into a file spec/support/my_helper.rb, making sure that the
-# spec/support/* files are require'd from inside the each_run block.)
-#
-# Any code that is left outside the two blocks will be run during preforking
-# *and* during each_run -- that's probably not what you want.
-#
-# These instructions should self-destruct in 10 seconds.  If they don't, feel
-# free to delete them.

--- a/spec/workers/document_destroyer_spec.rb
+++ b/spec/workers/document_destroyer_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe JobSubmitter do
+describe DocumentDestroyer do
 
-  let(:logger) { Logger.new($stderr) }
+  let(:logger) { Logger.new( File.open('/dev/null','w') ) }
 
   describe "destroying Simulator" do
 

--- a/spec/workers/job_submitter_spec.rb
+++ b/spec/workers/job_submitter_spec.rb
@@ -16,7 +16,7 @@ describe JobSubmitter do
       @sim.executable_on.push @host
       @sim.save!
 
-      @logger = Logger.new($stderr)
+      @logger = Logger.new( File.open('/dev/null','w') )
     end
 
     after(:each) do
@@ -52,7 +52,7 @@ describe JobSubmitter do
       }.to_not raise_error
     end
 
-    it "enqueus jobs to remote host in order of priorities on runs" do
+    it "enqueues jobs to remote host in order of priorities on runs" do
       run = @sim.parameter_sets.first.runs.create(priority: 0, submitted_to: @host.to_param)
       run.save!
       expect {
@@ -61,7 +61,7 @@ describe JobSubmitter do
       expect(Run.where(status: :submitted, priority: 1).count).to eq 0
     end
 
-    it "enqueus jobs to remote host in order of created_at.acs on runs" do
+    it "enqueues jobs to remote host in order of created_at.acs on runs" do
       run1 = @sim.parameter_sets.first.runs.build(priority:0, submitted_to: @host.to_param)
       run2 = @sim.parameter_sets.first.runs.build(priority:0, submitted_to: @host.to_param)
       run2.save!
@@ -82,7 +82,7 @@ describe JobSubmitter do
                                 parameter_sets_count: 1, runs_count: 3,
                                 analyzers_count: 0
                                 )
-      @logger = Logger.new($stderr)
+      @logger = Logger.new( File.open('/dev/null','w') )
     end
 
     it "destroys runs whose status is created and to_be_destroyed is true" do


### PR DESCRIPTION
Refactoring specs.

- Removed various deprecation warnings.
- Introduced a method to suppressing stdout and stderr. Before introducing method, all stdout and stderr used to be redirected to files, which prevents pry from working during specs.
- Removed "spork" gem. It did not contribute to speeding the tests. Furthermore, Rspec3 was not supported.
