### PR TITLE
worker raises an error when stderr contains an invalid character

### DIFF
--- a/lib/ssh_util.rb
+++ b/lib/ssh_util.rb
@@ -36,7 +36,7 @@ module SSHUtil
           output = {stdout: "", stderr: "", rc: nil}
 
           ch2.on_data do |c,data|
-            logger&.debug "o: #{data.chomp}"
+            logger&.debug "o: #{data.chomp.scrub}"
             if data =~ PATTERN
               output[:stdout] += data.chomp.sub(PATTERN,'')
               rc = $1.to_i
@@ -51,7 +51,7 @@ module SSHUtil
           end
 
           ch2.on_extended_data do |c,type,data|
-            logger&.debug "e: #{data.chomp}"
+            logger&.debug "e: #{data.chomp.scrub}"
             output[:stderr] += data
           end
         end


### PR DESCRIPTION
I came across the following error in the logs of the job_observer.

```
Error in JobObserver: #<Encoding::UndefinedConversionError: "\xE3" from ASCII-8BIT to UTF-8>
```

The backtrace is

```
["/Users/murase/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.1.4/lib/active_support/core_ext/object/json.rb:36:in `encode'", "/Users/murase/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.1.4/lib/active_support/core_ext/object/json.rb:36:in `to_json'", "/Users/murase/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.1.4/lib/active_support/core_ext/object/json.rb:36:in `to_json'", "/Users/murase/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.1.4/lib/active_support/json/encoding.rb:55:in `to_json'", "/Users/murase/.rbenv/versions/2.6.0/lib/ruby/2.6.0/json/common.rb:224:in `generate'", "/Users/murase/.rbenv/versions/2.6.0/lib/ruby/2.6.0/json/common.rb:224:in `generate'", "/Users/murase/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.1.4/lib/active_support/json/encoding.rb:100:in `stringify'", "/Users/murase/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.1.4/lib/active_support/json/encoding.rb:33:in `encode'", "/Users/murase/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.1.4/lib/active_support/json/encoding.rb:20:in `encode'", "/Users/murase/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/actioncable-5.1.4/lib/action_cable/server/broadcasting.rb:45:in `block in broadcast'", "/Users/murase/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/activesupport-5.1.4/lib/active_support/notifications.rb:168:in `instrument'", "/Users/murase/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/actioncable-5.1.4/lib/action_cable/server/broadcasting.rb:44:in `broadcast'", "/Users/murase/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/actioncable-5.1.4/lib/action_cable/server/broadcasting.rb:23:in `broadcast'", "/Users/murase/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/actioncable-5.1.4/lib/action_cable/channel/broadcasting.rb:13:in `broadcast_to'", "/Users/murase/work/oacis/app/workers/logger_for_worker.rb:12:in `send_by_cable'", "/Users/murase/work/oacis/app/workers/logger_for_worker.rb:16:in `debug'"
```

This is caused when SSH stdout/stderr contains an invalid character which cannot be converted to UTF-8. To prevent such an error, I called "String#scrub" before printing logs.
