### PR TITLE
add toggle status button at host/show page

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -45,7 +45,7 @@ class HostsController < ApplicationController
 
     @hosts = Host.asc(:position).all
     @host_groups = HostGroup.asc(:created_at).all
-    redirect_to action: 'index'
+    redirect_back(fallback_location: hosts_path)
   end
 
   # GET /hosts/new

--- a/app/views/hosts/_about.html.haml
+++ b/app/views/hosts/_about.html.haml
@@ -6,7 +6,11 @@
       %td= @host.name
     %tr
       %th Polling
-      %td= raw(host_status_label(@host.status))
+      %td
+        = raw(host_status_label(@host.status))
+        - if OACIS_ACCESS_LEVEL == 2
+          %a{href: _toggle_status_host_path(@host)}
+            %i.fa.fa-power-off.padding-left-half-em{data: {toggle: 'tooltip', 'original-title': 'suspend/restart polling', placement: 'bottom'}}
     %tr
       %th Work base directory
       %td= @host.work_base_dir


### PR DESCRIPTION
fixed #648 

added a button to toggle the host status to `host/show` page.

![image](https://user-images.githubusercontent.com/718731/71401521-771e8100-266d-11ea-9a20-fdcfbc15604e.png)
