### PR TITLE
Sim param order 順番入れ替えアイコン表示

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -45,6 +45,21 @@ $(document).ready(function () {
 
 // add/remove/Up/Down nested forms
 
+function find_from_parameter_definition_fields(me, offset) {
+  var p_lst =  $('.parameter-definition-field');
+  var idx, em = null;
+  for ( idx = 0; idx < p_lst.length; idx++ ) {
+    if ( p_lst[idx] === me ) {
+      em = p_lst[idx];
+      break;
+    }
+  }
+  if ( em == null ) return null;
+  var idx2 = idx + offset;
+  if ( idx2 < 0 || idx2 >= p_lst.length ) return null;
+  return p_lst[idx2];
+}
+
 function exchange_form_order(me, em) {
   var my_name = me.children[0].children[0].children[0].value;
   var my_type = me.children[0].children[1].children[0].value;
@@ -65,13 +80,9 @@ $(document).ready( function() {
     var me = $(this).closest('.parameter-definition-field')[0];
     var res = confirm("Are you sure to remove the parameter: " +
                       me.children[0].children[0].children[0].value);
-    if ( ! res ) {
-      event.preventDefault();
-      return;
-    }
+    if ( ! res ) event.preventDefault();
     $(this).closest('.parameter-definition-field').next('input[type=hidden]').val(true);
     $(this).closest('.parameter-definition-field').remove();
-    event.preventDefault();
   });
   $('form').on('click', '.add_fields', function() {
       var time = new Date().getTime();
@@ -83,38 +94,14 @@ $(document).ready( function() {
   });
   $('form').on('click', '.up_fields', function() {
     var me = $(this).closest('.parameter-definition-field')[0];
-    var p_lst =  $('.parameter-definition-field');
-    var idx, em = null;
-    for ( idx = 0; idx < p_lst.length; idx++ ) {
-      if ( p_lst[idx] === me ) {
-        em = p_lst[idx];
-        break;
-      }
-    }
-    if ( em == null || idx < 1 ) {
-      event.preventDefault();
-      return;
-    }
-    em = p_lst[idx - 1];
+    var em = find_from_parameter_definition_fields(me, -1);
+    if ( em == null ) return;
     exchange_form_order(me, em);
-    window.refresh();
   });
   $('form').on('click', '.down_fields', function() {
     var me = $(this).closest('.parameter-definition-field')[0];
-    var p_lst =  $('.parameter-definition-field');
-    var idx, em = null;
-    for ( idx = 0; idx < p_lst.length; idx++ ) {
-      if ( p_lst[idx] === me ) {
-        em = p_lst[idx];
-        break;
-      }
-    }
-    if ( em == null || idx >= p_lst.length - 1 ) {
-      event.preventDefault();
-      return;
-    }
-    em = p_lst[idx + 1];
+    var em = find_from_parameter_definition_fields(me, +1);
+    if ( em == null ) return;
     exchange_form_order(me, em);
-    window.refresh();
   });
 });

--- a/app/views/executable/_parameter_definition_fields.html.haml
+++ b/app/views/executable/_parameter_definition_fields.html.haml
@@ -8,12 +8,12 @@
     .col-md-3
       = f.text_field :default, placeholder: "Default value", class: 'form-control'
     - unless disabled
-      = link_to "Up ", '#', class: "up_fields"
+      = link_to sanitize('<i class="fa fa-arrow-up fa-lg"/>'), '#', class: "up_fields"
     - unless disabled
-      = link_to "Down", '#', class: "down_fields"
+      = link_to sanitize('<i class="fa fa-arrow-down fa-lg"/>'), '#', class: "down_fields"
   .form-group.row.no-margin.no-gutter
     .col-md-8
       = f.text_area :description, placeholder: "Description", rows: 3, class: 'form-control'
     - unless disabled
-      = link_to sanitize('<i class="fa fa-trash-o"/>'), '#', class: "remove_fields"
+      = link_to sanitize('<i class="fa fa-trash-o fa-lg"/>'), '#', class: "remove_fields"
 = f.hidden_field :_destroy


### PR DESCRIPTION
Simulatorのパラメータ順序入替えの’Up'と’Down'をFont Awesomeの矢印アイコンに変更しました。
なぜかアイコン表示にできないとコメントしていた件についての対応です。
ついでなので、アイコンのサイズを一回り大きいもの(fa-lg)に変更しています。
恐れ入りますが、ご確認をお願いいたします。