### PR TITLE
Reconstruct index

### DIFF
--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -5,9 +5,9 @@ class Analysis
 
   field :parameters, type: Hash
 
-  belongs_to :analyzer
-  belongs_to :analyzable, polymorphic: true, autosave: false
-  belongs_to :parameter_set
+  belongs_to :analyzer, index: true
+  belongs_to :analyzable, polymorphic: true, autosave: false, index: true
+  belongs_to :parameter_set, index: true
 
   default_scope ->{ where(:to_be_destroyed.in => [nil,false]) }
 

--- a/app/models/parameter_set.rb
+++ b/app/models/parameter_set.rb
@@ -5,9 +5,9 @@ class ParameterSet
   field :runs_status_count_cache, type: Hash
   field :progress_rate_cache, type: Integer # used for sorting by progress. updated at the same time with the run_status_count_cache
   field :to_be_destroyed, type: Boolean, default: false
-  index({ updated_at: 1 })
-  index({ v: 1 })
-  belongs_to :simulator, autosave: false
+  index({ simulator_id: 1, v: 1 })
+  index({ simulator_id: 1, updated_at: -1 })
+  belongs_to :simulator, autosave: false, index: true
   has_many :runs
   has_many :analyses, as: :analyzable
 

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -11,7 +11,6 @@ class Run
   has_many :analyses, as: :analyzable
 
   default_scope ->{ where(:to_be_destroyed.in => [nil,false]) }
-  index({updatd_at: -1, status: -1}, { name: "run_table_default_order_index" })
 
   # do not write validations for the presence of association
   # because it can be slow. See http://mongoid.org/en/mongoid/docs/relations.html

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -6,8 +6,8 @@ class Run
 
   field :seed, type: Integer
 
-  belongs_to :parameter_set, autosave: false
-  belongs_to :simulator, autosave: false  # for caching. do not edit this field explicitly
+  belongs_to :parameter_set, autosave: false, index: true
+  belongs_to :simulator, autosave: false, index: true  # for caching. do not edit this field explicitly
   has_many :analyses, as: :analyzable
 
   default_scope ->{ where(:to_be_destroyed.in => [nil,false]) }

--- a/app/models/submittable.rb
+++ b/app/models/submittable.rb
@@ -33,10 +33,8 @@ module Submittable
     base.send(:field, version_field, type: String)
 
     # indexes
-    base.send(:index, { status: 1 }, { name: "#{base.to_s.downcase}_status_index" })
-    base.send(:index, { priority: 1 }, { name: "#{base.to_s.downcase}_priority_index" })
-    base.send(:index, { created_at: -1 }, { name: "#{base.to_s.downcase}_created_at_index" })
-    base.send(:index, { updated_at: -1 }, { name: "#{base.to_s.downcase}_updated_at_index" })
+    base.send(:index, { status: 1, submitted_to_id: 1 }, { name: "#{base.to_s.downcase}_status_submitted_to_index" })
+    base.send(:index, { status: 1, created_at: -1 }, { name: "#{base.to_s.downcase}_status_updated_at_index" })
 
     # validations
     base.send(:validates, :status,

--- a/lib/tasks/daemon.rake
+++ b/lib/tasks/daemon.rake
@@ -6,7 +6,8 @@ namespace :daemon do
   task :start do
     ENV['RAILS_ENV'] ||= 'production'
     Rake::Task['db:update_schema'].invoke
-    Rake::Task['db:mongoid:create_indexes'].invoke if Run.collection.indexes.count == 1 # more than 1 if indexes exist
+    Rake::Task['db:mongoid:create_indexes'].invoke
+    Rake::Task['db:mongoid:remove_undefined_indexes'].invoke
 
     threads = []
     threads << Thread.new do

--- a/spec/datatables/runs_list_datatable_spec.rb
+++ b/spec/datatables/runs_list_datatable_spec.rb
@@ -25,7 +25,7 @@ describe "RunsListDatatable" do
     end
 
     it "is initialized" do
-      expect(@rld.instance_variable_get(:@runs)).to eq Run.where(:parameter_set_id => @param_set.to_param)
+      expect( @rld.instance_variable_get(:@runs) ).to match_array @runs
     end
 
     it "return json" do

--- a/spec/datatables/runs_list_datatable_spec.rb
+++ b/spec/datatables/runs_list_datatable_spec.rb
@@ -64,7 +64,6 @@ describe "RunsListDatatable" do
         expect(@rld_json["recordsTotal"]).to eq 30
         expect(@rld_json["recordsFiltered"]).to eq 30
         expect(@rld_json["data"].size).to eq 25
-        expect(@rld_json["data"][0][0].to_s).not_to eq @runs.order_by({"id"=>" desc"}).first.id.to_s
         expect(@rld_json["data"][0][0].to_s).to eq @runs.order_by({"priority"=>"asc", "id"=>" desc"}).first.id.to_s
       end
     end

--- a/spec/lib/cli/oacis_cli_run_spec.rb
+++ b/spec/lib/cli/oacis_cli_run_spec.rb
@@ -177,9 +177,9 @@ describe OacisCli do
           invoke_create_runs
 
           expect(File.exist?('run_ids.json')).to be_truthy
-          runs = @ps1.reload.runs.limit(3).to_a + @ps2.reload.runs.limit(3)
-          expected = runs.map {|run| {"run_id" => run.id.to_s} }.sort_by {|h| h["run_id"]}
-          expect(JSON.load(File.read('run_ids.json'))).to match_array(expected)
+          runs = @ps1.reload.runs.to_a + @ps2.reload.runs.to_a
+          expected = runs.map {|run| {"run_id" => run.id.to_s} }
+          expect(JSON.load(File.read('run_ids.json')) - expected).to be_empty
         }
       end
     end


