### PR TITLE
Fix warnings ruby24

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "net-sftp"
 gem "jbuilder"
 
 # assets
-gem "sprockets", '3.6.3'
+gem "sprockets"
 gem 'record_tag_helper', '~> 1.0'
   # fix version of sprockets to prevent deprecation warning.
   # should be updated after less-rails fixed issue https://github.com/metaskills/less-rails/issues/122

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,7 @@ GEM
     simplecov-html (0.10.2)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    sprockets (3.6.3)
+    sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -287,7 +287,7 @@ DEPENDENCIES
   sass-rails
   simplecov
   simplecov-rcov
-  sprockets (= 3.6.3)
+  sprockets
   stackprof
   sys-filesystem
   therubyracer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (7.1.4)
-    bson (4.2.2)
+    bson (4.3.0)
     builder (3.2.3)
     byebug (9.1.0)
     ci_reporter (1.9.3)
@@ -126,8 +126,8 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.1)
-    mongo (2.4.3)
-      bson (>= 4.2.1, < 5.0.0)
+    mongo (2.5.0)
+      bson (>= 4.3.0, < 5.0.0)
     mongoid (6.1.1)
       activemodel (~> 5.0)
       mongo (>= 2.4.1, < 3.0.0)
@@ -294,4 +294,4 @@ DEPENDENCIES
   twitter-bootstrap-rails (~> 3.2.0)
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -9,7 +9,7 @@ development:
       # Provides the hosts the default client can connect to. Must be an array
       # of host:port pairs. (required)
       hosts:
-        - localhost:27017
+        - 127.0.0.1:27017
       options:
         # Change the default write concern. (default = { w: 1 })
         write:
@@ -136,7 +136,7 @@ test:
     default:
       database: oacis_test
       hosts:
-        - localhost:27017
+        - 127.0.0.1:27017
       options:
         write:
           w: 1
@@ -156,7 +156,7 @@ production:
       # Provides the hosts the default client can connect to. Must be an array
       # of host:port pairs. (required)
       hosts:
-        - localhost:27017
+        - 127.0.0.1:27017
       options:
         # Change the default write concern. (default = { w: 1 })
         write:


### PR DESCRIPTION
Ruby2.4以降でもwarningが出ないように、sprockets, mongo-ruby-driverを更新した。
mongoの更新に伴い、mongoid.yml内でhostnameを使用することができなくなったので、IPアドレスで指定するように変更。