### PR TITLE
bugfix: clean up empty directory

### DIFF
--- a/app/services/remote_job_handler.rb
+++ b/app/services/remote_job_handler.rb
@@ -287,7 +287,7 @@ class RemoteJobHandler
   def cleanup_remote_dir(job, sh)
     work_dir = RemoteFilePath.work_dir_path(@host, job)
     if SSHUtil.exist?(sh, work_dir)
-      SSHUtil.download_directory(@host.name, work_dir, job.dir)
+      SSHUtil.download_recursive_if_exist(sh, @host.name, work_dir, job.dir)
       remove_remote_files(job) # try it once even when remove operation is failed.
     end
   end

--- a/lib/ssh_util.rb
+++ b/lib/ssh_util.rb
@@ -75,7 +75,12 @@ module SSHUtil
 
   def self.download_recursive_if_exist(sh, hostname, remote_path, local_path)
     if directory?(sh, remote_path)
-      download_directory(hostname, remote_path, local_path)
+      out = sh.exec!("ls #{remote_path}/")  # checking empty directory
+      if out.chomp.empty?
+        FileUtils.mkdir_p(local_path)
+      else
+        download_directory(hostname, remote_path, local_path)
+      end
       :directory
     elsif file?(sh, remote_path)
       download_file(hostname, remote_path, local_path)

--- a/spec/lib/ssh_util_spec.rb
+++ b/spec/lib/ssh_util_spec.rb
@@ -78,7 +78,7 @@ describe SSHUtil do
       expect(File.exist?(local_path.join('file'))).to be_truthy
     end
 
-    it "creates local directory if specified directory does not exist" do
+    it "creates local directory if local directory does not exist" do
       remote_path = @temp_dir.join('remote').expand_path
       FileUtils.mkdir_p(remote_path)
       remote_path2 = remote_path.join('file').expand_path
@@ -88,6 +88,14 @@ describe SSHUtil do
       SSHUtil.download_recursive_if_exist(@sh, @hostname, remote_path, local_path)
       expect(File.directory?(local_path)).to be_truthy
       expect(File.exist?(local_path.join('file'))).to be_truthy
+    end
+
+    it "does not cause an error if specified directory is an empty directory" do
+      remote_path = @temp_dir.join('empty')
+      FileUtils.mkdir_p(remote_path)
+      local_path = @temp_dir.join('local')
+      SSHUtil.download_recursive_if_exist(@sh, @hostname, remote_path, local_path)
+      expect(File.directory?(local_path)).to be_truthy
     end
 
     it "download file if the remote_path is not directory but file" do


### PR DESCRIPTION
Fixed an error that raises an exception when `downloading_directory` is called against an empty directory.
