### PR TITLE
prevent overwriting locale in JobScript

### DIFF
--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -2,8 +2,8 @@ module JobScriptUtil
 
   TEMPLATE = <<-EOS
 #!/bin/bash
-export LANG=C
-export LC_ALL=C
+export LANG=${LANG:-C}
+export LC_ALL=${LC_ALL:-C}
 
 # VARIABLE DEFINITIONS ------------
 export OACIS_JOB_ID=<%= run_id %>


### PR DESCRIPTION
Stop overwriting `LANG` and `LC_ALL` in a job script. Use the system default value. If these are not set by the system, `C` is used as a fallback.