### PR TITLE
SSH config support

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -109,11 +109,7 @@ class HostsController < ApplicationController
   def permitted_host_params
     params[:host].present? ? params.require(:host)
                                    .permit(:name,
-                                           :hostname,
                                            :status,
-                                           :user,
-                                           :port,
-                                           :ssh_key,
                                            :work_base_dir,
                                            :mounted_work_base_dir,
                                            :max_num_jobs,

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -2,14 +2,10 @@ class Host
   include Mongoid::Document
   include Mongoid::Timestamps
   field :name, type: String
-  field :hostname, type: String
 
   HOST_STATUS = [:enabled, :disabled]
 
   field :status, type: Symbol, default: HOST_STATUS[0]
-  field :user, type: String
-  field :port, type: Integer, default: 22
-  field :ssh_key, type: String, default: '~/.ssh/id_rsa'
   field :work_base_dir, type: String, default: '~'
   field :mounted_work_base_dir, type: String, default: ""
   field :max_num_jobs, type: Integer, default: 1
@@ -27,12 +23,6 @@ class Host
   has_and_belongs_to_many :host_groups
 
   validates :name, presence: true, uniqueness: true, length: {minimum: 1}
-  validates :hostname, presence: true, format: {with: /\A(?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?(?:\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)*\.?\z/}
-  # See http://stackoverflow.com/questions/1418423/the-hostname-regex for the regexp of the hsotname
-
-  validates :user, presence: true, format: {with: /\A[A-Za-z0-9. _-]+\z/}
-
-  validates :port, numericality: {greater_than_or_equal_to: 1, less_than: 65536}
   validates :max_num_jobs, numericality: {greater_than_or_equal_to: 0}
   validates :polling_interval, numericality: {greater_than_or_equal_to: 5}
   validates :min_mpi_procs, numericality: {greater_than_or_equal_to: 1}
@@ -138,7 +128,7 @@ class Host
       yield @ssh
     else
       ssh_logger.debug("starting SSH: " + self.inspect ) if ssh_logger
-      Net::SSH.start(hostname, user, password: "", timeout: 1, keys: ssh_key, port: port, non_interactive: true, logger: ssh_logger) do |ssh|
+      Net::SSH.start(name, nil, password: nil, timeout: 1, non_interactive: true, logger: ssh_logger) do |ssh|
         @ssh = ssh
         begin
           yield ssh

--- a/app/views/hosts/_about.html.haml
+++ b/app/views/hosts/_about.html.haml
@@ -5,20 +5,8 @@
       %th Name
       %td= @host.name
     %tr
-      %th Hostname
-      %td= @host.hostname
-    %tr
       %th Status
       %td= raw(host_status_label(@host.status))
-    %tr
-      %th User
-      %td= @host.user
-    %tr
-      %th Port
-      %td= @host.port
-    %tr
-      %th SSH key
-      %td= @host.ssh_key
     %tr
       %th Work base directory
       %td= @host.work_base_dir

--- a/app/views/hosts/_form.html.haml
+++ b/app/views/hosts/_form.html.haml
@@ -6,25 +6,9 @@
     .col-md-3
       = f.text_field(:name, class: 'form-control')
   .form-group
-    = f.label(:hostname, class: 'col-md-2 control-label')
-    .col-md-3
-      = f.text_field(:hostname, class: 'form-control')
-  .form-group
     = f.label(:status, 'Polling Status', class: 'col-md-2 control-label')
     .col-md-3
       = f.select(:status, Host::HOST_STATUS, {}, {class: 'form-control'})
-  .form-group
-    = f.label(:user, class: 'col-md-2 control-label')
-    .col-md-3
-      = f.text_field(:user, class: 'form-control')
-  .form-group
-    = f.label(:port, class: 'col-md-2 control-label')
-    .col-md-3
-      = f.number_field(:port, class: 'form-control')
-  .form-group
-    = f.label(:ssh_key, class: 'col-md-2 control-label')
-    .col-md-3
-      = f.text_field(:ssh_key, class: 'form-control')
   .form-group
     = f.label(:work_base_dir, class: 'col-md-2 control-label')
     .col-md-3

--- a/app/views/hosts/index.html.haml
+++ b/app/views/hosts/index.html.haml
@@ -5,11 +5,7 @@
   %thead
     %tr
       %th Name
-      %th Hostname
       %th Status
-      %th User
-      %th Port
-      %th Ssh key
       %th Work base dir
       %th Mounted work base dir
       %th Max # of jobs
@@ -22,11 +18,7 @@
     - @hosts.each do |host|
       = content_tag_for :tr, host do
         %td= link_to(host.name, host)
-        %td= host.hostname
         %td= raw(host_status_label(host.status))
-        %td= host.user
-        %td= host.port
-        %td= host.ssh_key
         %td= host.work_base_dir
         %td= host.mounted_work_base_dir
         %td= host.max_num_jobs

--- a/lib/cli/oacis_cli_common.rb
+++ b/lib/cli/oacis_cli_common.rb
@@ -36,7 +36,7 @@ EOS
     required: true
   def show_host
     hosts = Host.all.map do |host|
-      {id: host.id.to_s, name: host.name, hostname: host.hostname, user: host.user}
+      {id: host.id.to_s, name: host.name}
     end
     File.open(options[:output], 'w') {|io|
       io.puts JSON.pretty_generate(hosts)

--- a/spec/controllers/hosts_controller_spec.rb
+++ b/spec/controllers/hosts_controller_spec.rb
@@ -7,9 +7,7 @@ describe HostsController do
   # update the return value of this method accordingly.
   def valid_attributes
     {
-      name: "nameABC",
-      hostname: "localhost",
-      user: ENV['USER']
+      name: "localhost"
     }
   end
 
@@ -132,9 +130,10 @@ describe HostsController do
   describe "PUT update" do
     describe "with valid params" do
       it "updates the requested host" do
-        host = Host.create! valid_attributes
-        put :update, params: {id: host.to_param, host: {name: 'XYZ'}}
-        expect(host.reload.name).to eq('XYZ')
+        host = FactoryBot.create(:host)
+        expect(host.reload.name).to_not eq('localhost')
+        put :update, params: {id: host.to_param, host: {name: 'localhost'}}
+        expect(host.reload.name).to eq('localhost')
       end
 
       it "assigns the requested host as @host" do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -182,12 +182,10 @@ FactoryBot.define do
       def host.get_host_parameters; []; end
     end
     sequence(:name, 'A') {|n| "Host_#{n}"}
-    sequence(:hostname, 'A') {|n| "hostname.#{n}"}
     min_mpi_procs 1
     max_mpi_procs 8
     min_omp_threads 1
     max_omp_threads 8
-    user "login_user"
 
     factory :host_with_parameters do
       host_parameter_definitions {
@@ -209,11 +207,9 @@ FactoryBot.define do
   # :localhost needs ssh connection and xsub
   factory :localhost, class: Host do
     name "localhost"
-    hostname { `hostname`.chomp }
     min_mpi_procs 1
     max_mpi_procs 8
     min_omp_threads 1
     max_omp_threads 8
-    user {ENV['USER']}
   end
 end

--- a/spec/lib/cli/oacis_cli_common_spec.rb
+++ b/spec/lib/cli/oacis_cli_common_spec.rb
@@ -22,9 +22,7 @@ describe OacisCli do
       at_temp_dir {
         expected = [{
           "id" => @host.id.to_s,
-          "name" => @host.name,
-          "hostname" => @host.hostname,
-          "user" => @host.user
+          "name" => @host.name
         }]
         OacisCli.new.invoke(:show_host, [], {output: 'host.json'})
         expect(File.exist?('host.json')).to be_truthy

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -7,10 +7,6 @@ describe Host do
     before(:each) do
       @valid_attr = {
         name: "nameABC",
-        hostname: "localhost",
-        user: ENV['USER'],
-        port: 22,
-        ssh_key: '~/.ssh/id_rsa',
         work_base_dir: '~/__cm_work__',
         status: :enabled
       }
@@ -32,50 +28,6 @@ describe Host do
     it "'name' must not be an empty string" do
       @valid_attr.update(name: '')
       expect(Host.new(@valid_attr)).not_to be_valid
-    end
-
-    it "'hostname' must be present" do
-      @valid_attr.delete(:hostname)
-      expect(Host.new(@valid_attr)).not_to be_valid
-    end
-
-    it "'hostname' must conform to a format of hostname" do
-      @valid_attr.update(hostname: 'hostname;')
-      expect(Host.new(@valid_attr)).not_to be_valid
-      @valid_attr.update(hostname: 'xn--bcher-kva.ch.')
-      expect(Host.new(@valid_attr)).to be_valid
-    end
-
-    it "'user' must be present" do
-      @valid_attr.delete(:user)
-      expect(Host.new(@valid_attr)).not_to be_valid
-    end
-
-    it "format of the 'user' must be valid" do
-      @valid_attr.update(user: 'user-XYZ')
-      expect(Host.new(@valid_attr)).to be_valid
-      @valid_attr.update(user: 'user;XYZ')
-      expect(Host.new(@valid_attr)).not_to be_valid
-    end
-
-    it "'user' can include '.'" do
-      @valid_attr.update(user: 'user.XYZ')
-      expect(Host.new(@valid_attr)).to be_valid
-    end
-
-    it "default of 'port' is 22" do
-      @valid_attr.delete(:port)
-      expect(Host.new(@valid_attr).port).to eq(22)
-    end
-
-    it "'port' must be between 1..65535" do
-      @valid_attr.update(port: 'abc')  # => casted to 0
-      expect(Host.new(@valid_attr)).not_to be_valid
-    end
-
-    it "default of 'ssh_key' is '~/.ssh/id_rsa'" do
-      @valid_attr.delete(:ssh_key)
-      expect(Host.new(@valid_attr).ssh_key).to eq('~/.ssh/id_rsa')
     end
 
     it "default of 'work_base_dir' is '~'" do
@@ -213,20 +165,9 @@ describe Host do
       expect(@host.connected?).to be_truthy
     end
 
-    it "returns false when hostname is invalid" do
-      @host.hostname = "INVALID_HOSTNAME"
+    it "returns false when name is invalid" do
+      @host.name = "INVALID_NAME"
       expect(@host.connected?).to be_falsey
-    end
-
-    it "returns false when user name is not correct" do
-      @host.user = "NOT_EXISTING_USER"
-      expect(@host.connected?).to be_falsey
-    end
-
-    it "exception is stored into connection_error variable" do
-      @host.hostname = "INVALID_HOSTNAME"
-      @host.connected?
-      expect(@host.connection_error).to be_a(SocketError)
     end
   end
 
@@ -410,7 +351,7 @@ describe Host do
       allow_any_instance_of(Host).to receive(:get_host_parameters) do
         []
       end
-      expect(Host.create!(name: 'h1', hostname: 'localhost', user: 'foo').position).to eq 2
+      expect(Host.create!(name: 'h1').position).to eq 2
       expect(Host.all.map(&:position)).to match_array([0,1,2])
     end
   end


### PR DESCRIPTION
SSH configを見に行くように仕様変更。
Hostクラスから以下のフィールドを削除。これらの情報は~/.ssh/configファイルを参照するようにする。

- hostname
- user
- port
- ssh_key

Hostのnameの箇所で、`~/.ssh/config`のHostフィールドに入る名前を指定する。
Net::SSH gemが自動でconfigファイルを読んでくれるので、追加で実装をする必要はない。

configファイルを読むようにしたことにより`ProxyCommand`などの機能も使える。多段のSSHが必要なマシンへの対応が簡単に行えるようになる。