### PR TITLE
Keep ssh-shell session

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -123,6 +123,7 @@ class Host
     host_groups.all? {|hg| hg.hosts.count > 1 }
   end
 
+  private
   def start_ssh( ssh_logger: nil )
     if @ssh
       yield @ssh
@@ -139,6 +140,7 @@ class Host
     end
   end
 
+  public
   def start_ssh_shell( ssh_logger: nil )
     start_ssh(ssh_logger: ssh_logger) do |ssh|
       if @ssh_shell

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -74,10 +74,10 @@ class Host
 
   def scheduler_status
     ret = nil
-    start_ssh do |ssh|
+    start_ssh_shell do |sh|
       wrapper = SchedulerWrapper.new(self)
       cmd = wrapper.all_status_command
-      ret = SSHUtil.execute(ssh, cmd)
+      ret = SSHUtil.execute(sh, cmd)
     end
     return ret
   end
@@ -139,6 +139,24 @@ class Host
     end
   end
 
+  def start_ssh_shell( ssh_logger: nil )
+    start_ssh(ssh_logger: ssh_logger) do |ssh|
+      if @ssh_shell
+        yield @ssh_shell
+      else
+        ssh_logger.debug("starting SSH shell: " + self.inspect ) if ssh_logger
+        SSHUtil::ShellSession.start(ssh) do |sh|
+          @ssh_shell = sh
+          begin
+            yield sh
+          ensure
+            @ssh_shell = nil
+          end
+        end
+      end
+    end
+  end
+
   private
   def work_base_dir_is_not_editable_when_submitted_runs_exist
     if work_base_dir_is_not_editable? and self.work_base_dir_changed?
@@ -161,19 +179,9 @@ class Host
       ssh_logger.level = :debug
       ssh_logger.error("printing SSH debug messages")
     end
-    start_ssh(ssh_logger: ssh_logger) do |ssh|
-      cmd = "bash -l -c 'echo XSUB_BEGIN && xsub -t'"
-      ## bash -l invokes bash as a login shell.
-      ##   This is necessary to load PATH properly from .bash_profile.
-      ##   Otherwise, users do not have a way to set PATH in bash.
-      ##   .bashrc is not the place to set the PATH
-      ##   because only read by a shell that's both interactive and non-login
-      ## And sourcing bashrc may print some strings into stdout.
-      ##   In order to extract the output of xsub, use 'START_XSUB' as a separator.
-      ##   Lines below 'START_XSUB' is the json output written by 'xsub -t'.
-      ret = SSHUtil.execute(ssh, cmd).lines.to_a
-      begin_idx = ret.index {|line| line =~ /^XSUB_BEGIN$/}
-      xsub_out = ret[(begin_idx+1)..-1].join
+    start_ssh_shell(ssh_logger: ssh_logger) do |sh|
+      cmd = "xsub -t"
+      xsub_out = SSHUtil.execute(sh, cmd)
       self.host_parameter_definitions = JSON.load(xsub_out)["parameters"].reject do |key,val|
         key == "mpi_procs" or key == "omp_threads"
       end.map do |key,val|

--- a/app/workers/job_observer.rb
+++ b/app/workers/job_observer.rb
@@ -11,7 +11,10 @@ class JobObserver
       next if DateTime.now.to_i - @last_performed_at[host.id].to_i < host.polling_interval
       begin
         logger.debug "observing host #{host.name}"
-        observe_host(host, logger)
+        bm = Benchmark.measure {
+          observe_host(host, logger)
+        }
+        logger.info "observing #{host.name} finished in #{sprintf('%.1f', bm.real)}" if bm.real > 1.0
       rescue => ex
         logger.error("Error in JobObserver: #{ex.inspect}")
       end

--- a/app/workers/job_observer.rb
+++ b/app/workers/job_observer.rb
@@ -26,7 +26,7 @@ class JobObserver
   def self.observe_host(host, logger)
     # host.check_submitted_job_status(logger)
     return if host.submitted_runs.count == 0 and host.submitted_analyses.count == 0
-    host.start_ssh do |ssh|
+    host.start_ssh_shell do |sh|
       logger.debug "making SSH connection to #{host.name}"
       handler = RemoteJobHandler.new(host)
       # check if job is finished

