### PR TITLE
fixed format of dates

### DIFF
--- a/app/views/analyses/_attributes.html.haml
+++ b/app/views/analyses/_attributes.html.haml
@@ -62,19 +62,19 @@
       %td= @analysis.analyzer_version
     %tr
       %th created at
-      %td= @analysis.created_at
+      %td= @analysis.created_at.to_time
     %tr
       %th submitted at
-      %td= @analysis.submitted_at
+      %td= @analysis.submitted_at.to_time
     %tr
       %th started at
-      %td= @analysis.started_at
+      %td= @analysis.started_at.to_time
     %tr
       %th finished at
-      %td= @analysis.finished_at
+      %td= @analysis.finished_at.to_time
     %tr
       %th included at
-      %td= @analysis.included_at
+      %td= @analysis.included_at.to_time
     %tr
       %th updated at
-      %td= @analysis.updated_at
+      %td= @analysis.updated_at.to_time

--- a/app/views/runs/_about.html.haml
+++ b/app/views/runs/_about.html.haml
@@ -51,22 +51,22 @@
       %td= @run.simulator_version
     %tr
       %th created at
-      %td= @run.created_at
+      %td= @run.created_at.to_time
     %tr
       %th submitted at
-      %td= @run.submitted_at
+      %td= @run.submitted_at.to_time
     %tr
       %th started at
-      %td= @run.started_at
+      %td= @run.started_at.to_time
     %tr
       %th finished at
-      %td= @run.finished_at
+      %td= @run.finished_at.to_time
     %tr
       %th included at
-      %td= @run.included_at
+      %td= @run.included_at.to_time
     %tr
       %th updated at
-      %td= @run.updated_at
+      %td= @run.updated_at.to_time
 
 %h3 Directory
 %pre= @run.dir


### PR DESCRIPTION
fixed #701 
created_at, updated_at are saved as`TimeWithZone` while the other dates are saved as `DateTime` instances.
Those saved as `DateTime` are recorded at remote hosts using `date` in `_status.json` file. When parsing JSON file, it is converted to `DateTime`.
To fix this issue, we call `to_time` to unify the format when displaying these.

![image](https://user-images.githubusercontent.com/718731/83819934-33dd3980-a706-11ea-9db5-3dee6229e876.png)
