### PR TITLE
set proper error message when a dotted field is included in result

### DIFF
--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -141,13 +141,19 @@ EOS
         end
       end
 
-      if error_message.length > 0
-        job.update_attribute(:error_messages, error_message)
-      end
-
       if is_updated
         job.included_at = DateTime.now
-        job.save!
+        begin
+          job.save!
+        rescue => ex
+          error_message += "failed to save: #{ex.message}"
+          job.reload # reload must be called. Otherwise update_attribute will fail.
+          job.update_attribute(:status, :failed)
+        end
+      end
+
+      if error_message.length > 0
+        job.update_attribute(:error_messages, error_message)
       end
     }
   end

--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -126,7 +126,7 @@ EOS
           job.version = version
           is_updated = true
         rescue => ex
-          error_message+="failed to load _version.txt: #{ex.message}"
+          error_message+="failed to load _version.txt: #{ex.message}\n"
         end
       end
 
@@ -137,7 +137,7 @@ EOS
           job.result = {"result"=>job.result} unless job.result.is_a?(Hash)
           is_updated = true
         rescue => ex
-          error_message+="failed to load _output.json: #{ex.message}"
+          error_message+="failed to load _output.json: #{ex.message}\n"
         end
       end
 

--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -146,7 +146,7 @@ EOS
         begin
           job.save!
         rescue => ex
-          error_message += "failed to save: #{ex.message}"
+          error_message += "failed to save: #{ex.inspect}"
           job.reload # reload must be called. Otherwise update_attribute will fail.
           job.update_attribute(:status, :failed)
         end

--- a/spec/lib/job_script_util_spec.rb
+++ b/spec/lib/job_script_util_spec.rb
@@ -329,6 +329,25 @@ shared_examples_for JobScriptUtil do
       end
     end
 
+    context "when _output.json contains a dotted field" do
+
+      it "update the status to failed and set error_messages" do
+        File.open(@submittable.dir.join("_output.json"), "w") do |io|
+          io.puts '{"a.b": 1.0}'
+        end
+
+        expect {
+          JobScriptUtil.update_run(@submittable)
+        }.not_to raise_error
+
+        @submittable.reload
+        expect(@submittable.status).to eq :failed
+        expect(@submittable.error_messages).to match /dotted field/
+        expect(@submittable.result).to be_nil
+        # error messages: The dotted field 'a.b' in 'result.a.b' is not valid for storage.
+      end
+    end
+
     it "parse elapsed times" do
 
       time_str=<<EOS

--- a/spec/lib/job_script_util_spec.rb
+++ b/spec/lib/job_script_util_spec.rb
@@ -342,7 +342,7 @@ shared_examples_for JobScriptUtil do
 
         @submittable.reload
         expect(@submittable.status).to eq :failed
-        expect(@submittable.error_messages).to match /dotted field/
+        expect(@submittable.error_messages).not_to be_empty
         expect(@submittable.result).to be_nil
         # error messages: The dotted field 'a.b' in 'result.a.b' is not valid for storage.
       end

--- a/spec/lib/job_script_util_spec.rb
+++ b/spec/lib/job_script_util_spec.rb
@@ -218,72 +218,75 @@ shared_examples_for JobScriptUtil do
       end
     end
 
-    it "parse _output.json which is not a Hash but a Float" do
+    context "when _output.json is not a Hash" do
 
-      Dir.chdir(@submittable.dir) {
-        result = 0.12345
-        system("echo #{result} > _output.json")
-      }
+      it "parse _output.json which is not a Hash but a Float" do
 
-      JobScriptUtil.update_run(@submittable)
+        Dir.chdir(@submittable.dir) {
+          result = 0.12345
+          system("echo #{result} > _output.json")
+        }
 
-      # expand result properly
-      expect(File.exist?(@submittable.dir.join('_output.json'))).to be_truthy
+        JobScriptUtil.update_run(@submittable)
 
-      # parse status
-      @submittable.reload
-      expect(@submittable.result).to eq Hash["result",0.12345]
-    end
+        # expand result properly
+        expect(File.exist?(@submittable.dir.join('_output.json'))).to be_truthy
 
-    it "parse _output.json which is not a Hash but a Boolean" do
+        # parse status
+        @submittable.reload
+        expect(@submittable.result).to eq Hash["result",0.12345]
+      end
 
-      Dir.chdir(@submittable.dir) {
-        result = false
-        system("echo #{result} > _output.json")
-      }
+      it "parse _output.json which is not a Hash but a Boolean" do
 
-      JobScriptUtil.update_run(@submittable)
+        Dir.chdir(@submittable.dir) {
+          result = false
+          system("echo #{result} > _output.json")
+        }
 
-      # expand result properly
-      expect(File.exist?(@submittable.dir.join('_output.json'))).to be_truthy
+        JobScriptUtil.update_run(@submittable)
 
-      # parse status
-      @submittable.reload
-      expect(@submittable.result).to eq Hash["result",false]
-    end
+        # expand result properly
+        expect(File.exist?(@submittable.dir.join('_output.json'))).to be_truthy
 
-    it "parse _output.json which is not a Hash but a String" do
+        # parse status
+        @submittable.reload
+        expect(@submittable.result).to eq Hash["result",false]
+      end
 
-      Dir.chdir(@submittable.dir) {
-        result = "12345"
-        system("echo \\\"#{result}\\\" > _output.json")
-      }
+      it "parse _output.json which is not a Hash but a String" do
 
-      JobScriptUtil.update_run(@submittable)
+        Dir.chdir(@submittable.dir) {
+          result = "12345"
+          system("echo \\\"#{result}\\\" > _output.json")
+        }
 
-      # expand result properly
-      expect(File.exist?(@submittable.dir.join('_output.json'))).to be_truthy
+        JobScriptUtil.update_run(@submittable)
 
-      # parse status
-      @submittable.reload
-      expect(@submittable.result).to eq Hash["result","12345"]
-    end
+        # expand result properly
+        expect(File.exist?(@submittable.dir.join('_output.json'))).to be_truthy
 
-    it "parse _output.json which is not a Hash but a Array" do
+        # parse status
+        @submittable.reload
+        expect(@submittable.result).to eq Hash["result","12345"]
+      end
 
-      Dir.chdir(@submittable.dir) {
-        result = [1,2,3]
-        system("echo #{result} > _output.json")
-      }
+      it "parse _output.json which is not a Hash but a Array" do
 
-      JobScriptUtil.update_run(@submittable)
+        Dir.chdir(@submittable.dir) {
+          result = [1,2,3]
+          system("echo #{result} > _output.json")
+        }
 
-      # expand result properly
-      expect(File.exist?(@submittable.dir.join('_output.json'))).to be_truthy
+        JobScriptUtil.update_run(@submittable)
 
-      # parse status
-      @submittable.reload
-      expect(@submittable.result).to eq Hash["result",[1,2,3]]
+        # expand result properly
+        expect(File.exist?(@submittable.dir.join('_output.json'))).to be_truthy
+
+        # parse status
+        @submittable.reload
+        expect(@submittable.result).to eq Hash["result",[1,2,3]]
+      end
     end
 
     context "when _output.json has invalid json format" do


### PR DESCRIPTION
Fixed #527 

Mongoid does not accept including a dot. If a dotted field is included in the result field, Run was set to failed without any error message, which is pretty hard for users to figure out the cause of the error.

To show the cause of the error, we set a proper error_message. The run page looks like the following.

![image](https://cloud.githubusercontent.com/assets/718731/24929614/824e462c-1f41-11e7-9e46-38bbaae3e5d7.png)