--- a/app/workers/job_observer.rb
+++ b/app/workers/job_observer.rb
@@ -14,7 +14,7 @@ class JobObserver
         bm = Benchmark.measure {
           observe_host(host, logger)
         }
-        logger.info "observing #{host.name} finished in #{sprintf('%.1f', bm.real)}" if bm.real > 1.0
+        logger.info "observation of #{host.name} finished in #{sprintf('%.1f', bm.real)}" if bm.real > 1.0
       rescue => ex
         logger.error("Error in JobObserver: #{ex.inspect}")
       end

--- a/app/workers/job_submitter.rb
+++ b/app/workers/job_submitter.rb
@@ -52,8 +52,8 @@ class JobSubmitter
 
   private
   def self.submit(submittables, host, logger)
-    # call start_ssh in order to avoid establishing SSH connection for each run
-    host.start_ssh do |ssh|
+    # call start_ssh_shell in order to avoid establishing SSH connection for each run
+    host.start_ssh_shell do |sh|
       handler = RemoteJobHandler.new(host)
       submittables.each do |job|
         break if $term_received

--- a/app/workers/job_submitter.rb
+++ b/app/workers/job_submitter.rb
@@ -17,7 +17,10 @@ class JobSubmitter
           if analyses.present?
             logger.info("submitting analyses to #{host.name}: #{analyses.map do |r| r.id.to_s end.inspect}")
             num -= analyses.length  # [warning] analyses.length ignore 'limit', so 'num' can be negative.
-            submit(analyses, host, logger)
+            bm = Benchmark.measure {
+              submit(analyses, host, logger)
+            }
+            logger.info("submission of analyses (host:#{host.name}, pri:#{priority}) finished in #{sprintf('%.1f', bm.real)}")
           else
             logger.debug("no submittable analyses of priority #{priority} found for #{host.name}")
           end
@@ -28,7 +31,10 @@ class JobSubmitter
           if runs.present?
             logger.info("submitting runs to #{host.name}: #{runs.map do |r| r.id.to_s end.inspect}")
             num -= runs.length  # [warning] runs.length ignore 'limit', so 'num' can be negative.
-            submit(runs, host, logger)
+            bm = Benchmark.measure {
+              submit(runs, host, logger)
+            }
+            logger.info("submission of runs (host:#{host.name}, pri:#{priority}) finished in #{sprintf('%.1f', bm.real)}")
           else
             logger.debug("no submittable runs of priority #{priority} found for #{host.name}")
           end
@@ -56,7 +62,7 @@ class JobSubmitter
           bm = Benchmark.measure {
             handler.submit_remote_job(job)
           }
-          logger.info("submission of #{job.id} finished in #{bm.real}")
+          logger.info("submission of #{job.id} finished in #{sprintf('%.1f', bm.real)}")
         rescue => ex
           logger.error ex.inspect
           logger.error ex.backtrace

--- a/app/workers/job_submitter.rb
+++ b/app/workers/job_submitter.rb
@@ -64,7 +64,7 @@ class JobSubmitter
         begin
           logger.debug("submitting #{job.id} to #{host.name}")
           bm = Benchmark.measure {
-            handler.submit_remote_job(job, logger)
+            handler.submit_remote_job(job)
           }
           logger.info("submission of #{job.id} finished in #{sprintf('%.1f', bm.real)}")
         rescue => ex

--- a/lib/scheduler_wrapper.rb
+++ b/lib/scheduler_wrapper.rb
@@ -9,27 +9,24 @@ class SchedulerWrapper
     work_dir = @work_base_dir.join(run_id)
     scheduler_log_dir = @work_base_dir.join(run_id+"_log")
     escaped = Shellwords.escape(job_parameters.to_json)
-    # escaped = job_parameters.to_json.gsub("'","'\\\\''")
-    "bash -l -c 'echo XSUB_BEGIN && xsub #{script} -d #{work_dir} -l #{scheduler_log_dir} -p #{escaped}'"
+    "xsub #{script} -d #{work_dir} -l #{scheduler_log_dir} -p #{escaped}"
   end
 
   def parse_jobid_from_submit_command(output)
