### PR TITLE
bugfix: `f.text_field` does not display array

### DIFF
--- a/app/views/executable/_parameter_definition_fields.html.haml
+++ b/app/views/executable/_parameter_definition_fields.html.haml
@@ -6,7 +6,8 @@
     .col-md-2
       = f.select :type, ParametersUtil::TYPES, {}, disabled: disabled, class: 'form-control'
     .col-md-3
-      = f.text_field :default, placeholder: "Default value", class: 'form-control', data: tooltip_data(:simulator, :default_parameter)
+      = f.text_field :default, value: f.object.default.to_s, placeholder: "Default value", class: 'form-control', data: tooltip_data(:simulator, :default_parameter)
+      / we must explicitly set the value when f.object.default is an array
     - unless disabled
       = link_to sanitize('<i class="fa fa-arrow-up fa-lg"/>'), '#', class: "up_fields"
     - unless disabled

--- a/app/views/executable/_parameter_definition_fields.html.haml
+++ b/app/views/executable/_parameter_definition_fields.html.haml
@@ -6,8 +6,11 @@
     .col-md-2
       = f.select :type, ParametersUtil::TYPES, {}, disabled: disabled, class: 'form-control'
     .col-md-3
-      = f.text_field :default, value: f.object.default.to_s, placeholder: "Default value", class: 'form-control', data: tooltip_data(:simulator, :default_parameter)
-      / we must explicitly set the value when f.object.default is an array
+      - if f.object.type == "Object"
+        = f.text_field :default, value: f.object.default.to_json, placeholder: "Default value", class: 'form-control', data: tooltip_data(:simulator, :default_parameter)
+        / we must explicitly set the value when f.object.default is an array
+      - else
+        = f.text_field :default, placeholder: "Default value", class: 'form-control', data: tooltip_data(:simulator, :default_parameter)
     - unless disabled
       = link_to sanitize('<i class="fa fa-arrow-up fa-lg"/>'), '#', class: "up_fields"
     - unless disabled


### PR DESCRIPTION
fixed #696 Thanks @noda50 

When the default value of an object parameter is an array (such as `[1,2,3]`), the default value is not properly displayed in the form.
This is because `text_field` method changes its behavior when the object is an array. We explicitly call `to_json` and set it to the value of the form to avoid this issue.
https://apidock.com/rails/ActionView/Helpers/FormHelper/text_field

![image](https://user-images.githubusercontent.com/718731/77274072-662aed80-6cf8-11ea-9858-111c6e5fefe4.png)
