### PR TITLE
local preprocess

### DIFF
--- a/app/controllers/analyzers_controller.rb
+++ b/app/controllers/analyzers_controller.rb
@@ -112,6 +112,7 @@ class AnalyzersController < ApplicationController
                                                :support_mpi,
                                                :support_omp,
                                                :pre_process_script,
+                                               :local_pre_process_script,
                                                :auto_run_submitted_to,
                                                :auto_run_host_group,
                                                parameter_definitions_attributes: [[:id, :key, :type, :default, :description]],

--- a/app/controllers/simulators_controller.rb
+++ b/app/controllers/simulators_controller.rb
@@ -180,6 +180,7 @@ class SimulatorsController < ApplicationController
     params[:simulator].present? ? params.require(:simulator)
                                         .permit(:name,
                                                 :pre_process_script,
+                                                :local_pre_process_script,
                                                 :command,
                                                 :description,
                                                 :executable_on_ids,

--- a/app/models/executable.rb
+++ b/app/models/executable.rb
@@ -6,6 +6,7 @@ module Executable
     base.send(:field, :support_mpi, type: Boolean, default: false)
     base.send(:field, :support_omp, type: Boolean, default: false)
     base.send(:field, :pre_process_script, type: String)
+    base.send(:field, :local_pre_process_script, type: String)
     base.send(:field, :print_version_command, type: String)
     base.send(:field, :default_host_parameters, type: Hash, default: {}) # {Host.id => {host_param1 => foo, ...}}
     base.send(:field, :default_mpi_procs, type: Hash, default: {}) # {Host.id => 4, ...}

--- a/app/services/remote_file_path.rb
+++ b/app/services/remote_file_path.rb
@@ -16,10 +16,6 @@ module RemoteFilePath
     Pathname.new(host.work_base_dir).join("#{run.id}")
   end
 
-  def self.input_files_dir_path(host, anl)
-    work_dir_path(host, anl).join('_input')
-  end
-
   def self.result_file_path(host, run)
     Pathname.new(host.work_base_dir).join("#{run.id}.tar.bz2")
   end

--- a/app/services/remote_job_handler.rb
+++ b/app/services/remote_job_handler.rb
@@ -69,8 +69,12 @@ class RemoteJobHandler
   end
 
   def execute_local_pre_process(job)
-    script = job.executable.local_pre_process_script
     Dir.chdir( job.dir ) {
+      File.open('_input.json', 'w') {|io|
+        io.print job.input.to_json
+        io.flush
+      }
+      script = job.executable.local_pre_process_script
       File.open('_lpreprocess.sh', 'w') {|io|
         io.puts script; io.flush
       }

--- a/app/services/remote_job_handler.rb
+++ b/app/services/remote_job_handler.rb
@@ -72,10 +72,22 @@ class RemoteJobHandler
   def execute_local_pre_process(job)
     return unless job.executable.local_pre_process_script.present?
     Dir.chdir( job.dir ) {
-      File.open('_input.json', 'w') {|io|
-        io.print job.input.to_json
-        io.flush
-      }
+      if input = job.input
+        File.open('_input.json', 'w') {|io|
+          io.print input.to_json
+          io.flush
+        }
+      end
+      # prepare _input dir
+      if job.is_a?(Analysis)
+        FileUtils.mkdir_p('_input')
+        Dir.chdir('_input') do
+          job.input_files.each do |o,d|
+            FileUtils.ln_s(o, d)
+          end
+        end
+      end
+
       script = job.executable.local_pre_process_script
       File.open('_lpreprocess.sh', 'w') {|io|
         io.puts script; io.flush

--- a/app/services/remote_job_handler.rb
+++ b/app/services/remote_job_handler.rb
@@ -69,6 +69,7 @@ class RemoteJobHandler
   end
 
   def execute_local_pre_process(job)
+    return unless job.executable.local_pre_process_script.present?
     Dir.chdir( job.dir ) {
       File.open('_input.json', 'w') {|io|
         io.print job.input.to_json

--- a/app/views/analyzers/_about.html.haml
+++ b/app/views/analyzers/_about.html.haml
@@ -54,6 +54,11 @@
     %pre
       = analyzer.pre_process_script
   %li
+    Local Pre-process Script
+    %br
+    %pre
+      = analyzer.local_pre_process_script
+  %li
     Analyzer Command
     %br
     %pre

--- a/app/views/analyzers/_form.html.haml
+++ b/app/views/analyzers/_form.html.haml
@@ -22,6 +22,10 @@
     .col-md-6
       = f.text_area(:pre_process_script, rows: 3, class: 'form-control')
   .form-group
+    = f.label(:local_pre_process_script, class: ['col-md-2','control-label'])
+    .col-md-6
+      = f.text_area(:local_pre_process_script, rows: 1, class: 'form-control')
+  .form-group
     = f.label(:command, class: 'col-md-2 control-label')
     .col-md-6
       = f.text_field(:command, class: 'form-control')

--- a/app/views/simulators/_about.html.haml
+++ b/app/views/simulators/_about.html.haml
@@ -52,6 +52,11 @@
     %pre
       = simulator.pre_process_script
   %li
+    Local Pre-process Script
+    %br
+    %pre
+      = simulator.local_pre_process_script
+  %li
     Simulation Command
     %br
     %pre

--- a/app/views/simulators/_form.html.haml
+++ b/app/views/simulators/_form.html.haml
@@ -28,6 +28,10 @@
     .col-md-6
       = f.text_area(:pre_process_script, rows: 3, class: 'form-control')
   .form-group
+    = f.label(:local_pre_process_script, class: ['col-md-2','control-label'])
+    .col-md-6
+      = f.text_area(:local_pre_process_script, rows: 1, class: 'form-control')
+  .form-group
     = f.label(:command, class: ['col-md-2','control-label'])
     .col-md-6
       = f.text_field(:command, class: 'form-control')

--- a/docs/ja/configuring_simulator.md
+++ b/docs/ja/configuring_simulator.md
@@ -33,30 +33,38 @@ OACISはジョブ実行時にコマンドが埋め込まれたシェルスクリ
 
 ```text
 
-OACIS-server  |     remote host (login node)        |   computation node
---------------|-------------------------------------|---------------------------------------
-           ---|-->  SSH login                       |
-              |     create a work directory         |
-              |     prepare _input.json             |
-              |     create a job script             |
-              |     execute preprocess              |
-              |     submit job script               |
-              |                                     |   (when job script start)
-              |                                     |   execute print-version command
-              |                                     |   save execution logs to a file
-              |                                     |   execution of the simulation program
-              |                                     |   compress the work directory
-              |                                     |
-              |     (after the job finished)        |
-           ---|-->  SSH login                       |
-              |     download the compressed results |
+OACIS-server                                  |     computational host              |   computation node
+----------------------------------------------|-------------------------------------|---------------------------------------
+                                           ---|-->  SSH login                       |
+                                              |     create a work directory         |
+                                              |     prepare _input.json             |
+                                              |     create a job script             |
+execute local preprocess                      |                                     |
+                                              |     copy output of local preprocess |
+                                              |     execute preprocess              |
+                                              |     submit job script               |
+                                              |                                     |   (when job script start)
+                                              |                                     |   execute print-version command
+                                              |                                     |   save execution logs to a file
+                                              |                                     |   execution of the simulation program
+                                              |                                     |   compress the work directory
+                                              |                                     |
+                                              |     (after the job finished)        |
+                                           ---|-->  SSH login                       |
+                                              |     download the compressed results |
+extract the results                           |                                     |
+move the output files to specified directory  |                                     |
+parse logs and save them in MongoDB           |                                     |
 ```
+
 
 まずOACISはリモートホストにログインし、ワークディレクトリを作成します。その後、実行パラメータが書かれた`_input.json`を配置します。（Simulator登録時にJSON形式を指定した場合）
 
-ジョブスケジューラにジョブを投入する前に、ワークディレクトリで個別に実行する処理を定義することもできます。それをプリプロセスと呼んでいます。
+ジョブスケジューラにジョブを投入する前に、ワークディレクトリで個別に実行する処理を定義することもできます。プリプロセスと呼んでいます。
 詳細は以後説明しますが、例えばジョブの実行に必要なファイルなどをコピーしたりするのに利用します。
-`_input.json`が作成された後、ジョブ投入前にこのプリプロセスが実行されます。
+プリプロセスには２種類あり、OACISのあるサーバーで実行されるもの、計算ホストのログインノードで実行されるものを定義できます。（それぞれ"local pre-process", "pre-process"と呼びます。）
+`_input.json`が作成された後、ジョブ投入前にこれらのプリプロセスが実行されます。
+"local pre-process"についてはOACISサーバーで実行された後、出力ファイルが計算ホストのワークディレクトリに転送されます。
 
 その後、ジョブがスケジューラに投入され、ジョブが実行待ちになります。ジョブがスケジューリングされるとジョブスクリプトが実行されることになります。
 
@@ -215,7 +223,8 @@ OACISにSimulator登録する際に登録する項目の一覧を見ていきま
 |:---------------------------|:--------------------------------------------------------------------|
 | Name *                     | シミュレータの名前。Ascii文字、数字、アンダースコアのみ使用可。空白不可。他のSimulatorとの重複は不可。 |
 | Definition of Parameters * | シミュレータの入力パラメータの定義。パラメータの名前、型(Integer, Float, String, Boolean)、デフォルト値、パラメータの説明（任意）を入力する。 |
-| Preprocess Script          | ジョブの前に実行されるプリプロセスを記述するスクリプト。空の場合はプリプロセスは実行されない。|
+| Local Preprocess Script    | ジョブの前にローカルホストで実行されるプリプロセスを記述するスクリプト。空の場合はプリプロセスは実行されない。|
+| Preprocess Script          | ジョブの前に計算ホストで実行されるプリプロセスを記述するスクリプト。空の場合はプリプロセスは実行されない。|
 | Command *                  | シミュレータの実行コマンド。リモートホスト上でのパスを絶対パスかホームディレクトリからの相対パスで指定する。(例. *~/path/to/simulator.out*) |
 | Pirnt version command      | シミュレータのversionを標準出力に出力するコマンド。（例. *~/path/to/simulator.out --version* ）|
 | Input type                 | パラメータを引数形式で渡すか、JSON形式で渡すか指定する。|
@@ -231,7 +240,7 @@ OACISにSimulator登録する際に登録する項目の一覧を見ていきま
 **Definition of Parameters** の入力の際には、指定した型とデフォルト値の値が整合するように入力してください。
 例えば、型がIntegerなのにデフォルト値として文字列を指定するとエラーになります。
 
-**Preprocess Script** を指定すると、ジョブ投入前に実行されるプリプロセスを指定することができます。
+**Local Preprocess Script** または **Preprocess Script** を指定すると、ジョブ投入前に実行されるプリプロセスを指定することができます。
 シミュレーターの入力を準備したり、ジョブ投入ノードでしか実行できない処理を指定するとよいでしょう。
 詳細は[プリプロセスの定義](#preprocess)を参照してください。
 
@@ -279,22 +288,34 @@ mpiexec -n $OACIS_MPI_PROCS ~/path/to/simulator.out
 - ファイルのステージングの都合により、ジョブの実行前にファイルをすべて用意する必要があるケース
 
 そこで、OACISにはジョブの実行前にプリプロセスを個別に実行する仕組みを用意しています。
-このプリプロセスはジョブの投入前にログインノードで実行されるため上記の問題は起きません。
+このプリプロセスはジョブの投入前にローカルホストまたはログインノードで実行されるため上記の問題は起きません。
+プリプロセスの中には２種類あり、OACISの動いているサーバーで実行される"local pre-process", リモートホストでジョブの投入前に実行される"pre-process"の２種類があります。
 
-プリプロセスはジョブの投入前にworkerによってssh経由で実行されます。
-workerの実行手順は
+プリプロセスはジョブの投入前にworkerによって実行されます。
 
-1. 各Runごとにワークディレクトリを作成する
+"local pre-process"の実行手順は以下のようになる。
+
+1. OACIS稼働中のサーバーにて各ジョブ用のディレクトリが作られる
 1. SimulatorがJSON入力の場合、_input.jsonを配置する
-1. Simulatorの **pre_process_script** フィールドに記載されたジョブスクリプトをワークディレクトリに配置し実行権限をつける。(_preprocess.sh というファイル名で配置される)
+1. Simulatorの **local_pre_process_script** フィールドに記載されたスクリプトをディレクトリに配置し実行権限をつける。(_lpreprocess.sh というファイル名で配置される)
+1. _lpreprocess.sh をワークディレクトリをカレントディレクトリとして実行する
+    - この際Simulatorが引数形式ならば、同様の引数を与えて _lpreprocess.sh を実行する。この引数から実行パラメータを取得することができる。
+    - 標準出力、標準エラー出力は _stdout.txt, _stderr.txt にそれぞれリダイレクトされる。
+1. _lpreprocess.sh のリターンコードがノンゼロの場合には、そのRunをfailedとする
+1. カレントディレクトリに作成されたファイルをリモートホスト上に転送する
+
+"pre-process"の実行手順は
+
+1. SimulatorがJSON入力の場合、_input.jsonを配置する
+1. Simulatorの **pre_process_script** フィールドに記載されたスクリプトをワークディレクトリに配置し実行権限をつける。(_preprocess.sh というファイル名で配置される)
 1. _preprocess.sh をワークディレクトリをカレントディレクトリとして実行する
     - この際Simulatorが引数形式ならば、同様の引数を与えて _preprocess.sh を実行する。この引数から実行パラメータを取得することができる。
     - 標準出力、標準エラー出力は _stdout.txt, _stderr.txt にそれぞれリダイレクトされる。
 1. _preprocess.sh のリターンコードがノンゼロの場合には、SSHのセッションを切断しRunをfailedとする
     - failedの時には、ワークディレクトリの内容をサーバーにコピーし、リモートサーバー上のファイルは削除する
-1. シミュレーションジョブをサブミットする。
 
-ただし、 Simulatorの pre_process_script のフィールドが空の場合には、上記3~5の手順は実行されません。
+これらの"local pre-process", "pre-process" が終わったらジョブを投入します。
+ただし、 Simulatorの local_pre_process_script または pre_process_script のフィールドが空の場合には、上記の手順は実行されません。
 
 
 ## 結果をOACIS上でプロットする

--- a/spec/controllers/analyzers_controller_spec.rb
+++ b/spec/controllers/analyzers_controller_spec.rb
@@ -84,6 +84,7 @@ describe AnalyzersController do
           description: "xxx yyy",
           support_input_json: "1", support_mpi: "1", support_omp: "0",
           pre_process_script: "echo preprocess",
+          local_pre_process_script: "echo local_preprocess",
           executable_on_ids: [@host.id.to_s],
           auto_run_submitted_to: @host.id.to_s
         }
@@ -111,6 +112,7 @@ describe AnalyzersController do
         expect(azr.support_mpi).to be_truthy
         expect(azr.support_omp).to be_falsey
         expect(azr.pre_process_script).to eq("echo preprocess")
+        expect(azr.local_pre_process_script).to eq("echo local_preprocess")
         expect(azr.executable_on).to eq [@host]
         expect(azr.auto_run_submitted_to).to eq @host
       end
@@ -205,6 +207,7 @@ describe AnalyzersController do
           description: "xxx yyy",
           support_input_json: "1", support_mpi: "1", support_omp: "0",
           pre_process_script: "echo preprocess",
+          local_pre_process_script: "echo local_preprocess",
           executable_on: [],
           auto_run_submitted_to: ''
         }

--- a/spec/controllers/simulators_controller_spec.rb
+++ b/spec/controllers/simulators_controller_spec.rb
@@ -142,6 +142,8 @@ describe SimulatorsController do
         ]
         simulator = {
           name: "simulatorA", command: "echo", support_input_json: "0",
+          pre_process_script: "preprocess.sh",
+          local_pre_process_script: "local_preprocess.sh",
           support_mpi: "0", support_omp: "1",
           sequential_seed: "1",
           parameter_definitions_attributes: definitions,
@@ -162,6 +164,8 @@ describe SimulatorsController do
         expect(sim.name).to eq "simulatorA"
         expect(sim.command).to eq "echo"
         expect(sim.support_input_json).to be_falsey
+        expect(sim.pre_process_script).to eq "preprocess.sh"
+        expect(sim.local_pre_process_script).to eq "local_preprocess.sh"
         expect(sim.parameter_definition_for("param1").type).to eq "Integer"
         expect(sim.parameter_definition_for("param2").type).to eq "Float"
         expect(sim.support_mpi).to be_falsey
@@ -280,6 +284,8 @@ describe SimulatorsController do
         ]
         @valid_post_parameter = {
           name: "simulatorA", command: "echo", support_input_json: "0",
+          pre_process_script: "preprocess.sh",
+          local_pre_process_script: "local_preprocess.sh",
           support_mpi: "0", support_omp: "1",
           sequential_seed: "1",
           parameter_definitions_attributes: definitions
@@ -298,6 +304,8 @@ describe SimulatorsController do
         expect(assigns(:simulator).id).to eq simulator.id
         expect(assigns(:simulator).command).to eq "echo"
         expect(assigns(:simulator).support_input_json).to be_falsey
+        expect(assigns(:simulator).pre_process_script).to eq "preprocess.sh"
+        expect(assigns(:simulator).local_pre_process_script).to eq "local_preprocess.sh"
         expect(assigns(:simulator).support_mpi).to be_falsey
         expect(assigns(:simulator).support_omp).to be_truthy
         expect(assigns(:simulator).sequential_seed).to be_truthy

--- a/spec/services/remote_job_handler_spec.rb
+++ b/spec/services/remote_job_handler_spec.rb
@@ -29,6 +29,21 @@ shared_examples_for RemoteJobHandler do
       end
     end
 
+    describe "execute_local_preprocess" do
+
+      before(:each) do
+        @executable.update_attribute(:local_pre_process_script, "pwd > local_preprocess.txt")
+        allow_any_instance_of(RemoteJobHandler).to receive(:submit_to_scheduler)
+      end
+
+      it "execute local_preprocess at the directory of submittable" do
+        RemoteJobHandler.new(@host).submit_remote_job(@submittable)
+        path = @submittable.dir.join("local_preprocess.txt")
+        expect( path ).to be_exist
+        expect( File.read( path ).chomp ).to eq @submittable.dir.to_s
+      end
+    end
+
     describe "prepare job" do
 
       before(:each) do

--- a/spec/services/remote_job_handler_spec.rb
+++ b/spec/services/remote_job_handler_spec.rb
@@ -32,16 +32,23 @@ shared_examples_for RemoteJobHandler do
     describe "execute_local_preprocess" do
 
       before(:each) do
-        @executable.update_attribute(:local_pre_process_script, "pwd > local_preprocess.txt")
+        @executable.update_attribute(:local_pre_process_script, "pwd > pwd.txt && cat _input.json > cat.txt")
         allow_any_instance_of(RemoteJobHandler).to receive(:submit_to_scheduler)
       end
 
       it "execute local_preprocess at the directory of submittable" do
         RemoteJobHandler.new(@host).submit_remote_job(@submittable)
-        path = @submittable.dir.join("local_preprocess.txt")
+        path = @submittable.dir.join("pwd.txt")
         expect( path ).to be_exist
         expect( File.read( path ).chomp ).to eq @submittable.dir.to_s
       end
+
+      it "_input.json is prepared when executing local preprocess" do
+        RemoteJobHandler.new(@host).submit_remote_job(@submittable)
+        path = @submittable.dir.join("cat.txt")
+        expect( JSON.load(File.read(path)) ).to eq JSON.load(@submittable.input.to_json)
+      end
+
     end
 
     describe "prepare job" do

--- a/spec/services/remote_job_handler_spec.rb
+++ b/spec/services/remote_job_handler_spec.rb
@@ -4,34 +4,35 @@ shared_examples_for RemoteJobHandler do
 
   describe ".submit_remote_job" do
 
+    describe "set_submitted_to_if_host_group_is_given" do
+
+      before(:each) do
+        hg = FactoryGirl.create(:host_group, hosts: [@host])
+        @host.update_attribute( :host_parameter_definitions, [
+            HostParameterDefinition.new(key: "param1"),
+            HostParameterDefinition.new(key: "param2", default: "XXX")
+        ])
+        @submittable.update_attributes!( submitted_to: nil, host_group: hg )
+        allow_any_instance_of(RemoteJobHandler).to receive(:submit_to_scheduler)
+      end
+
+      it "sets #submitted_to to the current host" do
+        expect {
+          RemoteJobHandler.new(@host).submit_remote_job(@submittable)
+        }.to change { @submittable.submitted_to }.from(nil).to(@host)
+      end
+
+      it "sets #host_parameters to the default value of the one in Host" do
+        expect {
+          RemoteJobHandler.new(@host).submit_remote_job(@submittable)
+        }.to change { @submittable.host_parameters }.from({}).to(@host.default_host_parameters)
+      end
+    end
+
     describe "prepare job" do
 
       before(:each) do
         allow_any_instance_of(RemoteJobHandler).to receive(:submit_to_scheduler)
-      end
-
-      describe "when #host_group is set" do
-
-        before(:each) do
-          hg = FactoryGirl.create(:host_group, hosts: [@host])
-          @host.update_attribute( :host_parameter_definitions, [
-            HostParameterDefinition.new(key: "param1"),
-            HostParameterDefinition.new(key: "param2", default: "XXX")
-          ])
-          @submittable.update_attributes!( submitted_to: nil, host_group: hg )
-        end
-
-        it "sets #submitted_to to the current host" do
-          expect {
-            RemoteJobHandler.new(@host).submit_remote_job(@submittable)
-          }.to change { @submittable.submitted_to }.from(nil).to(@host)
-        end
-
-        it "sets #host_parameters to the default value of the one in Host" do
-          expect {
-            RemoteJobHandler.new(@host).submit_remote_job(@submittable)
-          }.to change { @submittable.host_parameters }.from({}).to(@host.default_host_parameters)
-        end
       end
 
       it "creates a work_dir on remote host" do


### PR DESCRIPTION
Add a new function "local preprocess" to Simulator and Analyzer.
If a user specifies a command to this field, the command is executed at the host where OACIS is running before submitting the job to a remote host.
With this new functionality, users can

- conduct a preprocess which is not available on a remote host
- copy results of another job.
    - In other words, users can define a job which depends on another job although it requires a fairly complex coding using APIs.

## Usage

Fill in "local pre process script" field when defining Simulator or Analyzer
![image](https://cloud.githubusercontent.com/assets/718731/24946999/f11318e0-1f9f-11e7-8a57-95f54dd09b9c.png)

The command is executed before submitting at the directory of the Run or Analysis. The output files of the local pre-process will be copied to the working directory of the remote host.
