### PR TITLE
OACIS watcher in Python

### DIFF
--- a/oacis/__init__.py
+++ b/oacis/__init__.py
@@ -20,3 +20,5 @@ Analysis = Rb.const('Analysis')
 Host = Rb.const('Host')
 HostGroup = Rb.const('HostGroup')
 
+from .oacis_watcher import OacisWatcher
+

--- a/oacis/__init__.py
+++ b/oacis/__init__.py
@@ -1,15 +1,15 @@
 import sys
 import os
 
-rb_call_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'rb_call') )
+rb_call_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../rb_call') )
 sys.path.append( rb_call_path )
 
-os.putenv('BUNDLE_GEMFILE', os.path.abspath(os.path.join(os.path.dirname(__file__),'Gemfile')) )
+os.putenv('BUNDLE_GEMFILE', os.path.abspath(os.path.join(os.path.dirname(__file__),'../Gemfile')) )
 from rb_call import RubySession
 
 Rb = RubySession()
-Rb.require_relative('config/environment')
-Rb.require_relative('rb_call/patch/mongoid_patch')
+Rb.require_relative('../config/environment')
+Rb.require_relative('../rb_call/patch/mongoid_patch')
 
 # Defining classes of OACIS
 Simulator = Rb.const('Simulator')

--- a/oacis/oacis_watcher.py
+++ b/oacis/oacis_watcher.py
@@ -4,33 +4,40 @@ class OacisWatcher():
 
     def __init__(self, polling = 5):
         self.polling = polling
-        self.observed_parameter_sets = {}
-        self.observed_parameter_sets_all = {}
+        self._observed_parameter_sets = {}
+        self._observed_parameter_sets_all = {}
 
     def watch_ps(self, ps, callback):
         psid = ps.id().to_s()
-        if psid in self.observed_parameter_sets:
-            self.observed_parameter_sets[psid].append( callback )
+        if psid in self._observed_parameter_sets:
+            self._observed_parameter_sets[psid].append( callback )
         else:
-            self.observed_parameter_sets[psid] = [ callback ]
+            self._observed_parameter_sets[psid] = [ callback ]
+
+    def watch_all_ps(self, ps_array, callback):
+        sorted_ps_ids = tuple( sorted( [ ps.id().to_s() for ps in ps_array ] ) )
+        if sorted_ps_ids in self._observed_parameter_sets_all:
+            self._observed_parameter_sets_all[sorted_ps_ids].append( callback )
+        else:
+            self._observed_parameter_sets_all[sorted_ps_ids] = [ callback ]
 
     def loop(self):
         print("start polling")
         while True:
             executed = True
             while executed:
-                executed = self.check_completed_ps()
-            if len(self.observed_parameter_sets) == 0:
+                executed = (self._check_completed_ps() or self._check_completed_ps_all())
+            if len(self._observed_parameter_sets) == 0 and len(self._observed_parameter_sets_all) == 0:
                 break
             print("waiting for %d sec" % self.polling)
             time.sleep( self.polling )
         print("stop polling")
 
-    def check_completed_ps(self):
+    def _check_completed_ps(self):
         from . import ParameterSet
         executed = False
-        watched_ps_ids = list( self.observed_parameter_sets.keys() )
-        psids = self.completed_ps_ids( watched_ps_ids )
+        watched_ps_ids = list( self._observed_parameter_sets.keys() )
+        psids = self._completed_ps_ids( watched_ps_ids )
         
         for psid in psids:
             ps = ParameterSet.find(psid)
@@ -39,27 +46,50 @@ class OacisWatcher():
             else:
                 print("calling callback for %s" % ps.id().to_s() )
                 executed = True
-                queue = self.observed_parameter_sets[psid]
+                queue = self._observed_parameter_sets[psid]
                 while len(queue) > 0:
                     callback = queue.pop(0)
                     callback( ps )
-                    if self.completed( ps.reload() ) == False:
+                    if self._completed( ps.reload() ) == False:
                         break
 
-        empty_psids = [ psid for psid,callbacks in self.observed_parameter_sets.items() if len(callbacks)==0 ]
+        empty_psids = [ psid for psid,callbacks in self._observed_parameter_sets.items() if len(callbacks)==0 ]
         for empty_psid in empty_psids:
-            self.observed_parameter_sets.pop(empty_psid)
+            self._observed_parameter_sets.pop(empty_psid)
 
         return executed
 
