### PR TITLE
Add ParamSetID to runs list in /jobs

### DIFF
--- a/app/assets/javascripts/bootstrap.js
+++ b/app/assets/javascripts/bootstrap.js
@@ -11,7 +11,9 @@ jQuery(function() {
 
 (function(){
   let myDefaultWhitelist = $.fn.tooltip.Constructor.DEFAULTS.whiteList;
-  myDefaultWhitelist.dl = [];
-  myDefaultWhitelist.dt = [];
-  myDefaultWhitelist.dd = [];
+  myDefaultWhitelist.table = [];
+  myDefaultWhitelist.tbody = [];
+  myDefaultWhitelist.tr = [];
+  myDefaultWhitelist.th = [];
+  myDefaultWhitelist.td = [];
 })();

--- a/app/assets/javascripts/bootstrap.js
+++ b/app/assets/javascripts/bootstrap.js
@@ -8,3 +8,10 @@ jQuery(function() {
     trigger: 'hover'
   });
 });
+
+(function(){
+  let myDefaultWhitelist = $.fn.tooltip.Constructor.DEFAULTS.whiteList;
+  myDefaultWhitelist.dl = [];
+  myDefaultWhitelist.dt = [];
+  myDefaultWhitelist.dd = [];
+})();

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -77,6 +77,11 @@ i.padding-left-half-em {
 .navbar-default .navbar-nav > li > a:focus {
   background-color: transparent;
 }
+.navbar-default .navbar-nav > li.dropdown > ul.dropdown-menu {
+  background-color: #ffffff;
+  border: 1px solid #ddd;
+  min-width: 400px;
+}
 .well {
   padding: 14px;
 }

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -152,6 +152,13 @@ pre {
 }
 .tooltip-inner {
   max-width: unset;
+  .table {
+    background-color: unset;
+    margin-bottom: 0;
+    &>tbody>tr>td, &>tbody>tr>th, &>tbody>tr>td {
+      border: 0;
+    }
+  }
 }
 .wide-tooltip .tooltip {width: 280px; line-height: 1.4}
 .wide-tooltip .tooltip dl {margin-top: 3px; margin-bottom: 3px;}

--- a/app/datatables/runs_list_datatable.rb
+++ b/app/datatables/runs_list_datatable.rb
@@ -76,13 +76,15 @@ EOS
 
   def _parameter_set_tooltip_title(parameter_set)
     parameters = parameter_set.v.inject('') do |str, (k, v)|
-      str + "<dt>#{k}:</dt><dd> #{v}</dd>"
+      str + "<tr><th>#{k}:</th><td>#{v}</td></tr>"
     end
     html = <<EOS
-<dl class='dl-horizontal'>
-  <dt>Simulator:</dt><dd>#{parameter_set.simulator.name}</dd>
-  #{parameters}
-</dl>
+<table class='table table-condensed'>
+  <tbody>
+    <tr><th>Simulator</th><td>#{parameter_set.simulator.name}</td></tr>
+#{parameters}
+  </tbody>
+</table>
 EOS
     html
   end

--- a/app/datatables/runs_list_datatable.rb
+++ b/app/datatables/runs_list_datatable.rb
@@ -44,7 +44,8 @@ private
       tmp << @view.link_to( @view.shortened_id_monospaced(run.id), @view.run_path(run), data: {toggle: 'tooltip', placement: 'bottom', html: true, 'original-title': _tooltip_title(run)} )
       tmp << @view.raw( @view.status_label(run.status) )
       tmp << @view.link_to( @view.shortened_id_monospaced(run.parameter_set.id), @view.parameter_set_path(run.parameter_set), data:
-        {toggle: 'tooltip', placement: 'bottom', html: true, 'original-title': _parameter_set_tooltip_title(run.parameter_set)} )
+        {toggle: 'tooltip', placement: 'bottom', html: true,
+         'original-title': _parameter_set_tooltip_title(run.parameter_set)} )
       tmp << Run::PRIORITY_ORDER[run.priority]
       tmp << @view.raw('<span class="run_elapsed">'+@view.formatted_elapsed_time(run.real_time)+'</span>')
       tmp << run.mpi_procs
