### PR TITLE
improved error message when identical PS exists

### DIFF
--- a/app/controllers/parameter_sets_controller.rb
+++ b/app/controllers/parameter_sets_controller.rb
@@ -58,7 +58,7 @@ class ParameterSetsController < ApplicationController
         casted[key] = [parameters.has_key?(key) ? ParametersUtil.cast_value(parameters[key], defn.type) : defn.default]
       end
       if casted[key].any? {|x| x == nil }
-        flash[:alert] = "Invalid parameter is given for #{key}"
+        @param_set.errors.add(:base, "Invalid parameter is given for #{key}")
         render action: "new"
         return
       end

--- a/app/controllers/parameter_sets_controller.rb
+++ b/app/controllers/parameter_sets_controller.rb
@@ -51,13 +51,18 @@ class ParameterSetsController < ApplicationController
       key = defn.key
       parameters = params[:v].dup
       if parameters[key] and JSON.is_not_json?(parameters[key]) and parameters[key].include?(',')
-        values = parameters[key].split(',').map {|x|
+        casted[key] = parameters[key].split(',').map {|x|
           ParametersUtil.cast_value(x.strip, defn.type)
         }
-        casted[key] = values.compact.uniq.sort
       else
         casted[key] = [parameters.has_key?(key) ? ParametersUtil.cast_value(parameters[key], defn.type) : defn.default]
       end
+      if casted[key].any? {|x| x == nil }
+        flash[:alert] = "Invalid parameter is given for #{key}"
+        render action: "new"
+        return
+      end
+      casted[key] = casted[key].uniq.sort
     end
     if MAX_CREATION_SIZE < casted.values.map(&:size).inject(1, :*)
       flash[:alert] = "You cannot create more than #{MAX_CREATION_SIZE} ParameterSets at once."
@@ -76,7 +81,7 @@ class ParameterSetsController < ApplicationController
       num_created_ps = simulator.reload.parameter_sets.count - previous_num_ps
       num_created_runs = simulator.runs.count - previous_num_runs
       if num_created_ps == 0 and num_created_runs == 0
-        @param_set.errors.add(:base, "No parameter set is created")
+        @param_set.errors.add(:base, "Identical ParameterSet already exists. No ParameterSet was created.")
         render action: "new"
       else
         flash[:notice] = "#{num_created_ps} ParameterSets and #{num_created_runs} runs were created"

--- a/spec/controllers/parameter_sets_controller_spec.rb
+++ b/spec/controllers/parameter_sets_controller_spec.rb
@@ -145,19 +145,6 @@ describe ParameterSetsController do
           expect(response).to redirect_to(@sim)
         end
 
-        it "non-castable elements are skipped" do
-          @valid_param.update(v: {"L" => "1, 2", "T" => "1.0, abc"})
-          expect {
-            post :create, params: @valid_param
-          }.to change { ParameterSet.count }.by(2)
-        end
-
-        it "redirects to parameter set when single paraemter set is created" do
-          @valid_param.update(v: {"L" => "1", "T" => "1.0, abc"})
-          post :create, params: @valid_param
-          expect(response).to redirect_to(ParameterSet.order_by(id: :asc).last)
-        end
-
         it "does not create duplicated parameter set" do
           @valid_param.update(v: {"L" => "1", "T" => "1.0, 1.0"})
           expect {
@@ -277,6 +264,12 @@ describe ParameterSetsController do
       end
 
       it "re-renders the 'new' template" do
+        post :create, params: @invalid_param
+        expect(response).to render_template("new")
+      end
+
+      it "when non-castable elements are included in CSV" do
+        @invalid_param.update(v: {"L" => "10", "T" => "1.0,abc"})
         post :create, params: @invalid_param
         expect(response).to render_template("new")
       end


### PR DESCRIPTION
When an invalid parameter is given, an error message indicating the invalid field is shown.
When an identical PS is specified, an error message indicating the duplicate of PS is shown.

Error message when identical PS exists.
![image](https://user-images.githubusercontent.com/718731/73423764-62ba5c00-4370-11ea-8077-fe604d664483.png)

Error message when invalid value is given.
![image](https://user-images.githubusercontent.com/718731/73423913-d3617880-4370-11ea-8460-97a59836925d.png)
