### PR TITLE
Error message when registering host

### DIFF
--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -314,7 +314,7 @@ describe Host do
 
     it "parse output of 'xsub -t' and set it to host_parameter_definitions" do
       hp = {"parameters" => {"foo" => {"default"=>1}, "bar" => {"default"=>"abc"} } }
-      expect(SSHUtil).to receive(:execute).and_return(hp.to_json)
+      expect(SSHUtil).to receive(:execute2).and_return([hp.to_json,"",0])
       @host = FactoryBot.create(:localhost)
       expect(@host.host_parameter_definitions.size).to eq 2
       expect(@host.host_parameter_definitions[0].key).to eq "foo"
@@ -323,13 +323,13 @@ describe Host do
 
     it "ignores 'mpi_procs' and 'omp_threads' parameters when setting host_parameter_definitions" do
       hp = {"parameters" => {"mpi_procs" => {"default"=>1}, "omp_threads" => {"default"=>"1"} } }
-      expect(SSHUtil).to receive(:execute).and_return(hp.to_json)
+      expect(SSHUtil).to receive(:execute2).and_return([hp.to_json,"",0])
       @host = FactoryBot.create(:localhost)
       expect(@host.host_parameter_definitions).to be_empty
     end
 
     it "'xsub' command fails, validation fails" do
-      expect(SSHUtil).to receive(:execute).and_return("{invalid:...")
+      expect(SSHUtil).to receive(:execute2).and_return(["{invalid:...","",0])
       @host = FactoryBot.build(:localhost)
       expect(@host).to_not be_valid
     end


### PR DESCRIPTION
Fix #632 

When registering a host, more user-friendly error messages are shown as follows.

- When the address is not resolved,
![image](https://user-images.githubusercontent.com/718731/60692769-9fc18b80-9f12-11e9-9bcb-24b1d57e695a.png)
- When an authentication failed,
![image](https://user-images.githubusercontent.com/718731/60692803-b5cf4c00-9f12-11e9-99eb-6f52a5000d33.png)
- When the key is not added to ssh-agent,
![image](https://user-images.githubusercontent.com/718731/60692840-de574600-9f12-11e9-8be0-231a28851aff.png)
- When XSUB is not installed,
![image](https://user-images.githubusercontent.com/718731/60692813-c1227780-9f12-11e9-8d6a-0cf605006f9f.png)
- When `XSUB_TYPE` is not set,
![image](https://user-images.githubusercontent.com/718731/60692821-ca134900-9f12-11e9-969e-ef9939f137ab.png)
