### PR TITLE
Ruby26 support

### DIFF
--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -70,7 +70,7 @@ class Analysis
   # returns an array of
   #   [ absolute input path, destination relative path ]
   def input_files
-    pattern = analyzer.files_to_copy.chomp.gsub(/(\r\n|\r|\n)/, "\0")
+    pattern = analyzer.files_to_copy.chomp.split(/(\r\n|\r|\n)/)
     case analyzer.type
     when :on_run
       run = self.analyzable

--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -56,6 +56,7 @@ In the docker images, step 1 of the tutorial in the next page has already been s
 - Ruby 2.5.1 or later ([https://www.ruby-lang.org/](https://www.ruby-lang.org/))
 - MongoDB 3.6 or later ([http://www.mongodb.org/](http://www.mongodb.org/))
 - bundler ([http://bundler.io/](http://bundler.io/))
+    - You may skip the installation for Ruby2.6.0 or later as it is built into Ruby as a standard library.
 - redis ([https://redis.io/](https://redis.io/))
 
 We recommend rbenv or rvm to install proper version of Ruby.
@@ -88,7 +89,7 @@ Here we show the instructions on how to setup prerequisites using homebrew.
     - `brew info mongo` will display the command to launch mongodb daemon.
     - Once you hit the command above, mongodb will be automatically launched at login.
     - Run `mongo` and find a terminal to control MongoDB is launched. Type `exit` to stop the terminal.
-- installing bundler
+- installing bundler (You can skip this process if you are using Ruby 2.6.0 or later. Bundler is built into Ruby as a standard library.)
     ``` sh
     gem install bundler
     which bundle
@@ -139,7 +140,7 @@ Here we show the instruction on how to setup prerequisites using apt-get, using 
     ```
     - The command above will launch mongod process. After this command, mongod process is automatically launched whenever you restart the system.
 
-- installing bundler
+- installing bundler (You can skip this process if you are using Ruby 2.6.0 or later. Bundler is built into Ruby as a standard library.)
     ``` sh
     gem install bundler
     which bundle

--- a/docs/ja/install.md
+++ b/docs/ja/install.md
@@ -57,6 +57,7 @@ Linuxだけでなく、Windows、MacOSにも導入することができます。
 - Ruby 2.5.1以降 ([https://www.ruby-lang.org/](https://www.ruby-lang.org/))
 - MongoDB 3.6以降 ([http://www.mongodb.org/](http://www.mongodb.org/))
 - bundler ([http://bundler.io/](http://bundler.io/))
+    - Ruby2.6.0以降を利用する場合は、標準ライブラリとして添付されるので個別にインストールする必要はない。
 - redis ([https://redis.io/](https://redis.io/))
 
 Rubyのインストールにはrbenvまたはrvmを使って環境を整えるのがよいです。
@@ -87,7 +88,7 @@ Linuxの場合、yumやaptコマンドを使ってインストールできます
     - `brew info mongo`コマンドを実行するとmongodを起動するコマンドが表示される。
     - コマンドを実行すると、以後ログイン時にmongodも自動的に起動する。
     - `mongo` コマンドを実行し端末が表示されれば成功。`exit`で端末から抜ける
-- bundlerのインストール
+- bundlerのインストール（Ruby2.6.0以降ではbundlerは標準ライブラリとして添付されるため、この行程は不要）
     ``` sh
     gem install bundler
     which bundle
@@ -147,7 +148,7 @@ Linuxの場合、yumやaptコマンドを使ってインストールできます
     - `sudo service mongod start`によってmongodを起動することができる。以後、システムの再起動時にmongodも自動的に起動する。
     - `mongo` コマンドを実行し端末が表示されれば成功。`exit`で端末から抜ける
 {% endcomment %}
-- bundlerのインストール
+- bundlerのインストール（Ruby2.6.0以降ではbundlerは標準ライブラリとして添付されるため、この行程は不要）
     ``` sh
     gem install bundler
     which bundle

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -386,7 +386,7 @@ describe Run do
     context "when pattern is given" do
 
       it "returns matched files" do
-        pattern = "result1.txt\0result_dir/result3.txt"
+        pattern = ["result1.txt", "result_dir/result3.txt"]
         paths = @run.result_paths(pattern)
         expected = %w(result1.txt result_dir/result3.txt).map {|f| @run.dir.join(f) }
         expect(paths).to match_array expected


### PR DESCRIPTION
Add a support of Ruby 2.6.

- Since 2.6, bundler is built into Ruby as a standard library. We remarked it in the documentation.
- Since 2.6, a warning is displayed when the argument of `Dir.glob` method contains `\0`. Replace the pattern with an array of patterns.
