### PR TITLE
removed tests which are incompatible with mongodb3.6

### DIFF
--- a/spec/lib/job_script_util_spec.rb
+++ b/spec/lib/job_script_util_spec.rb
@@ -329,25 +329,6 @@ shared_examples_for JobScriptUtil do
       end
     end
 
-    context "when _output.json contains a dotted field" do
-
-      it "update the status to failed and set error_messages" do
-        File.open(@submittable.dir.join("_output.json"), "w") do |io|
-          io.puts '{"a.b": 1.0}'
-        end
-
-        expect {
-          JobScriptUtil.update_run(@submittable)
-        }.not_to raise_error
-
-        @submittable.reload
-        expect(@submittable.status).to eq :failed
-        expect(@submittable.error_messages).not_to be_empty
-        expect(@submittable.result).to be_nil
-        # error messages: The dotted field 'a.b' in 'result.a.b' is not valid for storage.
-      end
-    end
-
     it "parse elapsed times" do
 
       time_str=<<EOS


### PR DESCRIPTION
MongoDB3.6で失敗するテストケースを削除。
フィールド名に対するMongoDBの仕様が3.6で変更になったことが原因。本体のコードでは特に対策を取らず、失敗するテストだけ削除する方針とした。
https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names 