### PR TITLE
use `xstat -m` command when available

### DIFF
--- a/app/workers/job_observer.rb
+++ b/app/workers/job_observer.rb
@@ -64,7 +64,7 @@ class JobObserver
   end
 
   def self.observe_jobs(jobs, host, handler, logger)
-    remote_statuses = handler.remote_status_multiple(jobs, logger) if handler.support_multiple_xstat?
+    remote_statuses = handler.remote_status_multiple(jobs, logger) if jobs.present? and handler.support_multiple_xstat?
     jobs.each do |job|
       break if $term_received
       remote_status = remote_statuses[job.job_id] if remote_statuses

--- a/lib/scheduler_wrapper.rb
+++ b/lib/scheduler_wrapper.rb
@@ -20,8 +20,16 @@ class SchedulerWrapper
     "xstat"
   end
 
+  def status_help_command
+    "xstat --help"
+  end
+
   def status_command(job_id)
     "xstat #{job_id}"
+  end
+
+  def status_multiple_command(job_ids)
+    "xstat -m #{job_ids.join(' ')}"
   end
 
   def parse_remote_status(stdout)
@@ -36,6 +44,25 @@ class SchedulerWrapper
     else
       raise "unknown status"
     end
+  end
+
+  def parse_remote_status_multiple(stdout)
+    parsed = JSON.load(stdout)
+    statuses = {}
+    parsed.each do |key,val|
+      status = case val["status"]
+               when "queued"
+                 :submitted
+               when "running"
+                 :running
+               when "finished"
+                 :includable
+               else
+                 raise "unknown status"
+               end
+      statuses[key] = status
+    end
+    statuses
   end
 
   def cancel_command(job_id)

--- a/spec/lib/scheduler_wrapper_spec.rb
+++ b/spec/lib/scheduler_wrapper_spec.rb
@@ -66,6 +66,37 @@ EOS
     end
   end
 
+  describe "#status_multiple_command" do
+
+    it "returns a command to show the statuses of the host" do
+      expect(@wrapper.status_multiple_command(["job_id0", "job_id1", "job_id2"])).to eq("xstat -m job_id0 job_id1 job_id2")
+    end
+  end
+
+  describe "#parse_remote_status_multiple" do
+
+    it "parses standard output of the status_multiple_command" do
+      stdout = <<-EOS
+        {
+          "123": {
+            "status": "running",
+            "raw_output": [
+              "  PID TTY           TIME CMD",
+              "  123 ??        25:13.39 ./a.out"
+            ]
+          },
+          "234": {
+            "status": "finished",
+            "raw_output": [
+              "  PID TTY           TIME CMD"
+            ]
+          }
+        }
+      EOS
+      expect(@wrapper.parse_remote_status_multiple(stdout)).to eq({"123" => :running, "234" => :includable})
+    end
+  end
+
   describe "#cancel_command" do
 
     it "returns command to cancel a job" do

--- a/spec/services/remote_job_handler_spec.rb
+++ b/spec/services/remote_job_handler_spec.rb
@@ -287,7 +287,7 @@ shared_examples_for RemoteJobHandler do
       out = <<-EOS
         Usage: xstat [options]
       EOS
-      allow(SSHUtil).to receive(:execute).and_return(out)
+      allow(SSHUtil).to receive(:execute2).and_return([out,'',0])
       expect(RemoteJobHandler.new(@host).support_multiple_xstat?).to be_falsey
     end
   end

--- a/spec/workers/job_observer_spec.rb
+++ b/spec/workers/job_observer_spec.rb
@@ -66,18 +66,21 @@ describe JobObserver do
     end
 
     it "do nothing if remote_status is 'submitted'" do
+      allow_any_instance_of(RemoteJobHandler).to receive(:support_multiple_xstat?).and_return(false)
       expect_any_instance_of(RemoteJobHandler).to receive(:remote_status).and_return(:submitted)
       JobObserver.__send__(:observe_host, @host, @logger)
       expect(@run.reload.status).to eq :submitted
     end
 
     it "update status to 'running' when remote_status of Run is 'running'" do
+      allow_any_instance_of(RemoteJobHandler).to receive(:support_multiple_xstat?).and_return(false)
       expect_any_instance_of(RemoteJobHandler).to receive(:remote_status).and_return(:running)
       JobObserver.__send__(:observe_host, @host, @logger)
       expect(@run.reload.status).to eq :running
     end
 
     it "include remote data and update status to 'finished' or 'failed'" do
+      allow_any_instance_of(RemoteJobHandler).to receive(:support_multiple_xstat?).and_return(false)
       expect_any_instance_of(RemoteJobHandler).to receive(:remote_status).and_return(:includable)
       expect(JobIncluder).to receive(:include_remote_job) do |host, run|
         expect(run.id).to eq @run.id
@@ -96,11 +99,13 @@ describe JobObserver do
       end
 
       it "cancels a remote job" do
+        allow_any_instance_of(RemoteJobHandler).to receive(:support_multiple_xstat?).and_return(false)
         expect_any_instance_of(RemoteJobHandler).to receive(:cancel_remote_job) # do nothing
         JobObserver.__send__(:observe_host, @host, @logger)
       end
 
       it "destroys run" do
+        allow_any_instance_of(RemoteJobHandler).to receive(:support_multiple_xstat?).and_return(false)
         allow_any_instance_of(RemoteJobHandler).to receive(:remote_status) { :includable }
         expect {
           JobObserver.__send__(:observe_host, @host, @logger)
@@ -111,6 +116,7 @@ describe JobObserver do
     context "when ssh connection error occers" do
 
       it "does not change run status into :failed" do
+        allow_any_instance_of(RemoteJobHandler).to receive(:support_multiple_xstat?).and_return(false)
         # return "#<NoMethodError: undefined method `stat' for nil:NilClass>"
         allow_any_instance_of(RemoteJobHandler).to receive(:remote_status) { nil.stat }
         expect {


### PR DESCRIPTION
When xstat accepts `-m` option, use `xstat -m` to reduce the number of command executions. When the command is not available, fall back to the normal `xstat` command.
Ref https://github.com/crest-cassia/xsub/pull/25