@@ -68,8 +69,12 @@ seed: #{run.seed}
 EOS
   end
 
-  def _parameter_set_tooltip_title(ps)
-    "ID: #{ps.id}"
+  def _parameter_set_tooltip_title(parameter_set)
+    parameters = parameter_set.v.inject('') do |str, (k, v)|
+      str + "#{k}: #{v}<br />"
+    end
+    "Simulator: #{parameter_set.simulator.name}<br />
+#{parameters}"
   end
 
   def runs_lists

--- a/app/datatables/runs_list_datatable.rb
+++ b/app/datatables/runs_list_datatable.rb
@@ -81,7 +81,7 @@ EOS
     html = <<EOS
 <table class='table table-condensed'>
   <tbody>
-    <tr><th>Simulator</th><td>#{parameter_set.simulator.name}</td></tr>
+    <tr><th>Simulator:</th><td>#{parameter_set.simulator.name}</td></tr>
 #{parameters}
   </tbody>
 </table>

--- a/app/datatables/runs_list_datatable.rb
+++ b/app/datatables/runs_list_datatable.rb
@@ -43,9 +43,14 @@ private
       tmp << @view.check_box_tag("checkbox[run]", run.id, false, attr)
       tmp << @view.link_to( @view.shortened_id_monospaced(run.id), @view.run_path(run), data: {toggle: 'tooltip', placement: 'bottom', html: true, 'original-title': _tooltip_title(run)} )
       tmp << @view.raw( @view.status_label(run.status) )
-      tmp << @view.link_to( @view.shortened_id_monospaced(run.parameter_set.id), @view.parameter_set_path(run.parameter_set), data:
-        {toggle: 'tooltip', placement: 'bottom', html: true,
-         'original-title': _parameter_set_tooltip_title(run.parameter_set)} )
+      tmp << @view.link_to(
+        @view.shortened_id_monospaced(run.parameter_set.id),
+        @view.parameter_set_path(run.parameter_set),
+        {
+          data: {toggle: 'tooltip', placement: 'bottom', html: true,
+                 'original-title': (_parameter_set_tooltip_title(run.parameter_set))
+          }
+        })
       tmp << Run::PRIORITY_ORDER[run.priority]
       tmp << @view.raw('<span class="run_elapsed">'+@view.formatted_elapsed_time(run.real_time)+'</span>')
       tmp << run.mpi_procs
@@ -71,10 +76,15 @@ EOS
 
   def _parameter_set_tooltip_title(parameter_set)
     parameters = parameter_set.v.inject('') do |str, (k, v)|
-      str + "#{k}: #{v}<br />"
+      str + "<dt>#{k}:</dt><dd> #{v}</dd>"
     end
-    "Simulator: #{parameter_set.simulator.name}<br />
-#{parameters}"
+    html = <<EOS
+<dl class='dl-horizontal'>
+  <dt>Simulator:</dt><dd>#{parameter_set.simulator.name}</dd>
+  #{parameters}
+</dl>
+EOS
+    html
   end
 
   def runs_lists

--- a/app/datatables/runs_list_datatable.rb
+++ b/app/datatables/runs_list_datatable.rb
@@ -1,8 +1,7 @@
 class RunsListDatatable
-
   SORT_BY = [nil, "id", "status", "priority", "real_time",
              "mpi_procs", "omp_threads", "simulator_version",
-             "created_at", "updated_at", "submitted_to", "job_id"]
+             "created_at", "updated_at", "submitted_to", "job_id", "parameter_set_id"]
 
   def initialize(runs, view)
     @view = view
@@ -25,7 +24,9 @@ class RunsListDatatable
       col0 = '<th style="min-width: 18px; width: 1%; padding-left: 5px; padding-right: 3px;"><input type="checkbox" id="run_check_all" value="true" /></th>'
     end
     header  = [col0,
-             '<th class="span1">RunID</th>', '<th class="span1">status</th>', '<th class="span1">priority</th>',
+             '<th class="span1">RunID</th>', '<th class="span1">status</th>',
+             '<th class="span1">ParamSetID</th>',
+             '<th class="span1">priority</th>',
              '<th class="span1">elapsed</th>',
              '<th class="span1">MPI</th>', '<th class="span1">OMP</th>', '<th class="span1">version</th>',
              '<th class="span1">created_at</th>', '<th class="span1">updated_at</th>', '<th class="span1">host(group)</th>', '<th class="span1">job_id</th>']
