### PR TITLE
Fixed a possible error in ParameterSetsListDatatable

### DIFF
--- a/app/controllers/parameter_sets_controller.rb
+++ b/app/controllers/parameter_sets_controller.rb
@@ -190,7 +190,8 @@ class ParameterSetsController < ApplicationController
     keys = base_ps.simulator.parameter_definitions.map(&:key)
     selectors = keys.map {|key| base_ps.parameter_sets_with_different(key).selector }
     parameter_sets = ParameterSet.or(*selectors)
-    render json: ParameterSetsListDatatable.new(parameter_sets, keys, view_context, base_ps)
+    num_ps_total = base_ps.simulator.parameter_sets.count
+    render json: ParameterSetsListDatatable.new(parameter_sets, keys, view_context, num_ps_total, base_ps)
   end
 
   def _line_plot

--- a/app/controllers/simulators_controller.rb
+++ b/app/controllers/simulators_controller.rb
@@ -136,7 +136,8 @@ class SimulatorsController < ApplicationController
       parameter_sets = q.parameter_sets
     end
     keys = simulator.parameter_definitions.map {|pd| pd.key }
-    render json: ParameterSetsListDatatable.new(parameter_sets, keys, view_context)
+    num_ps_total = simulator.parameter_sets.count
+    render json: ParameterSetsListDatatable.new(parameter_sets, keys, view_context, num_ps_total)
   end
 
   def _analyzer_list

--- a/app/datatables/analyses_list_datatable.rb
+++ b/app/datatables/analyses_list_datatable.rb
@@ -16,7 +16,7 @@ class AnalysesListDatatable
     {
       draw: @view.params[:draw].to_i,
       recordsTotal: @analyses.count,
-      recordsFiltered: analyses_lists.count,
+      recordsFiltered: @analyses.count,
       data: data
     }
   end
@@ -43,13 +43,7 @@ private
   end
 
   def analyses_lists
-    @analyses_lists ||= fetch_analyses_list
-  end
-
-  def fetch_analyses_list
-    list = @analyses.order_by(sort_column_direction)
-    list = list.skip(page).limit(per_page)
-    list
+    @analyses.order_by(sort_column_direction).skip(page).limit(per_page)
   end
 
   def page

--- a/app/datatables/analyzers_list_datatable.rb
+++ b/app/datatables/analyzers_list_datatable.rb
@@ -46,13 +46,7 @@ private
   end
 
   def analyzers_lists
-    @analyzers_lists ||= fetch_analyzers_list
-  end
-
-  def fetch_analyzers_list
-    list = @analyzers.order_by(sort_column_direction)
-    list = list.skip(page).limit(per_page)
-    list
+    @analyzers.order_by(sort_column_direction).skip(page).limit(per_page)
   end
 
   def page

--- a/app/datatables/parameter_sets_list_datatable.rb
+++ b/app/datatables/parameter_sets_list_datatable.rb
@@ -85,19 +85,13 @@ private
   end
 
   def parameter_sets_list
-    @parameter_sets_list ||= fetch_parameter_sets_list
+    @ps_list_cache ||= @param_sets.order_by(sort_column_direction).skip(page).limit(per_page).to_a
+    # `to_a` is necessary to fix the contents of parameter_sets_list
   end
 
   def runs_status_counts(ps)
     @runs_status_counts_cache ||= ParameterSet.runs_status_count_batch( parameter_sets_list )
     @runs_status_counts_cache[ps.id]
-  end
-
-  def fetch_parameter_sets_list
-    #"only" is removed due to ParameterSet.runs_status_count can not be called.
-    parameter_sets_list = @param_sets.order_by(sort_column_direction)
-    parameter_sets_list = parameter_sets_list.skip(page).limit(per_page)
-    parameter_sets_list
   end
 
   def page

--- a/app/datatables/parameter_sets_list_datatable.rb
+++ b/app/datatables/parameter_sets_list_datatable.rb
@@ -36,28 +36,28 @@ private
   end
 
   def data
-    parameter_sets_list.map do |param|
+    parameter_sets_list.map do |ps|
       tmp = []
-      tmp << @view.content_tag(:i, '', parameter_set_id: param.id.to_s, align: "center", class: "fa fa-search clickable")
-      counts = runs_status_counts(param)
+      tmp << @view.content_tag(:i, '', parameter_set_id: ps.id.to_s, align: "center", class: "fa fa-search clickable")
+      counts = runs_status_counts(ps)
       progress = @view.progress_bar( counts.values.inject(:+), counts[:finished], counts[:failed], counts[:running], counts[:submitted] )
       tmp << @view.raw(progress)
-      tmp << @view.link_to( @view.shortened_id_monospaced(param.id), @view.parameter_set_path(param) )
-      tmp << @view.distance_to_now_in_words(param.updated_at)
+      tmp << @view.link_to( @view.shortened_id_monospaced(ps.id), @view.parameter_set_path(ps) )
+      tmp << @view.distance_to_now_in_words(ps.updated_at)
       @param_keys.each do |key|
         if @base_ps
-          tmp << colorize_param_value(param.v[key], @base_ps.v[key])
+          tmp << colorize_param_value(ps.v[key], @base_ps.v[key])
         else
-          tmp <<  ERB::Util.html_escape(param.v[key])
+          tmp <<  ERB::Util.html_escape(ps.v[key])
         end
       end
-      if param == @base_ps
+      if ps == @base_ps
         tmp << ''
       else
         if OACIS_READ_ONLY
           tmp << @view.raw('<i class="fa fa-trash-o">')
         else