-    xsub_out = extract_xsub_output(output)
-    JSON.load(xsub_out)["job_id"]
+    JSON.load(output)["job_id"]
   end
 
   def all_status_command
-    "bash -l -c 'xstat'"
+    "xstat"
   end
 
   def status_command(job_id)
-    "bash -l -c 'echo XSUB_BEGIN && xstat #{job_id} 2> /dev/null'"
+    "xstat #{job_id}"
   end
 
   def parse_remote_status(stdout)
     return :unknown if stdout.empty?
-    xsub_out = extract_xsub_output(stdout)
-    case JSON.load(xsub_out)["status"]
+    case JSON.load(stdout)["status"]
     when "queued"
       :submitted
     when "running"
@@ -42,7 +39,7 @@ class SchedulerWrapper
   end
 
   def cancel_command(job_id)
-    "bash -l -c 'xdel #{job_id}; echo $?'"
+    "xdel #{job_id}"
   end
 
   def scheduler_log_file_paths(run)
@@ -50,12 +47,5 @@ class SchedulerWrapper
     dir = Pathname.new(@work_base_dir)
     paths << dir.join("#{run.id}_log")
     paths
-  end
-
-  private
-  def extract_xsub_output(output)
-    output_lines = output.lines.to_a
-    idx = output_lines.index {|line| line =~ /^XSUB_BEGIN$/ }
-    output_lines[(idx+1)..-1].join
   end
 end

--- a/lib/ssh_util.rb
+++ b/lib/ssh_util.rb
@@ -38,6 +38,7 @@ module SSHUtil
           ch2.on_data do |c,data|
             $stderr.puts "o: #{data}" if debug
             if data =~ PATTERN
+              output[:stdout] += data.chomp.sub(PATTERN,'')
               rc = $1.to_i
               $stderr.puts "rc: #{rc}" if debug
               output[:rc] = rc

--- a/lib/ssh_util.rb
+++ b/lib/ssh_util.rb
@@ -45,13 +45,6 @@ module SSHUtil
     ssh.exec!(command)
   end
 
-  def self.execute_in_background(ssh, command)
-    # NOTE: must be redirected to a file. Otherwise, ssh.exec! does not return immediately
-    # http://stackoverflow.com/questions/29142/getting-ssh-to-execute-a-command-in-the-background-on-target-machine
-    # a semi-colon is necessary at the back of the command
-    ssh.exec!("{ #{command.sub(/;^/,'')}; } > /dev/null 2>&1 < /dev/null &")
-  end
-
   def self.execute2(ssh, command)
     stdout_data = ""
     stderr_data = ""

--- a/lib/ssh_util.rb
+++ b/lib/ssh_util.rb
@@ -73,13 +73,15 @@ module SSHUtil
   end
 
   def self.download_recursive_if_exist(sh, hostname, remote_path, local_path)
-    s = stat(sh, remote_path)
-    if s == :directory
+    if directory?(sh, remote_path)
       download_directory(hostname, remote_path, local_path)
-    elsif s == :file
+      :directory
+    elsif file?(sh, remote_path)
       download_file(hostname, remote_path, local_path)
+      :file
+    else
+      nil
     end
-    s
   end
 
   def self.upload(hostname, local_path, remote_path)
@@ -117,23 +119,18 @@ module SSHUtil
     end
   end
 
-  def self.stat(sh, remote_path)
-    out = execute(sh, "{ test -d #{remote_path} && echo d; } || { test -f #{remote_path} && echo f; }")
-    if out.chomp == 'd'
-      :directory
-    elsif out.chomp == 'f'
-      :file
-    else
-      nil
-    end
-  end
-
-  def self.exist?(sh, remote_path)
-    s = stat(sh, remote_path)
-    s == :directory || s == :file
+  def self.file?(sh, remote_path)
+    _out,_err,rc = execute2(sh, "test -f #{remote_path}")
+    rc == 0
   end
 
   def self.directory?(sh, remote_path)
-    stat(sh, remote_path) == :directory
+    _out,_err,rc = execute2(sh, "test -d #{remote_path}")
+    rc == 0
+  end
+
+  def self.exist?(sh, remote_path)
+    _out,_err,rc = execute2(sh, "test -e #{remote_path}")
+    rc == 0
   end
 end

