### PR TITLE
set config.timezone to system timezone

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,13 @@ module AcmProto
     config.enable_dependency_loading = true
     config.autoload_paths += %W(#{config.root}/lib)
 
+    # get local timezone name
+    jan_offset = Time.now.beginning_of_year.utc_offset
+    jul_offset = Time.now.beginning_of_year.change(month: 7).utc_offset
+    offset = jan_offset < jul_offset ? jan_offset : jul_offset
+    zone = ActiveSupport::TimeZone.all.find {|z| z.utc_offset==offset}.name
+    config.time_zone = zone
+
     # load user config
     config.user_config = {}
     user_config_yml = Rails.root.join("config/user_config.yml")


### PR DESCRIPTION
これまではUTCでの表示だったが、OACISを起動したシステムのタイムゾーンで表示するようにした。

![image](https://user-images.githubusercontent.com/718731/35958358-ba7453b2-0ce3-11e8-82bf-be511335e4e0.png)

システムのタイムゾーンの文字列を得るには `rake time:zones:local` というrakeタスクを使うが、そこでの実装を参考にした。

https://github.com/rails/rails/blob/v5.1.4/railties/lib/rails/tasks/misc.rake#L40

`Time`クラスはシステムのタイムゾーンを取得し、そこから対象となる`ActiveSupport::TimeZone`のインスタンスを取得した。
