### PR TITLE
fix issue on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,9 @@ language: ruby
 rvm:
   - "2.2.2"
   - "2.4.1"
-addons:
-  apt:
-    sources:
-      - mongodb-upstart
-      - mongodb-3.2-precise
-    packages:
-      - mongodb-org-server
-      - mongodb-org-shell
-sudo: false
+services:
+  - mongodb
+sudo: required
 install:
   - ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa
   - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys


### PR DESCRIPTION
fixed #546 
Because of the upgrade of the container used in TravisCI, new builds fail even though the code is not changed at all.
See https://blog.travis-ci.com/2017-08-31-trusty-as-default-status
To fix this issue, we added `sudo: required`.
Because of this addition, the mongo service failed to boot. We added `services: mongodb` to fix it.
