### PR TITLE
fixed: rescue for JobObserver.perform

### DIFF
--- a/app/workers/job_observer.rb
+++ b/app/workers/job_observer.rb
@@ -6,21 +6,21 @@ class JobObserver
       logger.error("Disk space is not enough to include submitted jobs. Aborting.")
       return
     end
-    Host.where(status: :enabled).each do |host|
-      break if $term_received
-      next if DateTime.now.to_i - @last_performed_at[host.id].to_i < host.polling_interval
-      begin
+    begin
+      Host.where(status: :enabled).each do |host|
+        break if $term_received
+        next if DateTime.now.to_i - @last_performed_at[host.id].to_i < host.polling_interval
         logger.debug "observing host #{host.name}"
         bm = Benchmark.measure {
           observe_host(host, logger)
         }
         logger.info "observation of #{host.name} finished in #{sprintf('%.1f', bm.real)}" if bm.real > 1.0
-      rescue => ex
-        logger.error("Error in JobObserver: #{ex.inspect}")
-        logger.error(ex.backtrace)
       end
-      @last_performed_at[host.id] = DateTime.now
+    rescue => ex
+      logger.error("Error in JobObserver: #{ex.inspect}")
+      logger.error(ex.backtrace)
     end
+    @last_performed_at[host.id] = DateTime.now
   end
 
   private

--- a/app/workers/job_observer.rb
+++ b/app/workers/job_observer.rb
@@ -15,12 +15,12 @@ class JobObserver
           observe_host(host, logger)
         }
         logger.info "observation of #{host.name} finished in #{sprintf('%.1f', bm.real)}" if bm.real > 1.0
+        @last_performed_at[host.id] = DateTime.now
       end
     rescue => ex
       logger.error("Error in JobObserver: #{ex.inspect}")
       logger.error(ex.backtrace)
     end
-    @last_performed_at[host.id] = DateTime.now
   end
 
   private


### PR DESCRIPTION
#647 is fixed

## Bug
- JobObserver is dead when an error related to Net::SSH::ConnectionTimeout

## Solution
- Error handing is modified to cover such an error

- before:
    ```ruby
    Host.where(status: :enabled).each do |host|
      begin
        observe_host(host, logger)
      rescue => ex
      end
    end
    ```
- modified:
    ```ruby
    begin
      Host.where(status: :enabled).each do |host|
        observe_host(host, logger)
      end
    rescue => ex
    end
    ```