### PR TITLE
give 0 or 1 for boolean parameters

### DIFF
--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -64,7 +64,11 @@ class Analysis
       ""
     else
       params = analyzer.parameter_definitions.map do |pd|
-        parameters[pd.key]
+        if pd.type == "Boolean"
+          parameters[pd.key] ? 1 : 0
+        else
+          parameters[pd.key]
+        end
       end
       params.join(' ')
     end

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -51,7 +51,11 @@ class Run
     else
       ps = parameter_set
       params = simulator.parameter_definitions.map do |pd|
-        ps.v[pd.key]
+        if pd.type == "Boolean"
+          ps.v[pd.key] ? 1 : 0
+        else
+          ps.v[pd.key]
+        end
       end
       params << seed
       params.join(' ')

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -306,6 +306,16 @@ describe Run do
         expect(command).to eq "#{sim.command} #{prm.v["L"]} #{prm.v["T"]} #{run.seed}"
         expect(run.input).to be_nil
       end
+
+      it "returns boolean parameters in 0 or 1" do
+        pds = [ ParameterDefinition.new(key:"p1",type:"Boolean",default:true) ]
+        sim = FactoryGirl.create(:simulator,
+                                 parameter_definitions: pds, support_input_json: false,
+                                 parameter_sets_count: 0)
+        run = sim.parameter_sets.create!(v: {p1: true}).runs.create!(submitted_to: FactoryGirl.create(:host))
+        command = run.command_with_args
+        expect(command).to eq "#{sim.command} 1 #{run.seed}"
+      end
     end
 
     context "for simulators which receives parameters as _input.json" do


### PR DESCRIPTION
Fixed #526 
Command line arguments have "0" or "1" for boolean parameters.