-    def completed_ps_ids(self, watched_ps_ids ):
+    def _check_completed_ps_all(self):
+        from . import ParameterSet
+        from functools import reduce
+        executed = False
+        flattened = reduce(lambda x,y: list(x)+list(y), self._observed_parameter_sets_all.keys(), [])
+        watched_ps_ids = list( set(flattened) )
+        completed = self._completed_ps_ids( watched_ps_ids )
+
+        for psids,callbacks in self._observed_parameter_sets_all.items():
+            if all( (psid in completed) for psid in psids ):
+                print("calling callback for %s" % repr(psids) )
+                executed = True
+                watched_pss = [ ParameterSet.find(psid) for psid in psids ]
+                while len(callbacks) > 0:
+                    callback = callbacks.pop(0)
+                    callback(watched_pss)
+                    if any( self._completed(ps.reload()) for ps in watched_pss ):
+                        break
+
+        empty_keys = [ key for key,callbacks in self._observed_parameter_sets_all.items() if len(callbacks)==0 ]
+        for key in empty_keys:
+            self._observed_parameter_sets_all.pop(key)
+        return executed
+
+    def _completed_ps_ids(self, watched_ps_ids ):
         from . import Run
         query = Run.send('in',parameter_set_id = watched_ps_ids).send('in',status=['created','submitted','running']).selector()
         incomplete_ps_ids = [ psid.to_s() for psid in Run.collection().distinct( "parameter_set_id", query ) ]
         completed = list( set(watched_ps_ids) - set(incomplete_ps_ids) )
-        print( completed )
         return completed
 
-    def completed(self, ps):
+    def _completed(self, ps):
         return ps.runs().send('in', status=['created','submitted','running']).count() == 0
 

--- a/oacis/oacis_watcher.py
+++ b/oacis/oacis_watcher.py
@@ -51,7 +51,8 @@ class OacisWatcher():
             self.logger.info("stop polling. (interrupted=%s)" % self._signal_received)
         finally:
             signal.signal( signal.SIGINT, org_handler )
-            os.kill( os.getpid(), signal.SIGINT)
+            if self._signal_received:
+                os.kill( os.getpid(), signal.SIGINT)
 
     def _default_logger(self):
         logger = logging.getLogger(__name__)

--- a/oacis/oacis_watcher.py
+++ b/oacis/oacis_watcher.py
@@ -8,10 +8,10 @@ from functools import reduce
 class OacisWatcher():
 
     def __init__(self, polling = 5, logger = None):
-        self.polling = polling
+        self._polling = polling
         self._observed_parameter_sets = {}
         self._observed_parameter_sets_all = {}
-        self.logger = logger or self._default_logger()
+        self._logger = logger or self._default_logger()
         self._signal_received = False
 
     def watch_ps(self, ps, callback):
@@ -35,7 +35,7 @@ class OacisWatcher():
         org_handler = signal.signal( signal.SIGINT, on_sigint)
 
         try:
-            self.logger.info("start polling")
+            self._logger.info("start polling")
             while True:
                 if self._signal_received:
                     break
@@ -46,9 +46,9 @@ class OacisWatcher():
                     break
                 if self._signal_received:
                     break
-                self.logger.info("waiting for %d sec" % self.polling)
-                time.sleep( self.polling )
-            self.logger.info("stop polling. (interrupted=%s)" % self._signal_received)
+                self._logger.info("waiting for %d sec" % self._polling)
+                time.sleep(self._polling)
+            self._logger.info("stop polling. (interrupted=%s)" % self._signal_received)
         finally:
             signal.signal( signal.SIGINT, org_handler )
             if self._signal_received:
@@ -76,9 +76,9 @@ class OacisWatcher():
                 break
             ps = ParameterSet.find(psid)
             if len(ps.runs()) == 0:
-                self.logger.info("%s has no run" % ps.id().to_s() )
+                self._logger.info("%s has no run" % ps.id().to_s())
             else:
-                self.logger.info("calling callback for %s" % ps.id().to_s() )
+                self._logger.info("calling callback for %s" % ps.id().to_s())
                 executed = True
                 queue = self._observed_parameter_sets[psid]
                 while len(queue) > 0:
@@ -104,7 +104,7 @@ class OacisWatcher():
             if self._signal_received:
                 break
             if all( (psid in completed) for psid in psids ):
