### PR TITLE
to avoid encoding error, scrub before broadcasting

### DIFF
--- a/app/workers/logger_for_worker.rb
+++ b/app/workers/logger_for_worker.rb
@@ -8,7 +8,7 @@ class LoggerForWorker
   end
 
   def send_by_cable(message, severity = :debug)
-    s = @logger.formatter.call(severity, DateTime.now, nil, message)
+    s = @logger.formatter.call(severity, DateTime.now, nil, message.force_encoding('utf-8').scrub)
     WorkerLogChannel.broadcast_to('message', {@type => s})
   end
 


### PR DESCRIPTION
When the remote process has an stdout/stderr containing invalid multi-byte character, it causes the following error.

```
Error in JobObserver: #<Encoding::UndefinedConversionError: "\xAF" from ASCII-8BIT to UTF-8>
```

The stack trace is the following.

```
["/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.3/lib/active_support/core_ext/object/json.rb:38:in `encode'",
"/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.3/lib/active_support/core_ext/object/json.rb:38:in `to_json'",
"/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.3/lib/active_support/core_ext/object/json.rb:38:in `to_json'",
"/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.3/lib/active_support/json/encoding.rb:57:in `to_json'"
, "/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/2.5.0/json/common.rb:224:in `generate'"
, "/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/2.5.0/json/common.rb:224:in `generate'"
, "/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.3/lib/active_support/json/encoding.rb:102:in `stringify'"
, "/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.3/lib/active_support/json/encoding.rb:35:in `encode'"
, "/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.3/lib/active_support/json/encoding.rb:22:in `encode'"
, "/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actioncable-5.2.3/lib/action_cable/server/broadcasting.rb:47:in `block in broadcast'"
, "/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-5.2.3/lib/active_support/notifications.rb:170:in `instrument'"
, "/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actioncable-5.2.3/lib/action_cable/server/broadcasting.rb:46:in `broadcast'"
, "/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actioncable-5.2.3/lib/action_cable/server/broadcasting.rb:25:in `broadcast'"
, "/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/actioncable-5.2.3/lib/action_cable/channel/broadcasting.rb:15:in `broadcast_to'"
, "/Users/kyo/oacis/app/workers/logger_for_worker.rb:12:in `send_by_cable'"
, "/Users/kyo/oacis/app/workers/logger_for_worker.rb:16:in `debug'"
, "/Users/kyo/oacis/lib/ssh_util.rb:54:in `block (3 levels) in start'"
, "/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/net-ssh-5.2.0/lib/net/ssh/connection/channel.rb:597:in `do_extended_data'"
, "/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/net-ssh-5.2.0/lib/net/ssh/connection/session.rb:670:in `channel_extended_data'"
, "/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/net-ssh-5.2.0/lib/net/ssh/connection/session.rb:549:in `dispatch_incoming_packets'"
, "/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/net-ssh-5.2.0/lib/net/ssh/connection/session.rb:249:in `ev_preprocess'"
, "/Users/kyo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/net-ssh-5.2.0/lib/net/ssh/connection/event_loop.rb:101:in `each'"
```

To prevent this error, we `scrub` the log message before broadcasting using action cable.
