### PR TITLE
Async/Await methods

### DIFF
--- a/docs/en/api_python.md
+++ b/docs/en/api_python.md
@@ -19,10 +19,12 @@ Using this library, almost all methods in Ruby is directly translated into Pytho
 In the following, we assume that a Simulator "my_simulator" is registered on OACIS, which has three parameters "p1", "p2", and "p3".
 We assume that you know basics of Python programming language.
 
-To use OACIS, Python 3 is necessary. It also requires "msgpack-rpc-python" library.
+To use OACIS, Python 3 is necessary. It also requires "msgpack-rpc-python" and "fibers" library.
+
+<span class="label label-success">New in v2.13.0</span>"fibers" library is required since v2.13.0.
 
 ```
-$ pip install msgpack-rpc-python
+$ pip install msgpack-rpc-python fibers
 ```
 
 ## Executing script

--- a/lib/oacis_watcher.rb
+++ b/lib/oacis_watcher.rb
@@ -8,7 +8,6 @@ class OacisWatcher
   def self.start( logger: Logger.new($stderr), polling: 5 )
     w = self.new( logger: logger, polling: polling )
     Fiber.new { yield w }.resume
-    #yield w
     w.send(:start_polling)
   end
 

--- a/lib/oacis_watcher.rb
+++ b/lib/oacis_watcher.rb
@@ -1,5 +1,6 @@
 require 'pp'
 require 'logger'
+require 'fiber'
 
 class OacisWatcher
 
@@ -17,6 +18,19 @@ class OacisWatcher
     @observed_parameter_sets_all = {}
     @logger = logger
     @polling = polling
+  end
+
+  def async(&block)
+    Fiber.new(&block).resume
+  end
+
+  def await_ps(ps)
+    f = Fiber.current
+    watch_ps(ps) {
+      ps.reload
+      f.resume ps
+    }
+    Fiber.yield
   end
 
   def watch_ps(ps, &block)

--- a/lib/oacis_watcher.rb
+++ b/lib/oacis_watcher.rb
@@ -7,7 +7,8 @@ class OacisWatcher
 
   def self.start( logger: Logger.new($stderr), polling: 5 )
     w = self.new( logger: logger, polling: polling )
-    yield w
+    Fiber.new { yield w }.resume
+    #yield w
     w.send(:start_polling)
   end
 
@@ -29,6 +30,15 @@ class OacisWatcher
     watch_ps(ps) {
       ps.reload
       f.resume ps
+    }
+    Fiber.yield
+  end
+
+  def await_all_ps(ps_array)
+    f = Fiber.current
+    watch_all_ps(ps_array) {
+      ps_array.each {|ps| ps.reload}
+      f.resume ps_array
     }
     Fiber.yield
   end

--- a/lib/oacis_watcher.rb
+++ b/lib/oacis_watcher.rb
@@ -77,10 +77,11 @@ class OacisWatcher
       end while executed
       break if @observed_parameter_sets.empty? && @observed_parameter_sets_all.empty?
       break if @sigint_received
-      @logger.info "waiting for #{@polling} sec"
+      @logger.debug "waiting for #{@polling} sec"
       sleep @polling
     end
-    @logger.info "stop polling, #{@sigint_received}"
+    @logger.info "received SIGINT"  if @sigint_received
+    @logger.info "stop polling"
   ensure
     Signal.trap("INT", default_sigaction || "DEFAULT")
     Process.kill("INT", 0) if @sigint_received  # send INT to the current process
@@ -108,7 +109,7 @@ class OacisWatcher
       if ps.runs.count == 0
         @logger.warn "#{ps} has no run"
       else
-        @logger.info "calling callback for #{psid}"
+        @logger.debug "calling callback for #{psid}"
         executed = true
         while callback = @observed_parameter_sets[psid].shift
           callback.call( ps )
@@ -129,7 +130,7 @@ class OacisWatcher
     @observed_parameter_sets_all.keys.each do |watched_ps_ids|
       callbacks = @observed_parameter_sets_all[watched_ps_ids]
       if watched_ps_ids.all? {|psid| completed.include?(psid) }
-        @logger.info "calling callback for #{watched_ps_ids}"
+        @logger.debug "calling callback for #{watched_ps_ids}"
         executed = true
         while callback = callbacks.shift
           watched_pss = watched_ps_ids.map {|psid| ParameterSet.find(psid) }

--- a/oacis/README.md
+++ b/oacis/README.md
@@ -1,5 +1,5 @@
 # How to test python module
 
 ```
-oacis_python -m unittest oacis/oacis_watcher_test.py
+oacis_python -m unittest oacis_watcher_test.py
 ```

--- a/oacis/oacis_watcher.py
+++ b/oacis/oacis_watcher.py
@@ -4,6 +4,7 @@ import signal
 import sys
 import os
 from functools import reduce
+import fibers
 
 class OacisWatcher():
 
@@ -13,6 +14,18 @@ class OacisWatcher():
         self._observed_parameter_sets_all = {}
         self._logger = logger or self._default_logger()
         self._signal_received = False
+
+    def async(self, func):
+        f = fibers.Fiber( target=func )
+        f.switch()
+
+    def await_ps(self, ps):
+        f = fibers.Fiber.current()
+        def callback(ps):
+            ps.reload()
+            f.switch(ps)
+        self.watch_ps(ps, callback)
+        return f.parent.switch()
 
     def watch_ps(self, ps, callback):
         psid = ps.id().to_s()


### PR DESCRIPTION
Async/Await methods are added to OacisWatcher.

Defining callback functions often causes a deeply nested code, which is quite hard to write because the code looks quite different from a synchronous code.
To improve the usability of OacisWatcher, we introduced "async/await" methods to OacisWatcher class.

For the implementation, we used fibers to switch context.
