### PR TITLE
Add finished and unfinished Runs tabs in simulators#:id

### DIFF
--- a/app/controllers/runs_controller.rb
+++ b/app/controllers/runs_controller.rb
@@ -23,8 +23,10 @@ class RunsController < ApplicationController
   end
 
   def _jobs_table
-    stat = params["run_status"]
-    render json: RunsListDatatable.new(Run.in(status: stat), view_context)
+    conditions = {}
+    conditions[:status] = params["run_status"] # required
+    conditions[:simulator_id] = params["simulator_id"] if params["simulator_id"].present?
+    render json: RunsListDatatable.new(Run.in(conditions), view_context)
   end
 
   def show

--- a/app/views/simulators/_finished_runs_list.html.haml
+++ b/app/views/simulators/_finished_runs_list.html.haml
@@ -1,0 +1,13 @@
+%h3 Finished Runs
+%table.table.table-condensed.table-hover.table-striped#finished_runs_list{'data-source': _jobs_table_runs_path(format: 'json', run_status: ['finished','failed'], simulator_id: @simulator.id)}
+  %thead
+    %tr
+      - RunsListDatatable.header.each do |header|
+        = raw(header)
+  %tbody
+
+:javascript
+  $(function() {
+    // finished runs
+    const oFinishedRunsTable = datatables_for_runs_table('#finished_runs_list');
+  });

--- a/app/views/simulators/_finished_runs_list.html.haml
+++ b/app/views/simulators/_finished_runs_list.html.haml
@@ -9,5 +9,5 @@
 :javascript
   $(function() {
     // finished runs
-    const oFinishedRunsTable = datatables_for_runs_table('#finished_runs_list');
+    const oFinishedRunsTable = OACIS.datatables_for_runs_table('#finished_runs_list');
   });

--- a/app/views/simulators/_unfinished_runs_list.html.haml
+++ b/app/views/simulators/_unfinished_runs_list.html.haml
@@ -9,6 +9,6 @@
 :javascript
   $(function() {
     // unfinished runs
-    const oUnfinishedRunsTable = datatables_for_runs_table('#unfinished_runs_list');
+    const oUnfinishedRunsTable = OACIS.datatables_for_runs_table('#unfinished_runs_list');
   });
 

--- a/app/views/simulators/_unfinished_runs_list.html.haml
+++ b/app/views/simulators/_unfinished_runs_list.html.haml
@@ -1,0 +1,14 @@
+%h3 Unfinished Runs
+%table.table.table-condensed.table-hover.table-striped#unfinished_runs_list{'data-source': _jobs_table_runs_path(format: 'json', run_status: ['created','submitted','running'], simulator_id: @simulator.id)}
+  %thead
+    %tr
+      - RunsListDatatable.header.each do |header|
+        = raw(header)
+  %tbody
+
+:javascript
+  $(function() {
+    // unfinished runs
+    const oUnfinishedRunsTable = datatables_for_runs_table('#unfinished_runs_list');
+  });
+

--- a/app/views/simulators/show.html.haml
+++ b/app/views/simulators/show.html.haml
@@ -12,6 +12,10 @@
     %li.active
       %a{"href"=>"#tab-list-parameters", "data-toggle" => "tab"} Parameter Sets
     %li
+      %a{"href"=>"#tab-list-unfinished-runs", "data-toggle" => "tab"} Unfinished Runs
+    %li
+      %a{"href"=>"#tab-list-finished-runs", "data-toggle" => "tab"} Finished Runs
+    %li
       %a{"href"=>"#tab-progress", "data-toggle" => "tab"} Progress
 
   %div.tab-content
@@ -20,5 +24,10 @@
       = render "analyzers_list"
     %div.tab-pane.active#tab-list-parameters
       = render "parameter_sets_list"
+    %div.tab-pane#tab-list-unfinished-runs
+      = render "unfinished_runs_list"
+    %div.tab-pane#tab-list-finished-runs
+      = render "finished_runs_list"
     %div.tab-pane#tab-progress
       = render "progress"
+

--- a/spec/controllers/runs_controller_spec.rb
+++ b/spec/controllers/runs_controller_spec.rb
@@ -41,6 +41,18 @@ describe RunsController do
     end
   end
 
+  describe "GET _jobs_table" do
+    it "returns json record without filtering" do
+      get :_jobs_table, params: {run_status: ['created']}
+      expect(JSON.parse(response.body)['recordsTotal']).to eq(1)
+    end
+
+    it "returns json record with filtering" do
+      get :_jobs_table, params: {run_status: ['created'], simulator_id: 'dummy'}
+      expect(JSON.parse(response.body)['recordsTotal']).to eq(0)
+    end
+  end
+
   describe "POST 'create'" do
 
     before(:each) do


### PR DESCRIPTION
simulators#showページに `Finished Runs` 及び `Unfinished Runs` を追加 refs #717 

* [x] simulators#showにタブを追加
* [x] runs#_jobs_table がsimulator_idを引数に取れるように修正
* [x] テストコードの追加

![image](https://user-images.githubusercontent.com/818249/108444833-b743b880-729e-11eb-86c9-2e5ed27ea080.png)

## 要確認

* 扱い的にAnalysesもUnifished / Finished共に表示するのが良いか確認し、必要なら実装する
    * 2021/02/19の定例MTGにてAnalysesは表示対象としなくて良いことを確認済み