### PR TITLE
Improve ParameterSet table UI

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -25,6 +25,7 @@
 //= require dataTables/jquery.dataTables
 //= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
 //= require dataTables/extras/dataTables.colVis
+//= require dataTables/extras/dataTables.colReorder
 //= require dynatree/jquery.dynatree
 //= require cable.js
 //= require channels/status.js

--- a/app/assets/javascripts/parameter_set.js
+++ b/app/assets/javascripts/parameter_set.js
@@ -1,4 +1,22 @@
 function create_parameter_sets_list(selector, default_length) {
+  let columns = [];
+  $(selector).find('th').each(function(index, element) {
+    if (index === 0) {
+      columns.push({ data: 'Checkbox' });
+    } else {
+      columns.push({
+        data: $(element).text(),
+        createdCell: function(td, cellData, rowData, row, col) {
+          const span = $(td).children('span')[0];
+          if (span) {
+            const hue = span.className.split('color-')[1];
+            if (hue) { $(td).css('background', "hsl(" + hue + ", 100%, 50%)") }
+          }
+        }
+      })
+    }
+  })
+
   var oPsTable = $(selector).DataTable({
     processing: true,
     serverSide: true,
@@ -12,18 +30,31 @@ function create_parameter_sets_list(selector, default_length) {
       "orderable": false,
       "targets": [0,1]
     }],
-    dom: 'C<"clear">lrtip',
+    'columns': columns,
+    dom: 'C<"clear"><Rlrtp>t<ip>',
+    "colReorder": {
+      "fixedColumns": 4
+    },
     colVis: {
       exclude: [0],
       restore: "show all",
       buttonText: "show/hide columns"
     },
     bStateSave: true,
-    ajax: $(selector).data('source'),
-      "createdRow": function(row, data, dataIndex) {
-        const lnId = data[data.length-1];
-        $(row).attr('id', lnId);
+    ajax: {
+      url: $(selector).data('source'),
+      data: function (d) {
+        const data = JSON.parse(localStorage.getItem(`DataTables_${$(selector)[0].id}_`+window.location.pathname));
+        d.sort_column = data ? data['order'][0][0] : null;
       }
+    },
+    "createdRow": function(row, data, dataIndex) {
+      const lnId = data['params_list'];
+      $(row).attr('id', lnId);
+    }
+  });
+  oPsTable.on('column-reorder', function (e, settings, details) {
+    oPsTable.ajax.reload();
   });
   const actionUrl = '/parameter_sets/_delete_selected';
   const lengthDiv = $(selector+'_length');

--- a/app/assets/javascripts/parameter_set.js
+++ b/app/assets/javascripts/parameter_set.js
@@ -1,8 +1,11 @@
 function create_parameter_sets_list(selector, default_length) {
+  const default_columns = 4;
   let columns = [];
   $(selector).find('th').each(function(index, element) {
     if (index === 0) {
-      columns.push({ data: 'Checkbox' });
+      columns.push({ data: '-Checkbox' });
+    } else if (index < default_columns) {
+      columns.push({ data: '-' + $(element).text() });
     } else {
       columns.push({
         data: $(element).text(),
@@ -33,7 +36,7 @@ function create_parameter_sets_list(selector, default_length) {
     'columns': columns,
     dom: 'C<"clear"><Rlrtp>t<ip>',
     "colReorder": {
-      "fixedColumns": 4
+      "fixedColumns": default_columns
     },
     colVis: {
       exclude: [0],
@@ -53,7 +56,7 @@ function create_parameter_sets_list(selector, default_length) {
       $(row).attr('id', lnId);
     }
   });
-  oPsTable.on('column-reorder', function (e, settings, details) {
+  oPsTable.on('column-reorder', function(e, settings, details) {
     oPsTable.ajax.reload();
   });
   const actionUrl = '/parameter_sets/_delete_selected';

--- a/app/assets/javascripts/parameter_set.js
+++ b/app/assets/javascripts/parameter_set.js
@@ -10,7 +10,7 @@ function create_parameter_sets_list(selector, default_length) {
           const span = $(td).children('span')[0];
           if (span) {
             const hue = span.className.split('color-')[1];
-            if (hue) { $(td).css('background', "hsl(" + hue + ", 100%, 50%)") }
+            if (hue) { $(td).css('background', "hsla(" + hue + ", 100%, 50%, 0.3)") }
           }
         }
       })

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -10,6 +10,7 @@
  *
  *= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
  *= require dataTables/extras/dataTables.colVis
+ *= require dataTables/extras/dataTables.colReorder
  *= require dynatree/skin
  *= require font-awesome
 */

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -232,3 +232,10 @@ input[type="checkbox"] {
 .alert {
   padding: 10px;
 }
+
+table.dataTable.fixed_thead thead th {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  background-color: #ffffff;
+}

--- a/app/datatables/parameter_sets_list_datatable.rb
+++ b/app/datatables/parameter_sets_list_datatable.rb
@@ -25,9 +25,9 @@ class ParameterSetsListDatatable
       col0 = '<th style="min-width: 18px; width: 1%; padding-left: 5px; padding-right: 3px;"><input type="checkbox" id="ps_check_all" value="true" disabled="disabled" /></th>'
     end
     header = [ col0,
-               '<th class="span1" style="min-width: 150px;">Progress</th>',
-               '<th class="span1" style="min-width: 50px;">ParamSetID</th>',
-               '<th class="span1">Updated_at</th>'
+               "<th class='span1' style='min-width: 150px;'>#{default_columns[1]}</th>",
+               "<th class='span1' style='min-width: 50px;'>#{default_columns[2]}</th>",
+               "<th class='span1'>#{default_columns[3]}</th>"
              ]
     header += simulator.parameter_definitions.map do |pd|
       '<th class="span1">' + ERB::Util.html_escape(pd.key) + '</th>'
@@ -36,20 +36,25 @@ class ParameterSetsListDatatable
   end
 
 private
+  def self.default_columns
+    ["", "Progress", "ParamSetID", "Updated_at"]
+  end
+
   def sort_by
     ["id", "progress", "id", "updated_at"] + @param_keys.map {|key| "v.#{key}"} + ["id"]
   end
 
   def data
     data = []
+    default_columns = ParameterSetsListDatatable.default_columns
     parameter_sets_list.map do |ps|
       tmp = {}
       attr = (OACIS_ACCESS_LEVEL==0) ? {align: "center", disabled: "disabled"} : {align: "center"}
-      tmp.store('Checkbox', @view.check_box_tag("checkbox[ps]", ps.id, false, attr))
+      tmp.store('-Checkbox', @view.check_box_tag("checkbox[ps]", ps.id, false, attr))
       progress = @view.progress_bar(runs_status_counts(ps))
-      tmp.store('Progress', @view.raw(progress))
-      tmp.store('ParamSetID', @view.link_to( @view.shortened_id_monospaced(ps.id), @view.parameter_set_path(ps), data: {toggle: 'tooltip', placement: 'bottom', html: true, 'original-title': _tooltip_title(ps)} ))
-      tmp.store('Updated_at', @view.raw('<span class="ps_updated_at">'+@view.distance_to_now_in_words(ps.updated_at)+'</span>'))
+      tmp.store("-#{default_columns[1]}", @view.raw(progress))
+      tmp.store("-#{default_columns[2]}", @view.link_to( @view.shortened_id_monospaced(ps.id), @view.parameter_set_path(ps), data: {toggle: 'tooltip', placement: 'bottom', html: true, 'original-title': _tooltip_title(ps)} ))
+      tmp.store("-#{default_columns[3]}", @view.raw('<span class="ps_updated_at">'+@view.distance_to_now_in_words(ps.updated_at)+'</span>'))
       @param_keys.each do |key|
         if @base_ps
           tmp.store("#{key}", colorize_param_value(ps.v[key], @base_ps.v[key]))

--- a/app/datatables/parameter_sets_list_datatable.rb
+++ b/app/datatables/parameter_sets_list_datatable.rb
@@ -54,7 +54,7 @@ private
         if @base_ps
           tmp.store("#{key}", colorize_param_value(ps.v[key], @base_ps.v[key]))
         elsif colorized_key?(key)
-          tmp.store("#{key}", @view.raw("<span class=color-#{colorize_cell_by_param_value[key][ps.v[key]]}>" + ERB::Util.html_escape(ps.v[key]) + '</span>'))
+          tmp.store("#{key}", @view.raw("<span class=color-#{colorize_unique_param_values[key][ps.v[key]]}>" + ERB::Util.html_escape(ps.v[key]) + '</span>'))
         else
           tmp.store("#{key}", ERB::Util.html_escape(ps.v[key]))
         end
@@ -90,7 +90,7 @@ private
     end
   end
 
-  def colorize_cell_by_param_value
+  def colorize_unique_param_values
     return @colors if @colors.present?
 
     colors = {}
@@ -101,7 +101,7 @@ private
       colors_by_key = {}
       unique_values_by_key.size.times do |i|
         value = unique_values_by_key[i][0]
-        colors_by_key.store(value, calculate_cell_colors(i, unique_values_by_key.size))
+        colors_by_key.store(value, calculate_hue(i, unique_values_by_key.size))
       end
       colors.store(key, colors_by_key)
     end
@@ -109,7 +109,7 @@ private
     @colors
   end
 
-  def calculate_cell_colors(index, size)
+  def calculate_hue(index, size)
     return 0 if size == 1
 
     angle = HUE_MAX / (size - 1)

--- a/app/views/parameter_sets/_similar_parameter_sets_list.html.haml
+++ b/app/views/parameter_sets/_similar_parameter_sets_list.html.haml
@@ -1,6 +1,6 @@
 %h3 List of Similar Parameter Sets
 
-%table.table.table-condensed.table-striped#similar_params_list{data: {'source' => "#{_similar_parameter_sets_list_parameter_set_path(parameter_set.to_param, format: "json")}"} }
+%table.table.table-condensed.table-striped.fixed_thead#similar_params_list{data: {'source' => "#{_similar_parameter_sets_list_parameter_set_path(parameter_set.to_param, format: "json")}"} }
   %thead
     %tr
       - ParameterSetsListDatatable.header(parameter_set.simulator).each do |th_element|

--- a/app/views/simulators/_parameter_sets_list.html.haml
+++ b/app/views/simulators/_parameter_sets_list.html.haml
@@ -25,7 +25,7 @@
 .create_ps_area{id: "ps_being_created_#{@simulator.id}"}
   = render partial: 'save_ps_task_status', locals: {simulator: @simulator, offset_num_ps: 0, offset_num_runs: 0}
 .clear-element
-%table.table.table-condensed.table-striped#params_list{:'data-source' => "#{_parameter_sets_list_simulator_path(@simulator.to_param, format: "json", q: @filter&.conditions.to_json)}"}
+%table.table.table-condensed.table-striped.fixed_thead#params_list{:'data-source' => "#{_parameter_sets_list_simulator_path(@simulator.to_param, format: "json", q: @filter&.conditions.to_json)}"}
   %thead
     %tr
       - ParameterSetsListDatatable.header(@simulator).each do |th_element|

--- a/spec/controllers/simulators_controller_spec.rb
+++ b/spec/controllers/simulators_controller_spec.rb
@@ -585,7 +585,7 @@ describe SimulatorsController do
       it "show the list of filtered ParameterSets" do
         expect(@parsed_body["data"].size).to eq 5
         @parsed_body["data"].each do |ps|
-          expect(ps[4].to_i).to be >= 5 #ps[4].to_i is qeual to v.L(ps[checkbox, progress, id, updated_at, [keys]])
+          expect(ApplicationController.helpers.strip_tags(ps['L']).to_i).to be >= 5
         end
       end
     end

--- a/spec/datatables/parameter_sets_list_datatable_spec.rb
+++ b/spec/datatables/parameter_sets_list_datatable_spec.rb
@@ -41,7 +41,7 @@ describe "ParameterSetsListDatatable" do
         expect(@psld_json["recordsTotal"]).to eq(30)
         expect(@psld_json["recordsFiltered"]).to eq(30)
         expect(@psld_json["data"].size).to eq(25)
-        expect(@psld_json["data"].first[4].to_i).to eq(ParameterSet.only("v.L").where(:simulator_id => @simulator.to_param).min("v.L"))
+        expect(ApplicationController.helpers.strip_tags(@psld_json["data"].first['L']).to_i).to eq(ParameterSet.only("v.L").where(:simulator_id => @simulator.to_param).min("v.L"))
       end
     end
 
@@ -82,7 +82,7 @@ describe "ParameterSetsListDatatable" do
         expect(@psld_json["recordsTotal"]).to eq(30)
         expect(@psld_json["recordsFiltered"]).to eq(25)
         expect(@psld_json["data"].size).to eq(5)
-        expect(@psld_json["data"].first[4].to_i).to eq(@query.parameter_sets.only("v.L").max("v.L"))#["aaData"].first[4].to_i is qeual to v.L (["aaData"].first[id, updated_at, [keys]])
+        expect(ApplicationController.helpers.strip_tags(@psld_json["data"].first['L']).to_i).to eq(@query.parameter_sets.only("v.L").max("v.L"))
       end
     end
 
@@ -115,8 +115,8 @@ describe "ParameterSetsListDatatable" do
         expect(@psld_json["recordsTotal"]).to eq(30)
         expect(@psld_json["recordsFiltered"]).to eq(30)
         expect(@psld_json["data"].size).to eq(25)
-        expect(@psld_json["data"].first[4].to_i).to eq(ParameterSet.only("v.L").where(:simulator_id => @simulator.to_param).max("v.L"))
-        expect(@psld_json["data"].first[5].to_f).to eq(ParameterSet.only("v.T").where(:simulator_id => @simulator.to_param).where({"v.L"=>14}).min("v.T"))
+        expect(ApplicationController.helpers.strip_tags(@psld_json["data"].first['L']).to_i).to eq(ParameterSet.only("v.L").where(:simulator_id => @simulator.to_param).max("v.L"))
+        expect(ApplicationController.helpers.strip_tags(@psld_json["data"].first['T']).to_f).to eq(ParameterSet.only("v.T").where(:simulator_id => @simulator.to_param).where({"v.L"=>14}).min("v.T"))
       end
     end
   end


### PR DESCRIPTION
refs: https://github.com/crest-cassia/oacis/issues/716

### 対応内容

- [x] パラメータ列を並び替えられるようにする
- [x] スクロールしてもパラメータの名前が表示されるようにする
- [x] 画面上部にも次のページ、前のページに移動するボタンをつける
- [x] 値の大小の順位に応じてセルの色をグラデーションする


![Untitled](https://user-images.githubusercontent.com/49134429/107718061-679e4380-6d18-11eb-922a-9c6f3b35f4fe.gif)
