### PR TITLE
display matplotlib script for scatter plot

### DIFF
--- a/app/assets/javascripts/plot/scatter_plot.js
+++ b/app/assets/javascripts/plot/scatter_plot.js
@@ -319,6 +319,8 @@ ScatterPlot.prototype.AddDescription = function() {
       a_element.download = fileName;
       a_element.href = blobURL;
     };
+    const mpl_url = plot.url.replace(/\.json/, '.py');
+    list.append("li").append("a").attr({target: "_blank", href: mpl_url}).text("matplotlib script file");
     list.append("li").append("a").text("download svg").style("cursor", "pointer")
       .on("click", function() {
         const clone_region = document.createElement('div');

--- a/app/controllers/parameter_sets_controller.rb
+++ b/app/controllers/parameter_sets_controller.rb
@@ -517,6 +517,10 @@ class ParameterSetsController < ApplicationController
           data: data
         }
       }
+      format.py {
+        script = MatplotlibUtil.script_for_3d_scatter_plot(data, x_axis_key, y_axis_key, result)
+        render plain: script
+      }
     end
   end
 

--- a/lib/matplotlib_util.rb
+++ b/lib/matplotlib_util.rb
@@ -68,6 +68,37 @@ module MatplotlibUtil
     sio.string
   end
 
+  def self.script_for_3d_scatter_plot(data, xlabel = nil, ylabel = nil, zlabel = nil)
+    sio = StringIO.new
+    sio.puts "# %%"
+    sio.puts "import numpy as np"
+    sio.puts "import matplotlib.pyplot as plt", ""
+
+    sio.puts "fig = plt.figure()"
+    sio.puts "ax = fig.add_subplot(projection='3d')", ""
+
+    sio.puts "ax.set_xlabel(\"#{xlabel}\")" if xlabel
+    sio.puts "ax.set_ylabel(\"#{ylabel}\")" if ylabel
+    sio.puts "ax.set_zlabel(\"#{zlabel}\")" if zlabel
+    sio.puts ""
+
+    x = []
+    y = []
+    z = []
+    data.each do |entry|
+      x.push entry[0][xlabel]
+      y.push entry[0][ylabel]
+      z.push entry[1]
+    end
+    sio.puts "x = [#{x.join(', ')}]"
+    sio.puts "y = [#{y.join(', ')}]"
+    sio.puts "z = [#{z.join(', ')}]"
+    sio.puts "ax.scatter(x, y, z)"
+    sio.puts "plt.show()"
+
+    sio.string
+  end
+
   private
   def self.to_arrays(data)
     x = []

--- a/spec/lib/matplotlib_util_spec.rb
+++ b/spec/lib/matplotlib_util_spec.rb
@@ -134,4 +134,35 @@ plt.show()
       expect(MatplotlibUtil.script_for_multi_line_plot(data_arr, "XXX", "YYY", true, "ZZZ", [5, 4])).to eq expected
     end
   end
+
+  describe ".script_for_3d_scatter_plot" do
+
+    it "returns a script to plot 3d scatter plot" do
+      data_arr = [
+        [{"param_1" => 1.0, "param_2" => 2.0, "other_param" => 3.0}, 3.0, 0.001, "PSID1"],
+        [{"param_1" => 4.0, "param_2" => 5.0, "other_param" => 6.0}, 7.0, 0.001, "PSID2"]
+      ]
+      expected = <<-EOS
+# %%
+import numpy as np
+import matplotlib.pyplot as plt
+
+fig = plt.figure()
+ax = fig.add_subplot(projection='3d')
+
+ax.set_xlabel("param_1")
+ax.set_ylabel("param_2")
+ax.set_zlabel("z_label")
+
+x = [1.0, 4.0]
+y = [2.0, 5.0]
+z = [3.0, 7.0]
+ax.scatter(x, y, z)
+plt.show()
+      EOS
+
+      expect(MatplotlibUtil.script_for_3d_scatter_plot(data_arr, "param_1", "param_2", "z_label")).to eq expected
+    end
+
+  end
 end


### PR DESCRIPTION
added a button to display matplotlib Python script to draw a scatter plot in 3d.

<img width="1052" alt="image" src="https://user-images.githubusercontent.com/718731/168004759-5ad7c421-7ef0-4d3f-86be-6c80c5038922.png">

Example:
<img width="267" alt="image" src="https://user-images.githubusercontent.com/718731/168004902-def04047-8755-4e7a-9205-0930273d98e1.png">
