### PR TITLE
`CSV.parse( liberal_parsing:true)` is used for parsing parameters

### DIFF
--- a/app/controllers/parameter_sets_controller.rb
+++ b/app/controllers/parameter_sets_controller.rb
@@ -50,8 +50,8 @@ class ParameterSetsController < ApplicationController
     simulator.parameter_definitions.each do |defn|
       key = defn.key
       parameters = params[:v].dup
-      if parameters[key] and JSON.is_not_json?(parameters[key]) and parameters[key].include?(',')
-        casted[key] = parameters[key].split(',').map {|x|
+      if parameters[key].present?
+        casted[key] = CSV.parse(parameters[key], liberal_parsing: true)[0]&.map {|x|
           ParametersUtil.cast_value(x.strip, defn.type)
         }
       else

--- a/lib/parameters_util.rb
+++ b/lib/parameters_util.rb
@@ -50,16 +50,22 @@ module ParametersUtil
     case type
     when "Integer"
       if val.is_a?(String) and val !~ /^[-+]?[0-9]+$/
-        return nil
+        nil
+      else
+        val.to_i
       end
-      return val.to_i
     when "Float"
       if val.is_a?(String) and val !~ /^[-+]?([0-9]+(\.[0-9]*)?|\.[0-9]+)([eE][-+]?[0-9]+)?$/
-        return nil
+        nil
+      else
+        val.to_f
       end
-      return val.to_f
     when "String"
-      return val.to_s
+      if val.empty?
+        nil
+      else
+        val.to_s
+      end
     else
       raise "Unknown type : #{type}"
     end

--- a/lib/parameters_util.rb
+++ b/lib/parameters_util.rb
@@ -61,7 +61,7 @@ module ParametersUtil
         val.to_f
       end
     when "String"
-      if val.empty?
+      if val == ''
         nil
       else
         val.to_s


### PR DESCRIPTION
For parsing parameter values when creating ParameterSets, use `CSV.parse(x, liberal_parsing: true)` instead of `x.split(',')` in order to properly parse string according to a proper CSV format.

Previously, if parameter type is String and the given parameter `x` is valid as a JSON string, it is regarded as a single string. However, this specification is tricky and prevent users to properly escape comma.

For instance, three parameter sets (`a`,`b`,`aaa,bbb`) are created for the following input.
![image](https://user-images.githubusercontent.com/718731/75086236-437cac00-5575-11ea-8499-5e9cd7802c81.png)
