### PR TITLE
show error message when "check scheduler status" fails

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -25,10 +25,10 @@ class HostsController < ApplicationController
   # return remote scheduler status
   def _check_scheduler_status
     @host = Host.find(params[:id])
-    if (@host.connected? rescue false)
+    begin
       status = @host.scheduler_status
-    else
-      status = "Failed to establish connection. Check host information."
+    rescue => ex
+      status = "Failed to get status:\n#{ex.message}"
     end
     render plain: status
   end

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -77,7 +77,8 @@ class Host
     start_ssh_shell do |sh|
       wrapper = SchedulerWrapper.new(self)
       cmd = wrapper.all_status_command
-      ret = SSHUtil.execute(sh, cmd)
+      ret,err,rc = SSHUtil.execute2(sh, cmd)
+      raise "`xstat` failed: #{err}" unless rc == 0
     end
     return ret
   end


### PR DESCRIPTION
When "Check scheduler status" button was clicked in the host page, no error message was shown even if `xstat` failed.

Fixed such that a proper error message is displayed when `xstat` fails.
One of such error messages looks like the following.
![image](https://user-images.githubusercontent.com/718731/60693495-7d7d3d00-9f15-11e9-89a5-9445c23e3694.png)