@@ -42,6 +43,8 @@ private
       tmp << @view.check_box_tag("checkbox[run]", run.id, false, attr)
       tmp << @view.link_to( @view.shortened_id_monospaced(run.id), @view.run_path(run), data: {toggle: 'tooltip', placement: 'bottom', html: true, 'original-title': _tooltip_title(run)} )
       tmp << @view.raw( @view.status_label(run.status) )
+      tmp << @view.link_to( @view.shortened_id_monospaced(run.parameter_set.id), @view.parameter_set_path(run.parameter_set), data:
+        {toggle: 'tooltip', placement: 'bottom', html: true, 'original-title': _parameter_set_tooltip_title(run.parameter_set)} )
       tmp << Run::PRIORITY_ORDER[run.priority]
       tmp << @view.raw('<span class="run_elapsed">'+@view.formatted_elapsed_time(run.real_time)+'</span>')
       tmp << run.mpi_procs
@@ -63,6 +66,10 @@ private
 ID  : #{run.id}<br />
 seed: #{run.seed}
 EOS
+  end
+
+  def _parameter_set_tooltip_title(ps)
+    "ID: #{ps.id}"
   end
 
   def runs_lists

--- a/spec/datatables/runs_list_datatable_spec.rb
+++ b/spec/datatables/runs_list_datatable_spec.rb
@@ -20,6 +20,7 @@ describe "RunsListDatatable" do
       allow(@context).to receive(:shortened_id_monospaced).and_return("xxxx..yy")
       allow(@context).to receive(:host_path).and_return("/host/xxx")
       allow(@context).to receive(:shortened_job_id).and_return("123456..")
+      allow(@context).to receive(:parameter_set_path).and_return("/parameter_set/#{@param_set.id}")
       @rld = RunsListDatatable.new(@runs, @context)
       @rld_json = JSON.parse(@rld.to_json)
     end
@@ -56,6 +57,7 @@ describe "RunsListDatatable" do
         allow(@context).to receive(:shortened_id_monospaced).and_return("xxxx..yy")
         allow(@context).to receive(:host_path).and_return("/host/xxx")
         allow(@context).to receive(:shortened_job_id).and_return("123456..")
+        allow(@context).to receive(:parameter_set_path).and_return("/parameter_set/#{@param_set.id}")
         @rld = RunsListDatatable.new(@runs, @context)
         @rld_json = JSON.parse(@rld.to_json)
       end


### PR DESCRIPTION
refs: #714 

既存の `app/datatables/parameter_sets_list_datatable.rb` の内容をベースにParamSetID（jobs.parameter_set_id）を表示するようにした。
-> 2021/01/08: Tooltiopの表示内容をParameterSet IDからSimulator Nameとパラメータリストを表示するように修正

# Screenshots

## before

![image](https://user-images.githubusercontent.com/818249/103111427-372f1700-4690-11eb-9fc8-3ea09e7fb28d.png)

## after

![image](https://user-images.githubusercontent.com/818249/106217862-9e098980-6182-11eb-9394-72e5c9a52406.png)

# 要確認事項

マウスhoverして表示されるtooltipのIDが、table側に表示されているIDと明らかに違うが、これは問題ないか？
#shortened_id の実装上こうなること、既存の `simulators#index` でも同様の仕様でParamSetIDが表示されていることから仕様としては既存のものに揃っているが、ぱっと見バグにも見えてしまうのでやや気になる。
-> これはUUIDを使っている関係で先頭数文字はほぼ全部同じIDになってしまうことによる仕様。現状利用者側からも問題にはなっていないとのことなので、この仕様を踏襲して良い
--> その後、Tooltipの表示内容がSimulator Nameとパラメータリストに変更されたので、この違和感はなくなった
