### PR TITLE
fallback error when invalid json value is included

### DIFF
--- a/app/views/shared/_results.html.haml
+++ b/app/views/shared/_results.html.haml
@@ -10,7 +10,11 @@
           %th= h(key)
           %td
             - if val.is_a?(Hash) or val.is_a?(Array)
-              %pre= h(JSON.pretty_generate(val))
+              - begin
+                - j = JSON.pretty_generate(val)
+              - rescue JSON::GeneratorError
+                - j = val.to_json
+              %pre= h(j)
             - else
               = h(val)
 - elsif result.is_a?(Array)


### PR DESCRIPTION
When result contains an invalid JSON value such as Infinity, `JSON.pretty_generate` raises an error.
To fallback the error, we catch JSON::GeneratorError and replace it with `to_json`.