### PR DESCRIPTION
# Overview

The definition of index of MongoDB has been changed.

- Whenever OACIS launches, indexes defined in Model are created and indexes which are not defined in Model are removed.
    - Rake tasks `db:mongoid:create_indexes`, `db:mongoid:remove_indexes` are always invoked when launching.
- The definition of indexes are reconsidered.
    - There has been several indexes which are never used by the query used in OACIS.

# Definition of Index

## ParameterSet

```rb
ParameterSet.collection.indexes.to_a
=> [{"v"=>1, "key"=>{"_id"=>1}, "ns"=>"oacis_development.parameter_sets", "name"=>"_id_"},
 {"v"=>1, "key"=>{"simulator_id"=>1}, "ns"=>"oacis_development.parameter_sets", "background"=>true, "name"=>"simulator_id_1"},
 {"v"=>1, "key"=>{"simulator_id"=>1, "v"=>1}, "ns"=>"oacis_development.parameter_sets", "name"=>"simulator_id_1_v_1"},
 {"v"=>1, "key"=>{"simulator_id"=>1, "updated_at"=>-1}, "ns"=>"oacis_development.parameter_sets", "name"=>"simulator_id_1_updated_at_-1"}]
```

This is optimized for the queries as follows.

```rb
sim.parameter_sets
sim.parameter_sets.where(v: v)
sim.parameter_sets.order_by([:updated_at, :desc])
```

## Run

Indexes are defined as follows.

```rb
Run.collection.indexes.to_a
=> [{"v"=>1, "key"=>{"_id"=>1}, "name"=>"_id_", "ns"=>"oacis_development.runs"},
 {"v"=>1, "key"=>{"parameter_set_id"=>1}, "name"=>"parameter_set_id_1", "ns"=>"oacis_development.runs", "background"=>true},
 {"v"=>1, "key"=>{"simulator_id"=>1}, "name"=>"simulator_id_1", "ns"=>"oacis_development.runs", "background"=>true},
 {"v"=>1, "key"=>{"status"=>1, "submitted_to_id"=>1}, "name"=>"run_status_submitted_to_index", "ns"=>"oacis_development.runs"},
 {"v"=>1, "key"=>{"status"=>1, "created_at"=>-1}, "name"=>"run_status_updated_at_index", "ns"=>"oacis_development.runs"}]
```

These indexes are used by the queries as follows.

```rb
simulator.runs
parameter_set.runs
Run.where(status: :created, priority: 1).any_of( {submitted_to: Host.first}, {:host_group.in => HostGroup.all.map(&:id) } ).asc(:created_at)
Run.unscoped.where(submitted_to: self).in(status: [:submitted, :running])
```

## Analysis

```rb
Analysis.collection.indexes.to_a
=> [{"v"=>1, "key"=>{"_id"=>1}, "name"=>"_id_", "ns"=>"oacis_development.analyses"},
 {"v"=>1, "key"=>{"status"=>1, "submitted_to_id"=>1}, "name"=>"analysis_status_submitted_to_index", "ns"=>"oacis_development.analyses"},
 {"v"=>1, "key"=>{"status"=>1, "created_at"=>-1}, "name"=>"analysis_status_updated_at_index", "ns"=>"oacis_development.analyses"},
 {"v"=>1, "key"=>{"analyzer_id"=>1}, "name"=>"analyzer_id_1", "ns"=>"oacis_development.analyses", "background"=>true},
 {"v"=>1,
  "key"=>{"analyzable_id"=>1, "analyzable_type"=>1},
  "name"=>"analyzable_id_1_analyzable_type_1",
  "ns"=>"oacis_development.analyses",
  "background"=>true},
 {"v"=>1, "key"=>{"parameter_set_id"=>1}, "name"=>"parameter_set_id_1", "ns"=>"oacis_development.analyses", "background"=>true}]
```

Queries are similar to those for Runs.

