### PR TITLE
Rename async

### DIFF
--- a/docs/en/api_python.md
+++ b/docs/en/api_python.md
@@ -19,13 +19,15 @@ Using this library, almost all methods in Ruby is directly translated into Pytho
 In the following, we assume that a Simulator "my_simulator" is registered on OACIS, which has three parameters "p1", "p2", and "p3".
 We assume that you know basics of Python programming language.
 
-To use OACIS, Python 3 is necessary. It also requires the following libraries.
+To use OACIS, **Python3** is necessary. (**As of OACIS v3.2.1, Python 3.7.0 or later is not supported** since fibers library does not work with it.) It also requires the following libraries.
 
 ```ShellSession
 $ pip install msgpack-python==0.4.8 msgpack-rpc-python==0.4.1 fibers
 ```
 
 <span class="label label-success">New in v2.13.0</span>"fibers" library is required since v2.13.0.
+
+
 
 ## Executing script
 

--- a/docs/en/api_python.md
+++ b/docs/en/api_python.md
@@ -19,13 +19,13 @@ Using this library, almost all methods in Ruby is directly translated into Pytho
 In the following, we assume that a Simulator "my_simulator" is registered on OACIS, which has three parameters "p1", "p2", and "p3".
 We assume that you know basics of Python programming language.
 
-To use OACIS, Python 3 is necessary. It also requires "msgpack-rpc-python" and "fibers" library.
-
-<span class="label label-success">New in v2.13.0</span>"fibers" library is required since v2.13.0.
+To use OACIS, Python 3 is necessary. It also requires the following libraries.
 
 ```ShellSession
-$ pip install msgpack-rpc-python fibers
+$ pip install msgpack-python==0.4.8 msgpack-rpc-python==0.4.1 fibers
 ```
+
+<span class="label label-success">New in v2.13.0</span>"fibers" library is required since v2.13.0.
 
 ## Executing script
 

--- a/docs/en/api_watcher.md
+++ b/docs/en/api_watcher.md
@@ -126,6 +126,7 @@ The available methods in `OacisWatcher` class are as follows.
 
 - `#async { ... }`
     - The blocks are evaluated concurrently. In this block, you can call `await` methods.
+    - An alias method `async_do` is also available in v3.3.
 - `OacisWatcher.await_ps( ps )`
     - Block the execution until a ParameterSet "ps" becomes completed.
 - `OacisWatcher.await_all_ps( ps_list )`
@@ -176,19 +177,20 @@ Similar to the Ruby interface, "async/await" methods are available in Python int
 Here is an example.
 
 ```python
-oacis.OacisWatcher()
+import oacis
+w = oacis.OacisWatcher()
 
 def f1():
     # --- (1)
     oacis.OacisWatcher.await_ps( ps1 )
     # --- (2)
-w.async( f1 )
+w.do_async( f1 )
 
 def f2():
     # --- (3)
     oacis.OacisWatcher.await_all_ps( ps_list )
     # --- (4)
-w.async( f2 )
+w.do_async( f2 )
 
 w.loop()
 ```
@@ -198,12 +200,14 @@ Note that you can call `await` methods in a function called by `async` otherwise
 
 The available methods in `OacisWatcher` class are as follows.
 
-- `#async( func )`
+- `#do_async( func )`
     - "func" is evaluated concurrently. In "func", you can call `await` methods.
+    - The method name is changed from `async` to `do_async` in v3.3. Although `async` is still available, it is deprecated and not recommended to use.
 - `OacisWatcher.await_ps( ps )`
     - Block the execution until a ParameterSet "ps" becomes completed.
 - `OacisWatcher.await_all_ps( ps_list )`
     - Block the execution until all the ParameterSets in "ps_list" become completed.
+
 
 ## Definition of "completed" ParameterSet
 

--- a/lib/oacis_watcher.rb
+++ b/lib/oacis_watcher.rb
@@ -36,6 +36,9 @@ class OacisWatcher
     @@current.async(&block)
   end
 
+  alias_method :do_async, :async
+  class << self; alias_method :do_async, :async; end
+
   def self.await_ps(ps)
     f = Fiber.current
     @@current.watch_ps(ps) {

--- a/oacis/README.md
+++ b/oacis/README.md
@@ -1,5 +1,7 @@
 # How to test python module
 
+You need Python 3.6 or later because the test uses `assert_called` method, which is introduced by 3.6.0.
+
 ```
 oacis_python -m unittest oacis_watcher_test.py
 ```

--- a/oacis/oacis_watcher.py
+++ b/oacis/oacis_watcher.py
@@ -18,9 +18,13 @@ class OacisWatcher():
         self._signal_received = False
         self._fibers = []
 
-    def async(self, func):
+    def do_async(self, func):
         f = fibers.Fiber( target=func )
         self._fibers.append(f)
+
+    def async(self, func):
+        self._logger.warning("Warning : 'async' method is deprecated. Use 'do_async' instead.")
+        return self.do_async(func)
 
     @classmethod
     def await_ps(cls, ps):

--- a/oacis/oacis_watcher_test.py
+++ b/oacis/oacis_watcher_test.py
@@ -32,7 +32,7 @@ class TestOacisWatcher(unittest.TestCase):
         sim = oacis.Simulator.send('create!', {'name': 'my_test_simulator', 'command': 'echo', 'parameter_definitions': [pd1,pd2]} )
         #print( repr(sim), sim.parameter_definitions() )
         assert oacis.Simulator.count() == 1
-        host = oacis.Host.send('create!', {"name":"hostA", "hostname":"localhost", "user":os.environ['USER']} )
+        host = oacis.Host.send('create!', {"name":"localhost"} )
         sim.executable_on().push(host)
         return sim
 


### PR DESCRIPTION
rename `alias` method as `do_async` in OacisWatcher.
This is necessary because Python 3.7 makes `async` a reserved word of python. Currently, OACIS does not support Python 3.7 since the current "fibers" library is not compatible with Python 3.7.
However, we are going to support Python 3.7 in a future release, and `async` method is marked as deprecated for that release. In a future release of OACIS supporting python 3.7, `async` method will be completely removed.
