### PR TITLE
Tuning job includer

### DIFF
--- a/app/services/job_includer.rb
+++ b/app/services/job_includer.rb
@@ -97,7 +97,6 @@ module JobIncluder
         SSHUtil.download_recursive(ssh, path, submittable.dir.join(path.basename))
       end
     end
-    SSHUtil.rm_r(ssh, logs)
   end
 
   def self.move_local_file(host, submittable)
@@ -132,7 +131,6 @@ module JobIncluder
         SSHUtil.download_recursive(ssh, path, submittable.dir.join(path.basename))
       end
     end
-    SSHUtil.rm_r(ssh, logs)
   end
 
   def self.remove_remote_files(ssh, paths)

--- a/app/services/job_includer.rb
+++ b/app/services/job_includer.rb
@@ -90,13 +90,7 @@ module JobIncluder
     base = File.basename(archive)
     SSHUtil.download(ssh, archive, submittable.dir.join('..', base))
 
-    #include scheduler logs
-    logs = RemoteFilePath.scheduler_log_file_paths(host, submittable)
-    logs.each do |path|
-      if SSHUtil.exist?(ssh, path)
-        SSHUtil.download_recursive(ssh, path, submittable.dir.join(path.basename))
-      end
-    end
+    download_scheduler_logs(host, submittable, ssh)
   end
 
   def self.move_local_file(host, submittable)
@@ -123,13 +117,14 @@ module JobIncluder
     if SSHUtil.exist?(ssh, work_dir)
       SSHUtil.download_recursive(ssh, work_dir, submittable.dir)
     end
+    download_scheduler_logs(host, submittable, ssh)
+  end
 
+  def self.download_scheduler_logs(host, submittable, ssh)
     #include scheduler logs
     logs = RemoteFilePath.scheduler_log_file_paths(host, submittable)
     logs.each do |path|
-      if SSHUtil.exist?(ssh, path)
-        SSHUtil.download_recursive(ssh, path, submittable.dir.join(path.basename))
-      end
+      SSHUtil.download_recursive_if_exist(ssh, path, submittable.dir.join(path.basename))
     end
   end
 

--- a/app/services/job_includer.rb
+++ b/app/services/job_includer.rb
@@ -114,9 +114,7 @@ module JobIncluder
 
   def self.download_work_dir_if_exists(host, submittable, ssh)
     work_dir = RemoteFilePath.work_dir_path(host, submittable)
-    if SSHUtil.exist?(ssh, work_dir)
-      SSHUtil.download_recursive(ssh, work_dir, submittable.dir)
-    end
+    SSHUtil.download_recursive_if_exist(ssh, work_dir, submittable.dir)
     download_scheduler_logs(host, submittable, ssh)
   end
 

--- a/lib/scheduler_wrapper.rb
+++ b/lib/scheduler_wrapper.rb
@@ -42,7 +42,7 @@ class SchedulerWrapper
   end
 
   def cancel_command(job_id)
-    "bash -l -c 'xdel #{job_id}'"
+    "bash -l -c 'xdel #{job_id}; echo $?'"
   end
 
   def scheduler_log_file_paths(run)

--- a/spec/lib/scheduler_wrapper_spec.rb
+++ b/spec/lib/scheduler_wrapper_spec.rb
@@ -70,7 +70,7 @@ EOS
   describe "#cancel_command" do
 
     it "returns command to cancel a job" do
-      expect(@wrapper.cancel_command("job_id")).to eq "bash -l -c 'xdel job_id'"
+      expect(@wrapper.cancel_command("job_id")).to eq "bash -l -c 'xdel job_id; echo $?'"
     end
   end
 end

--- a/spec/services/remote_job_handler_spec.rb
+++ b/spec/services/remote_job_handler_spec.rb
@@ -248,6 +248,7 @@ shared_examples_for RemoteJobHandler do
 
     before(:each) do
       allow_any_instance_of(SchedulerWrapper).to receive(:cancel_command).and_return("echo")
+      allow(SSHUtil).to receive(:execute).and_return("0\n")
       @handler = RemoteJobHandler.new(@host)
     end
 


### PR DESCRIPTION
A bit more performance tuning and refactoring of JobIncluder.
Tried to replace `SSHUtil.execute2` as much as possible. Critical commands such as job submission still uses `SSHUtil.execute2`.
