### PR TITLE
bugfix: error when message is not a String

### DIFF
--- a/app/workers/logger_for_worker.rb
+++ b/app/workers/logger_for_worker.rb
@@ -8,7 +8,7 @@ class LoggerForWorker
   end
 
   def send_by_cable(message, severity = :debug)
-    s = @logger.formatter.call(severity, DateTime.now, nil, message.force_encoding('utf-8').scrub)
+    s = @logger.formatter.call(severity, DateTime.now, nil, message.to_s.force_encoding('utf-8').scrub)
     WorkerLogChannel.broadcast_to('message', {@type => s})
   end
 


### PR DESCRIPTION
fixed #647

When an unhandled exception occurs in `job_observer_worker`, the exception is caught by the outer most loop as the following.

```ruby
class JobObserver
  def self.perform(logger)
    Host.where(status: :enabled).each do |host|
      # ...... some operation ...
      begin
        # ..... some operation ...
      rescue => ex
        logger.error("Error in JobObserver: #{ex.inspect}")
        logger.error(ex.backtrace)          # error handling
      end
    end
```

However, this causes another problem as the argument of `logger.error` is assumed to be a string while `ex.backtrace` returns an array of strings. See `logger_for_worker.rb`.

```ruby
  def send_by_cable(message, severity = :debug)
    s = @logger.formatter.call(severity, DateTime.now, nil, message.force_encoding('utf-8').scrub)
    WorkerLogChannel.broadcast_to('message', {@type => s})
  end
```

When `message` is not a String, `force_encoding` method is missing thus causes an error.

To solve this problem, I changed the code as the following.

```diff
   def send_by_cable(message, severity = :debug)
-    s = @logger.formatter.call(severity, DateTime.now, nil, message.force_encoding('utf-8').scrub)
+    s = @logger.formatter.call(severity, DateTime.now, nil, message.to_s.force_encoding('utf-8').scrub)
     WorkerLogChannel.broadcast_to('message', {@type => s})
   end
```
