### PR TITLE
bugfix SSH hang problem

### DIFF
--- a/lib/ssh_util.rb
+++ b/lib/ssh_util.rb
@@ -3,7 +3,7 @@ module SSHUtil
   class ShellSession
 
     TOKEN = "XXXDONEXXX"
-    PATTERN = /^XXXDONEXXX (\d+)$/
+    PATTERN = /XXXDONEXXX (\d+)$/
 
     def initialize(channel)
       @ch = channel


### PR DESCRIPTION
cause of the problem:
Occasionally, standard output of xsub and echo 'TOKEN' comes
simultaneously. In that case, TOKEN is not properly detected.
We fixed this issue by changing the regular expression that matches
TOKEN.