### PR TITLE
use timestamp for a dump file to avoid potential overwriting

### DIFF
--- a/bin/oacis_dump_db
+++ b/bin/oacis_dump_db
@@ -3,7 +3,9 @@
 set -eux
 script_dir=$(cd $(dirname $0); pwd)
 RESULT_DIR="$script_dir/../public/Result_development"
-DUMP_FILE="$RESULT_DIR/db_dump"
+DUMP_FILE="$RESULT_DIR/db_dump_$(date '+%Y%m%d_%H:%M:%S')"  # save to a timestamped file just in case
+DUMP_FILE_LINK="$RESULT_DIR/db_dump"
 mongodump --archive="$DUMP_FILE" --db=oacis_development
+ln -fs "$(basename ${DUMP_FILE})" "${DUMP_FILE_LINK}"
 set +x
-echo "File \"$DUMP_FILE\" was successfully written" >&2
+echo "File \"$DUMP_FILE\" was successfully written"


### PR DESCRIPTION
Before: When running `oacis_dump_db`, the same file name was used for the dump file, which causes overwriting of the output.
After: The name of the dump file has a unique suffix made from the time stamp. Then, a symbolic link to the dump file is created. Since the name of the symbolic link is identical, the same restore command keeps working.