### PR TITLE
bugfix: invalid field has been used for CLI create_analyses

### DIFF
--- a/lib/cli/oacis_cli_analysis.rb
+++ b/lib/cli/oacis_cli_analysis.rb
@@ -127,7 +127,7 @@ class OacisCli < Thor
 
   def set_job_parameters(analyses, job_param_json_path)
     job_parameters = load_json_file_or_string( job_param_json_path )
-    submitted_to = job_parameters["host_id"] ? Host.find(job_parameters["host_id"]) : nil
+    submitted_to = job_parameters["submitted_to"] ? Host.find(job_parameters["submitted_to"]) : nil
     host_parameters = job_parameters["host_parameters"].to_hash
     mpi_procs = job_parameters["mpi_procs"]
     omp_threads = job_parameters["omp_threads"]

--- a/spec/lib/cli/oacis_cli_analysis_spec.rb
+++ b/spec/lib/cli/oacis_cli_analysis_spec.rb
@@ -19,7 +19,7 @@ describe OacisCli do
   def create_job_parameters_json(path)
     File.open(path, 'w') {|io|
       job_parameters = {
-        "host_id" => @host.id.to_s,
+        "submitted_to" => @host.id.to_s,
         "host_parameters" => {"param1" => "foo", "param2" => "bar"},
         "mpi_procs" => 2,
         "omp_threads" => 8,


### PR DESCRIPTION
fixed the key name of job_parameters.json for CLI "create_analyses".