### PR TITLE
refactoring: Fix deprecation warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
     msgpack (1.0.3)
     net-ssh (5.2.0)
     nio4r (2.3.1)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     pry (0.12.2)
       coderay (~> 1.1.0)

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,4 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
-AcmProto::Application.load_tasks
+Oacis::Application.load_tasks

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate
 
-  USERS = AcmProto::Application.config.user_config["authentication"]
+  USERS = Oacis::Application.config.user_config["authentication"]
 
   private
   def authenticate

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment',  __FILE__)
-run AcmProto::Application
+run Oacis::Application

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,7 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module AcmProto
+module Oacis
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.0

--- a/config/initializers/access_level.rb
+++ b/config/initializers/access_level.rb
@@ -1,5 +1,5 @@
 if ENV.has_key?('OACIS_ACCESS_LEVEL')
   OACIS_ACCESS_LEVEL = Integer(ENV['OACIS_ACCESS_LEVEL'])
 else
-  OACIS_ACCESS_LEVEL = AcmProto::Application.config.user_config["access_level"] || 2
+  OACIS_ACCESS_LEVEL = Oacis::Application.config.user_config["access_level"] || 2
 end

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,7 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Your secret key for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-AcmProto::Application.config.secret_token = '8f5f9ca4f1497858b6e66215ac8fd7dd8bdf4de0f889236bbe11d4b98d94e06943d8bb8104a53d14b4f466b088e003031395a08255a854fd1ed9983696e130fe'

--- a/lib/tasks/daemon.rake
+++ b/lib/tasks/daemon.rake
@@ -10,14 +10,14 @@ namespace :daemon do
     Rake::Task['db:mongoid:remove_undefined_indexes'].invoke
 
     threads = []
-    level = AcmProto::Application.config.user_config["access_level"] || 2
+    level = Oacis::Application.config.user_config["access_level"] || 2
     threads << Thread.new do
       if is_server_running?
         $stderr.puts "server is already running: #{SERVER_PID}"
       else
         binding_ip = "127.0.0.1"
         binding_ip = "0.0.0.0" if level <= 1
-        binding_ip = AcmProto::Application.config.user_config["binding_ip"] || binding_ip
+        binding_ip = Oacis::Application.config.user_config["binding_ip"] || binding_ip
         cmd = "bundle exec rails s -d -b #{binding_ip}"
         puts cmd
         system(cmd)


### PR DESCRIPTION
- To fix a deprecation warning, remove secret_token.rb.
- Fix app name from `AcmProto` to `Oacis`
- update nokogiri gem