--- a/spec/lib/scheduler_wrapper_spec.rb
+++ b/spec/lib/scheduler_wrapper_spec.rb
@@ -18,7 +18,7 @@ describe SchedulerWrapper do
     it "returns a command to submit a job from work_dir" do
       work_dir = File.join(@host.work_base_dir, "xxx")
       log_dir = File.join(@host.work_base_dir, "xxx_log")
-      expected = "bash -l -c 'echo XSUB_BEGIN && xsub ~/path/to/job.sh -d #{work_dir} -l #{log_dir} -p \\{\\}'"
+      expected = "xsub ~/path/to/job.sh -d #{work_dir} -l #{log_dir} -p \\{\\}"
       expect(@wrapper.submit_command("~/path/to/job.sh","xxx")).to eq expected
     end
 
@@ -28,7 +28,7 @@ describe SchedulerWrapper do
         work_dir = File.join(@host.work_base_dir, "xxx")
         log_dir = File.join(@host.work_base_dir, "xxx_log")
         expected = <<EOS.chomp
-bash -l -c 'echo XSUB_BEGIN && xsub ~/path/to/job.sh -d #{work_dir} -l #{log_dir} -p \\{\\\"param1\\\":\\\"1\\\",\\\"param2\\\":\\\"2\\\"\\}'
+xsub ~/path/to/job.sh -d #{work_dir} -l #{log_dir} -p \\{\\\"param1\\\":\\\"1\\\",\\\"param2\\\":\\\"2\\\"\\}
 EOS
         expect(@wrapper.submit_command("~/path/to/job.sh","xxx",{param1:"1",param2:"2"})).to eq expected
       end
@@ -38,14 +38,14 @@ EOS
   describe "#all_status_command" do
 
     it "returns a command to show the status of all the jobs in the host" do
-      expect(@wrapper.all_status_command).to match(/bash -l -c 'xstat'/)
+      expect(@wrapper.all_status_command).to eq("xstat")
     end
   end
 
   describe "#status_command" do
 
     it "returns a command to show the status of the host" do
