### PR TITLE
changed the spec of shortened id

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,7 +61,7 @@ module ApplicationHelper
 
   def shortened_id(id)
     str = id.to_s
-    str[4..7] + str[-6..-5]
+    str[5..7] + str[-3..-1]
   end
 
   def shortened_job_id(job_id)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -8,7 +8,7 @@ describe ApplicationHelper, type: :helper do
 
     it "returns shortened id" do
       id_org = "51d0f8e5899e53cf2e031001"
-      expect(helper.shortened_id(id_org)).to eq "f8e503"
+      expect(helper.shortened_id(id_org)).to eq "8e5001"
     end
   end
 


### PR DESCRIPTION
Shortened IDs sometimes become identical for different documents. Changed the specification to avoid such conflict.