### PR TITLE
added tooltips on data_tables

### DIFF
--- a/app/datatables/parameter_sets_list_datatable.rb
+++ b/app/datatables/parameter_sets_list_datatable.rb
@@ -46,7 +46,7 @@ private
       tmp << @view.check_box_tag("checkbox[ps]", ps.id, false, attr)
       progress = @view.progress_bar(runs_status_counts(ps))
       tmp << @view.raw(progress)
-      tmp << @view.link_to( @view.shortened_id_monospaced(ps.id), @view.parameter_set_path(ps) )
+      tmp << @view.link_to( @view.shortened_id_monospaced(ps.id), @view.parameter_set_path(ps), data: {toggle: 'tooltip', placement: 'bottom', html: true, 'original-title': _tooltip_title(ps)} )
       tmp << @view.raw('<span class="ps_updated_at">'+@view.distance_to_now_in_words(ps.updated_at)+'</span>')
       @param_keys.each do |key|
         if @base_ps
@@ -58,6 +58,10 @@ private
       tmp << "params_list_#{ps.id}"
       tmp
     end
+  end
+
+  def _tooltip_title(ps)
+    "ID: #{ps.id}"
   end
 
   def colorize_param_value(val, compared_val)

--- a/app/datatables/runs_list_datatable.rb
+++ b/app/datatables/runs_list_datatable.rb
@@ -40,7 +40,7 @@ private
       tmp = []
       attr = OACIS_ACCESS_LEVEL==0 ? {align: "center", disabled: "disabled"} : {align: "center"}
       tmp << @view.check_box_tag("checkbox[run]", run.id, false, attr)
-      tmp << @view.link_to( @view.shortened_id_monospaced(run.id), @view.run_path(run) )
+      tmp << @view.link_to( @view.shortened_id_monospaced(run.id), @view.run_path(run), data: {toggle: 'tooltip', placement: 'bottom', html: true, 'original-title': _tooltip_title(run)} )
       tmp << @view.raw( @view.status_label(run.status) )
       tmp << Run::PRIORITY_ORDER[run.priority]
       tmp << @view.raw('<span class="run_elapsed">'+@view.formatted_elapsed_time(run.real_time)+'</span>')
@@ -56,6 +56,13 @@ private
       a << tmp
     end
     a
+  end
+
+  def _tooltip_title(run)
+    <<EOS
+ID  : #{run.id}<br />
+seed: #{run.seed}
+EOS
   end
 
   def runs_lists


### PR DESCRIPTION
Add tooltips to the tables of Runs and ParameterSets in order to display ID and seed.

![image](https://user-images.githubusercontent.com/718731/71427083-39663a80-26f7-11ea-8565-77b4670e0ba3.png)
![image](https://user-images.githubusercontent.com/718731/71427085-3bc89480-26f7-11ea-919f-f72177f2ced2.png)