-                self.logger.info("calling callback for %s" % repr(psids) )
+                self._logger.info("calling callback for %s" % repr(psids))
                 executed = True
                 watched_pss = [ ParameterSet.find(psid) for psid in psids ]
                 while len(callbacks) > 0:

--- a/oacis/oacis_watcher.py
+++ b/oacis/oacis_watcher.py
@@ -1,0 +1,65 @@
+import time
+
+class OacisWatcher():
+
+    def __init__(self, polling = 5):
+        self.polling = polling
+        self.observed_parameter_sets = {}
+        self.observed_parameter_sets_all = {}
+
+    def watch_ps(self, ps, callback):
+        psid = ps.id().to_s()
+        if psid in self.observed_parameter_sets:
+            self.observed_parameter_sets[psid].append( callback )
+        else:
+            self.observed_parameter_sets[psid] = [ callback ]
+
+    def loop(self):
+        print("start polling")
+        while True:
+            executed = True
+            while executed:
+                executed = self.check_completed_ps()
+            if len(self.observed_parameter_sets) == 0:
+                break
+            print("waiting for %d sec" % self.polling)
+            time.sleep( self.polling )
+        print("stop polling")
+
+    def check_completed_ps(self):
+        from . import ParameterSet
+        executed = False
+        watched_ps_ids = list( self.observed_parameter_sets.keys() )
+        psids = self.completed_ps_ids( watched_ps_ids )
+        
+        for psid in psids:
+            ps = ParameterSet.find(psid)
+            if len(ps.runs()) == 0:
+                print("%s has no run" % ps.id().to_s() )
+            else:
+                print("calling callback for %s" % ps.id().to_s() )
+                executed = True
+                queue = self.observed_parameter_sets[psid]
+                while len(queue) > 0:
+                    callback = queue.pop(0)
+                    callback( ps )
+                    if self.completed( ps.reload() ) == False:
+                        break
+
+        empty_psids = [ psid for psid,callbacks in self.observed_parameter_sets.items() if len(callbacks)==0 ]
+        for empty_psid in empty_psids:
+            self.observed_parameter_sets.pop(empty_psid)
+
+        return executed
+
+    def completed_ps_ids(self, watched_ps_ids ):
+        from . import Run
+        query = Run.send('in',parameter_set_id = watched_ps_ids).send('in',status=['created','submitted','running']).selector()
+        incomplete_ps_ids = [ psid.to_s() for psid in Run.collection().distinct( "parameter_set_id", query ) ]
+        completed = list( set(watched_ps_ids) - set(incomplete_ps_ids) )
+        print( completed )
+        return completed
+
+    def completed(self, ps):
+        return ps.runs().send('in', status=['created','submitted','running']).count() == 0
+

--- a/oacis/oacis_watcher_test.py
+++ b/oacis/oacis_watcher_test.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import MagicMock
 import os
 
 os.environ['RAILS_ENV'] = 'test'
@@ -15,12 +16,11 @@ class TestOacisWatcher(unittest.TestCase):
     def setUp(self):
         self.DatabaseCleaner = oacis.Rb.const('DatabaseCleaner')
         self.DatabaseCleaner.start()
-        print( oacis.Simulator.count() )
+        assert oacis.Simulator.count() == 0
 
     def tearDown(self):
-        print("being cleaned up")
         self.DatabaseCleaner.clean()
-        print( oacis.Simulator.count() )
+        assert oacis.Simulator.count() == 0
         root_dir = oacis.Rb.const('ResultDirectory').root().to_s()  #=> public/Result_test
         import shutil
         shutil.rmtree( root_dir )
@@ -30,9 +30,8 @@ class TestOacisWatcher(unittest.TestCase):
         pd1 = ParameterDefinition( {'key':"p1", 'type':"Integer", 'default': 0} )
         pd2 = ParameterDefinition( {'key':"p2", 'type':"Float", 'default': 1.0} )
         sim = oacis.Simulator.create( {'name': 'my_test_simulator', 'command': 'echo', 'parameter_definitions': [pd1,pd2]} )
-        #print( repr(sim) )
-        #print( sim.parameter_definitions() )
-        #print( oacis.Simulator.count() )
+        #print( repr(sim), sim.parameter_definitions() )
+        assert oacis.Simulator.count() == 1
         return sim
 
     def build_ps(self, sim, num_ps):
