### PR TITLE
Set priority when creating runs from API

### DIFF
--- a/app/models/parameter_set.rb
+++ b/app/models/parameter_set.rb
@@ -74,11 +74,11 @@ class ParameterSet
   end
 
   # public APIs
-  def find_or_create_runs_upto( num_runs, submitted_to: nil, host_param: nil, host_group: nil, mpi_procs: 1, omp_threads: 1 )
+  def find_or_create_runs_upto( num_runs, submitted_to: nil, host_param: nil, host_group: nil, mpi_procs: 1, omp_threads: 1, priority: 1)
     found = runs.asc(:created_at).limit(num_runs).to_a
     n = found.size
 
-    params = { mpi_procs: mpi_procs, omp_threads: omp_threads }
+    params = { mpi_procs: mpi_procs, omp_threads: omp_threads, priority: priority }
     if num_runs > n
       if host_group
         raise "You can set either submitted_to or host_group" if submitted_to

--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -198,7 +198,9 @@ host_param = {ppn:"4",walltime:"1:00:00"}
 # To get default host parameters, the following method is available.
 #  host.default_host_parameters
 
-runs = ps.find_or_create_runs_upto( 10, submitted_to: host, host_param: host_param, mpi_procs: 4 )
+runs = ps.find_or_create_runs_upto( 10, submitted_to: host, host_param: host_param, mpi_procs: 4, priority: 0 )
+# The paraemters "host_param", "mpi_procs", "omp_threads", "priority" are optional.
+# Priority "0" is the highest priority. You can choose from 0,1, and 2.
 ```
 
 `ParameterSet#find_or_create_runs_upto` method create runs until the number of Runs becomes the specified number.
@@ -209,7 +211,7 @@ You can also specify "HostGroup" as follows.
 
 ```
 host_group = HostGroup.where(name: "my_host_group").first
-runs = ps.find_or_create_runs_upto( 10, host_group: host_group, mpi_procs: 4 )
+runs = ps.find_or_create_runs_upto( 10, host_group: host_group)
 ```
 
 #### removing

--- a/docs/ja/api.md
+++ b/docs/ja/api.md
@@ -199,9 +199,10 @@ host_param = {ppn:"4",walltime:"1:00:00"}
 
 # hostパラメータのデフォルト値を得るには以下のメソッドが有用
 #  host.get_default_host_parameters
-run = ps.runs.create!(submitted_to: host, host_parameters: host_param, mpi_procs: 4)
 
-runs = ps.find_or_create_runs_upto( 10, submitted_to: host, host_param: host_param, mpi_procs: 4 )
+runs = ps.find_or_create_runs_upto( 10, submitted_to: host, host_param: host_param, mpi_procs: 4, priority: 0 )
+# The paraemters "host_param", "mpi_procs", "omp_threads", "priority" are optional.
+# Priority "0" is the highest priority. You can choose from 0,1, and 2.
 ```
 
 `ParameterSet#find_or_create_runs_upto` メソッドは指定した数になるまでRunを作成する。
@@ -212,7 +213,7 @@ runs = ps.find_or_create_runs_upto( 10, submitted_to: host, host_param: host_par
 
 ```
 host_group = HostGroup.where(name: "my_host_group").first
-runs = ps.find_or_create_runs_upto( 10, host_group: host_group, mpi_procs: 4 )
+runs = ps.find_or_create_runs_upto( 10, host_group: host_group)
 ```
 
 #### 削除

--- a/spec/models/parameter_set_spec.rb
+++ b/spec/models/parameter_set_spec.rb
@@ -329,23 +329,24 @@ describe ParameterSet do
         }.to change { @ps.runs.count }.from(1).to(3)
       end
 
-      it "sets submitted_to, host_param, mpi_proc, omp_threads to newly created runs" do
+      it "sets submitted_to, host_param, mpi_proc, omp_threads, priority to newly created runs" do
         h = FactoryGirl.create(:host_with_parameters)
         host_param = { param1: "foo", param2: "bar" }
-        mpi_procs = 1
-        omp_threads = 4
         
         runs = @ps.find_or_create_runs_upto(3,
                                             submitted_to: h,
                                             host_param: host_param,
                                             mpi_procs: 1,
-                                            omp_threads: 4 )
+                                            omp_threads: 4,
+                                            priority: 0
+                                            )
         expect( runs.count ).to eq 3
         runs.each do |run|
           expect( run.submitted_to ).to eq h
           expect( run.host_parameters ).to eq({"param1"=>"foo","param2"=>"bar"})
           expect( run.mpi_procs ).to eq 1
           expect( run.omp_threads ).to eq 4
+          expect( run.priority ).to eq 0
         end
       end
 


### PR DESCRIPTION
Let `ParameterSet#find_or_create_runs_upto` method to accept "priority" parameter.