### PR TITLE
support OpenSSH format by installing ED25519

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,9 @@ source 'https://rubygems.org'
 gem 'rails', '~> 5.2'
 gem "puma"
 gem "mongoid", ' ~> 7.0'
-gem "net-ssh"
+gem "net-ssh", '~> 5.0'
+gem "ed25519", '>= 1.2', '< 2.0'  # support openssh format: https://github.com/net-ssh/net-ssh/issues/478
+gem "bcrypt_pbkdf", '>= 1.0', '< 2.0'
 gem "jbuilder"
 gem "redis", '~> 3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
     arel (9.0.0)
     autoprefixer-rails (9.6.0)
       execjs
+    bcrypt_pbkdf (1.0.1)
     bootsnap (1.4.4)
       msgpack (~> 1.0)
     bootstrap-sass (3.4.1)
@@ -73,6 +74,7 @@ GEM
     database_cleaner (1.7.0)
     diff-lcs (1.3)
     dynatree-rails (1.2.6)
+    ed25519 (1.2.4)
     erubi (1.8.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -247,6 +249,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt_pbkdf (>= 1.0, < 2.0)
   bootsnap
   bootstrap-sass
   bootswatch-rails
@@ -254,6 +257,7 @@ DEPENDENCIES
   daemon-spawn
   database_cleaner
   dynatree-rails
+  ed25519 (>= 1.2, < 2.0)
   factory_bot_rails
   faker
   font-awesome-rails
@@ -264,7 +268,7 @@ DEPENDENCIES
   jquery-ui-rails
   mongoid (~> 7.0)
   msgpack-rpc!
-  net-ssh
+  net-ssh (~> 5.0)
   pry
   pry-byebug
   pry-rails


### PR DESCRIPTION
OpenSSH >= 7.8 uses OpenSSH format for generating key pairs by default. This new format is not supported by net-ssh by default, and it raises an exception when the connection fails.
In order to support it, we had to install the following gems additionally.

- "ed25519", '>= 1.2', '< 2.0' 
- "bcrypt_pbkdf", '>= 1.0', '< 2.0'

See https://github.com/net-ssh/net-ssh/issues/478