-      expect(@wrapper.status_command("job_id")).to match(/bash -l -c 'echo XSUB_BEGIN && xstat job_id/)
+      expect(@wrapper.status_command("job_id")).to eq("xstat job_id")
     end
   end
 
@@ -53,7 +53,6 @@ EOS
 
     it "parses standard output of the status_command" do
       stdout = <<EOS
-XSUB_BEGIN
 {
   "status": "running",
   "raw_output": [
@@ -70,7 +69,7 @@ EOS
   describe "#cancel_command" do
 
     it "returns command to cancel a job" do
-      expect(@wrapper.cancel_command("job_id")).to eq "bash -l -c 'xdel job_id; echo $?'"
+      expect(@wrapper.cancel_command("job_id")).to eq "xdel job_id"
     end
   end
 end

--- a/spec/lib/ssh_util_spec.rb
+++ b/spec/lib/ssh_util_spec.rb
@@ -207,26 +207,6 @@ describe SSHUtil do
     end
   end
 
-  describe ".stat" do
-
-    it "returns :directory if the remote path is a directory" do
-      remote_path = @temp_dir.join('abc').expand_path
-      FileUtils.mkdir_p(remote_path)
-      expect(SSHUtil.stat(@sh, remote_path)).to eq :directory
-    end
-
-    it "returns :file if the remote path is a file" do
-      remote_path = @temp_dir.join('abc').expand_path
-      FileUtils.touch(remote_path)
-      expect(SSHUtil.stat(@sh, remote_path)).to eq :file
-    end
-
-    it "returns nil if the path does not exist" do
-      remote_path = @temp_dir.join('abc').expand_path
-      expect(SSHUtil.stat(@sh, remote_path)).to be_nil
-    end
-  end
-
   describe ".exist?" do
 
     it "returns true when the remote file exists" do
@@ -244,6 +224,26 @@ describe SSHUtil do
       remote_path = @temp_dir.join('abc').expand_path
       FileUtils.mkdir_p(remote_path)
       expect(SSHUtil.exist?(@sh, remote_path)).to be_truthy
+    end
+  end
+
+  describe ".file?" do
+
+    it "returns true when the remote file exists" do
+      remote_path = @temp_dir.join('abc').expand_path
+      FileUtils.touch(remote_path)
+      expect(SSHUtil.file?(@sh, remote_path)).to be_truthy
+    end
+
+    it "returns false when the remote file does not exist" do
+      remote_path = @temp_dir.join('abc').expand_path
+      expect(SSHUtil.file?(@sh, remote_path)).to be_falsey
+    end
+
+    it "returns false if the path is a directory" do
+      remote_path = @temp_dir.join('abc').expand_path
+      FileUtils.mkdir_p(remote_path)
+      expect(SSHUtil.file?(@sh, remote_path)).to be_falsey
     end
   end
 

--- a/spec/lib/ssh_util_spec.rb
+++ b/spec/lib/ssh_util_spec.rb
@@ -164,30 +164,6 @@ describe SSHUtil do
     end
   end
 
-  describe ".execute_in_background" do
-
-    it "executes command in background and return it immediately" do
-      expect {
-        SSHUtil.execute_in_background(@ssh, 'sleep 3')
-      }.to change { Time.now }.by_at_most(1)
-    end
-
-    it "does not hung up when execute is called after execute_in_background" do
-      expect {
-        SSHUtil.execute_in_background(@ssh, 'sleep 3')
-        SSHUtil.execute(@ssh, 'pwd')
-      }.to change { Time.now }.by_at_most(1)
-    end
-
-    it "handles redirection properly" do
-      remote_path = @temp_dir.join('abc').expand_path
-      SSHUtil.execute_in_background(@ssh, "echo $USER > #{remote_path}")
-      sleep 1
-      expect(File.exist?(remote_path)).to be_truthy
-      expect(File.open(remote_path).read.chomp).to eq ENV['USER']
-    end
-  end
-
   describe ".execute2" do
 
     it "execute command and return outputs and exit_codes" do

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -314,8 +314,7 @@ describe Host do
 
     it "parse output of 'xsub -t' and set it to host_parameter_definitions" do
       hp = {"parameters" => {"foo" => {"default"=>1}, "bar" => {"default"=>"abc"} } }
-      ret_str = "XSUB_BEGIN\n#{hp.to_json}"
-      expect(SSHUtil).to receive(:execute).and_return(ret_str)
+      expect(SSHUtil).to receive(:execute).and_return(hp.to_json)
       @host = FactoryBot.create(:localhost)
       expect(@host.host_parameter_definitions.size).to eq 2
       expect(@host.host_parameter_definitions[0].key).to eq "foo"
@@ -324,8 +323,7 @@ describe Host do
 
     it "ignores 'mpi_procs' and 'omp_threads' parameters when setting host_parameter_definitions" do
       hp = {"parameters" => {"mpi_procs" => {"default"=>1}, "omp_threads" => {"default"=>"1"} } }
-      ret_str = "XSUB_BEGIN\n#{hp.to_json}"
-      expect(SSHUtil).to receive(:execute).and_return(ret_str)
+      expect(SSHUtil).to receive(:execute).and_return(hp.to_json)
       @host = FactoryBot.create(:localhost)
       expect(@host.host_parameter_definitions).to be_empty
     end


### PR DESCRIPTION
workerの処理の中でsubmission, observationの最中にリモートシェルのセッションをキープする。
複数のコマンドを同じシェルの中で実行するようにする。

## 必要になった経緯

pyenvやrbenvの起動が遅いので、各コマンドごとに`bash -l`をしていると、.bash_profileの実行に時間がかかり、全体の処理が遅くなる。

## 対処法

workerの中の各イテレーションごとにbashを起動して、その中でコマンドを実行するようにする。bashの起動回数が減るので高速化する。

## パフォーマンス計測

- 手元のMacProで5本のRunを実行する場合
    - submission 4sec => 2.1sec に改善
    - observation 3.4sec => 1.2sec に改善
- clusterに3本のRunを投げる場合
    - submission 207sec => 111sec に改善
    - observation 122sec => 78secに改善

（そもそもこのcluster環境が少し変で、シェルからxsubを実行するだけでも5secくらい要している。通常はここまで遅くないはずだが、いずれにしろ効果は出ている。）

## TODOs

- ~~Travis環境でテストが動かなくなるので要調査。~~ → 解決