### PR TITLE
improve the format of Run CSV

### DIFF
--- a/app/models/simulator.rb
+++ b/app/models/simulator.rb
@@ -371,6 +371,7 @@ class Simulator
     result_attr = plottable_keys(latest_run&.result).map {|key| [:result]+key.split('.') }
     attr = run_attr + ps_attr + result_attr
     header = run_attr + ps_attr_header + result_attr_header
+    header[0] = 'run_id'
 
     aggregated = Run.collection.aggregate([
       { '$match'  => runs.selector },

--- a/app/views/simulators/_parameter_sets_list.html.haml
+++ b/app/views/simulators/_parameter_sets_list.html.haml
@@ -16,7 +16,7 @@
       not filtering
   %div{style: "float:right"}
     %a.btn.btn-default{href: export_runs_simulator_path(@simulator, format: :csv), style: "float: left; margin-right: 3px;"}
-      Export CSV
+      Export Runs in CSV
     - if OACIS_ACCESS_LEVEL >= 1
       %a.btn.btn-primary{href: new_simulator_parameter_set_path(@simulator), style: "float: left; margin-right: 3px;"}
         New Parameter Set

--- a/spec/models/simulator_spec.rb
+++ b/spec/models/simulator_spec.rb
@@ -752,7 +752,7 @@ describe Simulator do
     it "returns runs in CSV format" do
       csv = @sim.runs_csv.lines
       expected_header = <<~EOS
-        _id,status,hostname,real_time,started_at,finished_at,seed,ps_id,p.L,p.T,r.r1,r.r2.r3,r.r2.r4
+        run_id,status,hostname,real_time,started_at,finished_at,seed,ps_id,p.L,p.T,r.r1,r.r2.r3,r.r2.r4
       EOS
       id_format = /\A[0-9a-f]{24}\z/
       status_format = /\Acreated|finished\z/


### PR DESCRIPTION
- Change the button label from `Export CSV` to `Export Runs in CSV`.
  - ![image](https://user-images.githubusercontent.com/718731/71402038-227c0580-266f-11ea-82f5-42364150dc3a.png)
- Change the first column of CSV from `_id` to `run_id`.

Related issue #659