### PR TITLE
bugfix: explicitly specify output format of `date`

### DIFF
--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -14,7 +14,7 @@ OACIS_PRINT_VERSION_COMMAND="<%= print_version_command %>"
 
 # PRE-PROCESS ---------------------
 echo "{" > ../${OACIS_JOB_ID}_status.json
-echo "  \\"started_at\\": \\"`date`\\"," >> ../${OACIS_JOB_ID}_status.json
+echo "  \\"started_at\\": \\"`date -R`\\"," >> ../${OACIS_JOB_ID}_status.json
 echo "  \\"hostname\\": \\"`hostname`\\"," >> ../${OACIS_JOB_ID}_status.json
 
 # PRINT SIMULATOR VERSION ---------
@@ -27,7 +27,7 @@ export OMP_NUM_THREADS=${OACIS_OMP_THREADS}
 { time -p { { <%= cmd %>; } 1>> _stdout.txt 2>> _stderr.txt; } } 2>> ../${OACIS_JOB_ID}_time.txt
 RC=$?
 echo "  \\"rc\\": $RC," >> ../${OACIS_JOB_ID}_status.json
-echo "  \\"finished_at\\": \\"`date`\\"" >> ../${OACIS_JOB_ID}_status.json
+echo "  \\"finished_at\\": \\"`date -R`\\"" >> ../${OACIS_JOB_ID}_status.json
 echo "}" >> ../${OACIS_JOB_ID}_status.json
 
 # POST-PROCESS --------------------


### PR DESCRIPTION
`Run#started_at` and `Run#finished_at` are not properly recorded.
This is a regression caused by this commit.
https://github.com/crest-cassia/oacis/commit/60652edc7de8b9d96c201454949681cf33ce93af
With this revision, we stopped overwriting `LANG` to respect the original locale, but this causes changes in the output format of date command.
To resolve this issue, we set `date -R` option to explicitly specify the output format.