@@ -40,14 +39,137 @@ class TestOacisWatcher(unittest.TestCase):
             v = {"p1": i, "p2": 0.0}
             sim.find_or_create_parameter_set(v)
 
+    def build_run(self, ps, num_created_runs, num_finished_runs):
+        for i in range(num_created_runs):
+            ps.runs().create()
+        for i in range(num_finished_runs):
+            ps.runs().create( status='finished' )
+
     def test_watch_ps(self):
         sim = self.build_simulator()
         self.build_ps(sim, 1)
+        ps = sim.parameter_sets().first()
         w = oacis.OacisWatcher()
-        self.assertEqual( len(w.observed_parameter_sets), 0 )
-        def on_ps_finished(ps): pass
-        w.watch_ps( sim.parameter_sets().first(), on_ps_finished )
-        self.assertEqual( len(w.observed_parameter_sets), 1 )
+        self.assertEqual( len(w._observed_parameter_sets), 0 )
+        w.watch_ps( ps, lambda x: None )
+        self.assertEqual( len(w._observed_parameter_sets), 1 )
+
+        w.watch_ps( ps, lambda x: None )
+        self.assertEqual( len(w._observed_parameter_sets[ps.id().to_s()]), 2 )
+
+    def test_watch_all_ps(self):
+        sim = self.build_simulator()
+        self.build_ps(sim, 2)
+        ps = sim.parameter_sets().first()
+        w = oacis.OacisWatcher()
+
+        self.assertEqual( len(w._observed_parameter_sets_all), 0 )
+        w.watch_all_ps( sim.parameter_sets(), lambda pss: None )
+        self.assertEqual( len(w._observed_parameter_sets_all), 1 )
+        w.watch_all_ps( sim.parameter_sets(), lambda pss: None )
+        psids = tuple( sorted([ps.id().to_s() for ps in sim.parameter_sets()]) )
+        self.assertEqual( len(w._observed_parameter_sets_all[psids]), 2 )
+
+    def test_completed(self):
+        sim = self.build_simulator()
+        self.build_ps(sim, 1)
+        ps = sim.parameter_sets().first()
+        self.build_run(ps, 1, 2)
+        assert ps.runs().count() == 3
+        assert ps.runs().where( status='created' ).count() == 1
+        assert ps.runs().where( status='finished' ).count() == 2
+        w = oacis.OacisWatcher()
+        self.assertFalse( w._completed(ps) )
+
+        ps.runs().where(status='created').first().update_attribute('status','finished')
+        self.assertTrue( w._completed(ps) )
+
+    def test_completed_ps_ids(self):
+        sim = self.build_simulator()
+        self.build_ps(sim, 2)
+        ps1 = sim.parameter_sets().asc('id').first()
+        ps2 = sim.parameter_sets().asc('id').last()
+        self.build_run(ps1, 0, 2)
+        self.build_run(ps2, 1, 1)
+        w = oacis.OacisWatcher()
+        psids = [ps1.id().to_s(), ps2.id().to_s() ]
+        finished = w._completed_ps_ids( psids )
+        self.assertEqual( finished, [ps1.id().to_s()] )
+
+    def test_check_completed_ps__callback(self):
+        sim = self.build_simulator()
+        self.build_ps(sim, 2)
+        ps1 = sim.parameter_sets().asc('id').first()
+        ps2 = sim.parameter_sets().asc('id').last()
+        self.build_run(ps1, 0, 2)
+        self.build_run(ps2, 1, 1)
+
+        mock1 = MagicMock()
+        mock2 = MagicMock()
+
+        w = oacis.OacisWatcher()
+        w.watch_ps(ps1, mock1); w.watch_ps(ps2, mock2)
+        w._check_completed_ps()
+        mock1.assert_called_with(ps1)
+        mock2.assert_not_called()
+
+    def test_check_completed_ps__stop_calling(self):
+        sim = self.build_simulator()
+        self.build_ps(sim, 1)
+        ps = sim.parameter_sets().first()
+        self.build_run(ps, 0, 1)
+
+        mock1 = MagicMock()
+        mock2 = MagicMock()
+        def callback1(ps):
+            mock1();
+            ps.runs().create()
+
+        w = oacis.OacisWatcher()
+        w.watch_ps(ps, callback1 ); w.watch_ps(ps, mock2)
+        ret = w._check_completed_ps()
+        mock1.assert_called_with()
+        mock2.assert_not_called()
+        self.assertTrue( ret )
+
+    def test_check_completed_ps__return_false_when_no_callback_executed(self):
+        sim = self.build_simulator()
+        self.build_ps(sim, 1)
+        ps = sim.parameter_sets().first()
+        self.build_run(ps, 1, 0)
+
+        w = oacis.OacisWatcher()
+        w.watch_ps(ps, lambda x: None )
+        ret = w._check_completed_ps()
+        self.assertFalse( ret )
+
+    def test_check_completed_ps_all__callback(self):
+        sim = self.build_simulator()
+        self.build_ps(sim, 2)
+        for ps in sim.parameter_sets():
+            self.build_run(ps, 0, 2)
+
+        mock1 = MagicMock()
+        w = oacis.OacisWatcher()
+        w.watch_all_ps( sim.parameter_sets(), mock1 )
+        ret = w._check_completed_ps_all()
+        mock1.assert_called_with( sim.parameter_sets().asc('id') )
+        self.assertTrue( ret )
+
+    def test_check_completed_ps_all__not_called(self):
+        sim = self.build_simulator()
+        self.build_ps(sim, 2)
+        ps1 = sim.parameter_sets().asc('id').first()
+        self.build_run( ps1, 0, 2 )
+        ps2 = sim.parameter_sets().asc('id').last()
+        self.build_run( ps2, 1, 1 )
+
+        mock1 = MagicMock()
+        w = oacis.OacisWatcher()
+        w.watch_all_ps( [ps1,ps2], mock1 )
+        ret = w._check_completed_ps_all()
+        mock1.assert_not_called()
+        self.assertFalse( ret )
 
 if __name__ == '__main__':
     setupSuite()

