### PR TITLE
set Simulator#executable_on by default

### DIFF
--- a/app/controllers/simulators_controller.rb
+++ b/app/controllers/simulators_controller.rb
@@ -44,6 +44,9 @@ class SimulatorsController < ApplicationController
   # GET /simulators/new.json
   def new
     @simulator = Simulator.new
+    if @simulator.executable_on.empty? and h = Host.first
+      @simulator.executable_on.push h
+    end
     respond_to do |format|
       format.html
       format.json { render json: @simulator }

--- a/spec/controllers/simulators_controller_spec.rb
+++ b/spec/controllers/simulators_controller_spec.rb
@@ -96,6 +96,12 @@ describe SimulatorsController do
       expect(assigns(:simulator)).to be_a_new(Simulator)
     end
 
+    it "executable_on is not empty by default" do
+      h = FactoryBot.create(:host)
+      get :new, params: {}
+      expect(assigns(:simulator).executable_on.size).to be 1
+    end
+
     it "@duplicating_simulator is nil" do
       get :new, params: {}
       expect(assigns(:duplicating_simulator)).to be_nil


### PR DESCRIPTION
When creating a Simulator, executable_on field is empty by default. This is not user-friendly as one may keep it as the default value, and might find a trouble when creating a Run.
To address this issue, the default value is changed from an empty list to a list having one Host (the first one).

![image](https://user-images.githubusercontent.com/718731/71517574-020fad80-28f2-11ea-98a5-affa47d7d240.png)
