### PR TITLE
Tuning includer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "quiet_assets"
 gem "pry"
 gem "pry-rails"
 gem "rspec-rails", '~>3.5' # must be in :development group to use the rake task 'spec'
+gem "stackprof"
 
 group :test do
   gem "factory_girl_rails", '~> 4.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,6 +221,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    stackprof (0.2.10)
     sys-filesystem (1.1.7)
       ffi
     therubyracer (0.12.2)
@@ -274,6 +275,7 @@ DEPENDENCIES
   simplecov
   simplecov-rcov
   sprockets (= 3.6.3)
+  stackprof
   sys-filesystem
   therubyracer
   thin

--- a/app/services/job_includer.rb
+++ b/app/services/job_includer.rb
@@ -95,9 +95,9 @@ module JobIncluder
     logs.each do |path|
       if SSHUtil.exist?(ssh, path)
         SSHUtil.download_recursive(ssh, path, submittable.dir.join(path.basename))
-        SSHUtil.rm_r(ssh, path)
       end
     end
+    SSHUtil.rm_r(ssh, logs)
   end
 
   def self.move_local_file(host, submittable)
@@ -130,14 +130,12 @@ module JobIncluder
     logs.each do |path|
       if SSHUtil.exist?(ssh, path)
         SSHUtil.download_recursive(ssh, path, submittable.dir.join(path.basename))
-        SSHUtil.rm_r(ssh, path)
       end
     end
+    SSHUtil.rm_r(ssh, logs)
   end
 
   def self.remove_remote_files(ssh, paths)
-    paths.each do |path|
-      SSHUtil.rm_r(ssh, path) if SSHUtil.exist?(ssh, path)
-    end
+    SSHUtil.rm_r(ssh,paths)
   end
 end

--- a/app/services/remote_job_handler.rb
+++ b/app/services/remote_job_handler.rb
@@ -31,6 +31,7 @@ class RemoteJobHandler
     @host.start_ssh do |ssh|
       begin
         out = SSHUtil.execute(ssh, cmd)
+        raise RemoteSchedulerError if out.empty?
         status = scheduler.parse_remote_status(out)
       rescue => ex
         error_handle(ex, job, ssh)

--- a/app/services/remote_job_handler.rb
+++ b/app/services/remote_job_handler.rb
@@ -30,12 +30,8 @@ class RemoteJobHandler
     cmd = scheduler.status_command(job.job_id)
     @host.start_ssh do |ssh|
       begin
-        out, err, rc, sig = SSHUtil.execute2(ssh, cmd)
-        if rc == 0
-          status = scheduler.parse_remote_status(out) if rc == 0
-        else
-          raise RemoteSchedulerError, "remote_status failed: rc:#{rc}, #{out}, #{err}"
-        end
+        out = SSHUtil.execute(ssh, cmd)
+        status = scheduler.parse_remote_status(out)
       rescue => ex
         error_handle(ex, job, ssh)
       end

--- a/app/services/remote_job_handler.rb
+++ b/app/services/remote_job_handler.rb
@@ -172,7 +172,7 @@ class RemoteJobHandler
   def remove_remote_files(job)
     @host.start_ssh do |ssh|
       paths = RemoteFilePath.all_file_paths(@host, job)
-      SSHUtil.rm_r(ssh, path)
+      SSHUtil.rm_r(ssh, paths)
     end
   end
 

--- a/app/services/remote_job_handler.rb
+++ b/app/services/remote_job_handler.rb
@@ -175,9 +175,8 @@ class RemoteJobHandler
 
   def remove_remote_files(job)
     @host.start_ssh do |ssh|
-      RemoteFilePath.all_file_paths(@host, job).each do |path|
-        SSHUtil.rm_r(ssh, path) if SSHUtil.exist?(ssh, path)
-      end
+      paths = RemoteFilePath.all_file_paths(@host, job)
+      SSHUtil.rm_r(ssh, path)
     end
   end
 

--- a/lib/scheduler_wrapper.rb
+++ b/lib/scheduler_wrapper.rb
@@ -23,7 +23,7 @@ class SchedulerWrapper
   end
 
   def status_command(job_id)