-          tmp << @view.link_to( @view.raw('<i class="fa fa-trash-o">'), param, remote: true, method: :delete, data: {confirm: 'Are you sure?'})
+          tmp << @view.link_to( @view.raw('<i class="fa fa-trash-o">'), ps, remote: true, method: :delete, data: {confirm: 'Are you sure?'})
         end
       end
       tmp

--- a/app/datatables/parameter_sets_list_datatable.rb
+++ b/app/datatables/parameter_sets_list_datatable.rb
@@ -1,17 +1,18 @@
 class ParameterSetsListDatatable
 
-  def initialize(parameter_sets, parameter_definition_keys, view, base_ps = nil)
+  def initialize(parameter_sets, parameter_definition_keys, view, num_ps_total, base_ps = nil)
     @view = view
     @param_sets = parameter_sets
     @param_keys = parameter_definition_keys
     @base_ps = base_ps
+    @num_ps_total = num_ps_total
   end
 
   def as_json(options = {})
     {
       draw: @view.params[:draw].to_i,
-      recordsTotal: @param_sets.count,
-      recordsFiltered: parameter_sets_list.count,
+      recordsTotal: @num_ps_total,
+      recordsFiltered: @param_sets.count,
       data: data
     }
   end

--- a/app/datatables/runs_list_datatable.rb
+++ b/app/datatables/runs_list_datatable.rb
@@ -18,7 +18,7 @@ class RunsListDatatable
     {
       draw: @view.params[:draw].to_i,
       recordsTotal: @runs.count,
-      recordsFiltered: runs_lists.count,
+      recordsFiltered: @runs.count,
       data: data
     }
   end
@@ -50,13 +50,7 @@ private
   end
 
   def runs_lists
-    @runs_lists ||= fetch_runs_list
-  end
-
-  def fetch_runs_list
-    runs_list = @runs.without(:result).order_by(sort_column_direction)
-    runs_list = runs_list.skip(page).limit(per_page)
-    runs_list
+    @runs.without(:result).order_by(sort_column_direction).skip(page).limit(per_page)
   end
 
   def page

--- a/spec/controllers/parameter_sets_controller_spec.rb
+++ b/spec/controllers/parameter_sets_controller_spec.rb
@@ -448,7 +448,7 @@ describe ParameterSetsController do
 
     it "returns correct number of parameter sets" do
       parsed_body = JSON.parse(response.body)
-      expect(parsed_body['recordsTotal']).to eq 8
+      expect(parsed_body['recordsFiltered']).to eq 8
     end
   end
 

--- a/spec/datatables/parameter_sets_list_datatable_spec.rb
+++ b/spec/datatables/parameter_sets_list_datatable_spec.rb
@@ -28,7 +28,8 @@ describe "ParameterSetsListDatatable" do
         allow(@context).to receive(:parameter_set_path).and_return("/parameter_sets/00000000ffffff0000ffffffff")
         allow(@context).to receive(:shortened_id_monospaced).and_return("xxxx..yy")
         keys = @simulator.parameter_definitions.map {|x| x.key}
-        @psld = ParameterSetsListDatatable.new(@simulator.parameter_sets, keys, @context)
+        num_ps_total = @simulator.parameter_sets.count
+        @psld = ParameterSetsListDatatable.new(@simulator.parameter_sets, keys, @context, num_ps_total)
         @psld_json = JSON.parse(@psld.to_json)
       end
 
@@ -68,7 +69,8 @@ describe "ParameterSetsListDatatable" do
         allow(@context).to receive(:parameter_set_path).and_return("/parameter_sets/00000000ffffff0000ffffffff")
         allow(@context).to receive(:shortened_id_monospaced).and_return("xxxx..yy")
         keys = @simulator.parameter_definitions.map {|x| x.key}
-        @psld = ParameterSetsListDatatable.new(@query.parameter_sets, keys, @context)
+        num_ps_total = @simulator.parameter_sets.count
+        @psld = ParameterSetsListDatatable.new(@query.parameter_sets, keys, @context, num_ps_total)
         @psld_json = JSON.parse(@psld.to_json)
       end
 
@@ -77,7 +79,7 @@ describe "ParameterSetsListDatatable" do
       end
 
       it "return json" do
-        expect(@psld_json["recordsTotal"]).to eq(25)
+        expect(@psld_json["recordsTotal"]).to eq(30)
         expect(@psld_json["recordsFiltered"]).to eq(25)
         expect(@psld_json["data"].size).to eq(5)
         expect(@psld_json["data"].first[4].to_i).to eq(@query.parameter_sets.only("v.L").max("v.L"))#["aaData"].first[4].to_i is qeual to v.L (["aaData"].first[id, updated_at, [keys]])
@@ -104,7 +106,8 @@ describe "ParameterSetsListDatatable" do
         allow(@context).to receive(:parameter_set_path).and_return("/parameter_sets/00000000ffffff0000ffffffff")
         allow(@context).to receive(:shortened_id_monospaced).and_return("xxxx..yy")
         keys = @simulator.parameter_definitions.map {|x| x.key}
-        @psld = ParameterSetsListDatatable.new(@simulator.parameter_sets, keys, @context)
+        num_ps_total = @simulator.parameter_sets.count
+        @psld = ParameterSetsListDatatable.new(@simulator.parameter_sets, keys, @context, num_ps_total)
         @psld_json = JSON.parse(@psld.to_json)
       end
 


### PR DESCRIPTION
Fixed #514 

To fix #514, I investigated the code and found a possible cause of the error.
Since `ParameterSetsListDatatable#parameter_sets_list` returns a query, not an Array of ParameterSets, contents of the `parameter_sets_list` can change when it is called more than once.
To resolve this issue, we fixed the contents of `parameter_sets_list` by calling `to_a`. Hopefully, this fix issue #514 although it is hard to confirm the bug fix since it happens not always but occasionally.

In addition, I conducted minor refactoring.