--- a/oacis/oacis_watcher_test.py
+++ b/oacis/oacis_watcher_test.py
@@ -1,0 +1,55 @@
+import unittest
+import os
+
+os.environ['RAILS_ENV'] = 'test'
+import oacis
+
+def setupSuite():
+    print("setting up")
+    Mongoid = oacis.Rb.const("Mongoid")
+    assert Mongoid.default_client().options()['database'] == 'oacis_test'
+    oacis.Rb.require('database_cleaner')
+
+class TestOacisWatcher(unittest.TestCase):
+
+    def setUp(self):
+        self.DatabaseCleaner = oacis.Rb.const('DatabaseCleaner')
+        self.DatabaseCleaner.start()
+        print( oacis.Simulator.count() )
+
+    def tearDown(self):
+        print("being cleaned up")
+        self.DatabaseCleaner.clean()
+        print( oacis.Simulator.count() )
+        root_dir = oacis.Rb.const('ResultDirectory').root().to_s()  #=> public/Result_test
+        import shutil
+        shutil.rmtree( root_dir )
+
+    def build_simulator(self):
+        ParameterDefinition = oacis.Rb.const('ParameterDefinition')
+        pd1 = ParameterDefinition( {'key':"p1", 'type':"Integer", 'default': 0} )
+        pd2 = ParameterDefinition( {'key':"p2", 'type':"Float", 'default': 1.0} )
+        sim = oacis.Simulator.create( {'name': 'my_test_simulator', 'command': 'echo', 'parameter_definitions': [pd1,pd2]} )
+        #print( repr(sim) )
+        #print( sim.parameter_definitions() )
+        #print( oacis.Simulator.count() )
+        return sim
+
+    def build_ps(self, sim, num_ps):
+        for i in range(num_ps):
+            v = {"p1": i, "p2": 0.0}
+            sim.find_or_create_parameter_set(v)
+
+    def test_watch_ps(self):
+        sim = self.build_simulator()
+        self.build_ps(sim, 1)
+        w = oacis.OacisWatcher()
+        self.assertEqual( len(w.observed_parameter_sets), 0 )
+        def on_ps_finished(ps): pass
+        w.watch_ps( sim.parameter_sets().first(), on_ps_finished )
+        self.assertEqual( len(w.observed_parameter_sets), 1 )
+
+if __name__ == '__main__':
+    setupSuite()
+    unittest.main()
+


### PR DESCRIPTION
migrated oacis_watcher.rb into Python. Both library code and its unit tests are migrated.

Also renamed "oacis.py" to "oacis/__init__.py", but this does not require the change in user's code, i.e., `import oacis` loads necessary modules.

A sample Python script using oacis_watcher.py is found at 
https://gist.github.com/yohm/a186812fec6bbce04d384416f3f16147