-    "bash -l -c 'echo XSUB_BEGIN && xstat #{job_id}'"
+    "bash -l -c 'echo XSUB_BEGIN && xstat #{job_id} 2> /dev/null'"
   end
 
   def parse_remote_status(stdout)

--- a/lib/ssh_util.rb
+++ b/lib/ssh_util.rb
@@ -123,7 +123,11 @@ module SSHUtil
   # a relative path is recognized as a relative path from home directory
   # so replace '~' with '.' in this method
   def self.expand_remote_home_path(ssh, path)
-    home = ssh.exec!("echo $HOME").chomp
+    home = ssh.instance_variable_get(:@home_dir_cache)
+    unless home
+      home = ssh.exec!("echo $HOME").chomp
+      ssh.instance_variable_set(:@home_dir_cache, home)
+    end
     Pathname.new( path.to_s.sub(/^~/, home) )
   end
 end

--- a/lib/ssh_util.rb
+++ b/lib/ssh_util.rb
@@ -27,9 +27,10 @@ module SSHUtil
     end
   end
 
-  def self.rm_r(ssh, remote_path)
-    rpath = expand_remote_home_path(ssh, remote_path)
-    ssh.exec!("rm -r #{rpath}")
+  def self.rm_r(ssh, remote_paths)
+    remote_paths = [remote_paths] unless remote_paths.is_a?(Array)
+    rpaths = remote_paths.to_a.map {|rpath| expand_remote_home_path(ssh,rpath) }
+    ssh.exec!("rm -r #{rpaths.join(' ')}")
   end
 
   def self.uname(ssh)

--- a/lib/ssh_util.rb
+++ b/lib/ssh_util.rb
@@ -30,7 +30,7 @@ module SSHUtil
   def self.rm_r(ssh, remote_paths)
     remote_paths = [remote_paths] unless remote_paths.is_a?(Array)
     rpaths = remote_paths.to_a.map {|rpath| expand_remote_home_path(ssh,rpath) }
-    ssh.exec!("rm -r #{rpaths.join(' ')}")
+    ssh.exec!("rm -rf #{rpaths.join(' ')}")
   end
 
   def self.uname(ssh)

--- a/spec/lib/scheduler_wrapper_spec.rb
+++ b/spec/lib/scheduler_wrapper_spec.rb
@@ -45,7 +45,7 @@ EOS
   describe "#status_command" do
 
     it "returns a command to show the status of the host" do
-      expect(@wrapper.status_command("job_id")).to eq "bash -l -c 'echo XSUB_BEGIN && xstat job_id'"
+      expect(@wrapper.status_command("job_id")).to match(/bash -l -c 'echo XSUB_BEGIN && xstat job_id/)
     end
   end
 

--- a/spec/services/remote_job_handler_spec.rb
+++ b/spec/services/remote_job_handler_spec.rb
@@ -230,7 +230,7 @@ shared_examples_for RemoteJobHandler do
     end
 
     it "raise RemoteSchedulerError if remote status is not obtained by SchedulerWrapper" do
-      allow(SSHUtil).to receive(:execute2).and_return([nil, nil, 1, nil])
+      allow(SSHUtil).to receive(:execute).and_return("")
       expect {
         RemoteJobHandler.new(@host).remote_status(@submittable)
       }.to raise_error(RemoteJobHandler::RemoteSchedulerError)


### PR DESCRIPTION
Performance tuning of JobIncluder.
In my machine, it took  16.9sec to include one job. After the tuning, it takes about 6.3 sec.

- SSHUtil.expand_remote_home_path was too slow.
    - The remote home directory is cached on a instance variable.
- Improve SSHUtil.rm_r.
    - Instead of using sftp, we call "rm -rf" on the remote shell. Switching sftp and ssh take some time, so I reduced switching as low as possible.
- Use `SSHUtil.execute` rather than `SSHUtil.execute2`.
    - With `execute2`, we can get return code and stderr as well as stdout. However, it takes more time compared to that of `execute`
    - So I tried to use `execute` if possible.
