### PR TITLE
show number of runs in the tooltips of plots

### DIFF
--- a/app/assets/javascripts/plot/line_plot.js
+++ b/app/assets/javascripts/plot/line_plot.js
@@ -128,7 +128,8 @@ LinePlot.prototype.AddPlot = function() {
         return d.map(function(v) {
           return {
             x: v[0], y: v[1], yerror: v[2],
-            series_index: i, series_value: plot.data.series_values[i], psid: v[3]
+            series_index: i, series_value: plot.data.series_values[i], psid: v[3],
+            count: v[4]
           };
         });
       }).enter();
@@ -140,12 +141,13 @@ LinePlot.prototype.AddPlot = function() {
         tooltip.transition()
           .duration(200)
           .style("opacity", 0.8);
-        tooltip.html(
-          plot.data.xlabel + " : " + d.x + "<br/>" +
-          plot.data.ylabel + " : " + Math.round(d.y*1000000)/1000000 +
-          " (" + Math.round(d.yerror*1000000)/1000000 + ")<br/>" +
-          (plot.data.series ? (plot.data.series + " : " + d.series_value + "<br/>") : "") +
-          "ID: " + d.psid);
+        let html = plot.data.xlabel + " : " + d.x + "<br/>" +
+            plot.data.ylabel + " : " + Math.round(d.y*1000000)/1000000 +
+            " (" + Math.round(d.yerror*1000000)/1000000 + ")<br/>" +
+            (plot.data.series ? (plot.data.series + " : " + d.series_value + "<br/>") : "") +
+            "ID: " + d.psid;
+        if (d.count) html += `<br />${d.count} Runs`;
+        tooltip.html(html);
       })
       .on("mousemove", function() {
         tooltip

--- a/app/assets/javascripts/plot/scatter_plot.js
+++ b/app/assets/javascripts/plot/scatter_plot.js
@@ -161,7 +161,8 @@ ScatterPlot.prototype.AddPlot = function() {
     const mapped = plot.data.data.map(function(v) {
       return {
         x: v[0][plot.data.xlabel], y: v[0][plot.data.ylabel],
-        average: v[1], error: v[2], psid: v[3]
+        average: v[1], error: v[2], psid: v[3],
+        count: v[4]
       };
     });
     const point = plot_group.append("g")
@@ -176,12 +177,14 @@ ScatterPlot.prototype.AddPlot = function() {
           tooltip.transition()
             .duration(200)
             .style("opacity", 0.8);
-          tooltip.html(
-            plot.data.xlabel + " : " + d.x + "<br/>" +
-            plot.data.ylabel + " : " + d.y + "<br/>" +
-            "Result : " + Math.round(d.average*1000000)/1000000 +
-            " (" + Math.round(d.error*1000000)/1000000 + ")<br/>" +
-            "ID: " + d.psid);
+          let html =
+              plot.data.xlabel + " : " + d.x + "<br/>" +
+              plot.data.ylabel + " : " + d.y + "<br/>" +
+              "Result : " + Math.round(d.average*1000000)/1000000 +
+              " (" + Math.round(d.error*1000000)/1000000 + ")<br/>" +
+              "ID: " + d.psid;
+          if (d.count) html += `<br/>${d.count} Runs`;
+          tooltip.html(html);
         })
         .on("mousemove", function() {
           tooltip

--- a/app/controllers/parameter_sets_controller.rb
+++ b/app/controllers/parameter_sets_controller.rb
@@ -347,7 +347,7 @@ class ParameterSetsController < ApplicationController
 
     plot_data = collect_result_values(ps_ids, analyzer, result_keys).map do |h|
       ps_id = h["_id"]
-      [ ps_id_to_x[ps_id.to_s], h["average"], h["error"], ps_id.to_s ]
+      [ ps_id_to_x[ps_id.to_s], h["average"], h["error"], ps_id.to_s, h["count"]]
     end
     plot_data.sort_by {|d| d[0]}
   end
@@ -364,7 +364,7 @@ class ParameterSetsController < ApplicationController
 
     plot_data = collect_latest_elapsed_times(ps_ids).map do |h|
       ps_id = h["_id"]
-      [ ps_id_to_x[ps_id.to_s], h[y_axis_key], nil, ps_id.to_s ]
+      [ ps_id_to_x[ps_id.to_s], h[y_axis_key], nil, ps_id.to_s, nil ]
     end
     plot_data.sort_by {|d| d[0]}
   end
@@ -487,7 +487,7 @@ class ParameterSetsController < ApplicationController
 
       data = result_values.map do |h|
         found = parameter_values.find {|pv| pv["_id"] == h["_id"] }
-        [found["v"], h["average"], h["error"], h["_id"].to_s]
+        [found["v"], h["average"], h["error"], h["_id"].to_s, h["count"]]
       end
       result = result_keys.last
     elsif ["cpu_time", "real_time"].include?(params[:result])
@@ -499,12 +499,12 @@ class ParameterSetsController < ApplicationController
       #  {...}, {...}, ... ]
       data = elapsed_times.map do |h|
         found = parameter_values.find {|pv| pv["_id"] == h["_id"] }
-        [found["v"], h[result], nil, h["_id"].to_s]
+        [found["v"], h[result], nil, h["_id"].to_s, nil]
       end
     else
       result = nil
       data = parameter_values.map do |pv|
-        [pv["v"], nil, nil, pv["_id"].to_s]
+        [pv["v"], nil, nil, pv["_id"].to_s, nil]
       end
     end
 

--- a/spec/controllers/parameter_sets_controller_spec.rb
+++ b/spec/controllers/parameter_sets_controller_spec.rb
@@ -523,9 +523,9 @@ describe ParameterSetsController do
         plot_url: parameter_set_url(@ps_array.first) + "?plot_type=line&x_axis=L&y_axis=.ResultKey1&series=&irrelevants=#!tab-plot",
         data: [
           [
-            [1, 99.0, nil, @ps_array[0].id.to_s],
-            [2, 99.0, nil, @ps_array[1].id.to_s],
-            [3, 99.0, nil, @ps_array[2].id.to_s],
+            [1, 99.0, nil, @ps_array[0].id.to_s, 1],
+            [2, 99.0, nil, @ps_array[1].id.to_s, 1],
+            [3, 99.0, nil, @ps_array[2].id.to_s, 1],
           ]
         ]
       }.to_json
@@ -540,9 +540,9 @@ describe ParameterSetsController do
         plot_url: parameter_set_url(@ps_array.first) + "?plot_type=line&x_axis=L&y_axis=cpu_time&series=&irrelevants=#!tab-plot",
         data: [
           [
-            [1, 10.0, nil, @ps_array[0].id.to_s],
-            [2, 10.0, nil, @ps_array[1].id.to_s],
-            [3, 10.0, nil, @ps_array[2].id.to_s],
+            [1, 10.0, nil, @ps_array[0].id.to_s, nil],
+            [2, 10.0, nil, @ps_array[1].id.to_s, nil],
+            [3, 10.0, nil, @ps_array[2].id.to_s, nil],
           ]
         ]
       }.to_json
@@ -559,13 +559,13 @@ describe ParameterSetsController do
           plot_url: parameter_set_url(@ps_array.first) + "?plot_type=line&x_axis=L&y_axis=.ResultKey1&series=T&irrelevants=#!tab-plot",
           data: [
             [
-              [1, 99.0, nil, @ps_array[3].id.to_s],
-              [2, 99.0, nil, @ps_array[4].id.to_s],
+              [1, 99.0, nil, @ps_array[3].id.to_s, 1],
+              [2, 99.0, nil, @ps_array[4].id.to_s, 1],
             ],
             [
-              [1, 99.0, nil, @ps_array[0].id.to_s],
-              [2, 99.0, nil, @ps_array[1].id.to_s],
-              [3, 99.0, nil, @ps_array[2].id.to_s]
+              [1, 99.0, nil, @ps_array[0].id.to_s, 1],
+              [2, 99.0, nil, @ps_array[1].id.to_s, 1],
+              [3, 99.0, nil, @ps_array[2].id.to_s, 1]
             ]
           ]
         }.to_json
@@ -583,14 +583,14 @@ describe ParameterSetsController do
           plot_url: parameter_set_url(@ps_array.first) + "?plot_type=line&x_axis=L&y_axis=.ResultKey1&series=T&irrelevants=P#!tab-plot",
           data: [
             [
-              [1, 99.0, nil, @ps_array[3].id.to_s],
-              [2, 99.0, nil, @ps_array[4].id.to_s],
-              [3, 99.0, nil, @ps_array[5].id.to_s]
+              [1, 99.0, nil, @ps_array[3].id.to_s, 1],
+              [2, 99.0, nil, @ps_array[4].id.to_s, 1],
+              [3, 99.0, nil, @ps_array[5].id.to_s, 1]
             ],
             [
-              [1, 99.0, nil, @ps_array[0].id.to_s],
-              [2, 99.0, nil, @ps_array[1].id.to_s],
-              [3, 99.0, nil, @ps_array[2].id.to_s]
+              [1, 99.0, nil, @ps_array[0].id.to_s, 1],
+              [2, 99.0, nil, @ps_array[1].id.to_s, 1],
+              [3, 99.0, nil, @ps_array[2].id.to_s, 1]
             ]
           ]
         }.to_json
@@ -630,9 +630,9 @@ describe ParameterSetsController do
           plot_url: parameter_set_url(@ps_array.first) + "?plot_type=line&x_axis=L&y_axis=#{@analyzer.name}.ResultKey1&series=&irrelevants=#!tab-plot",
           data: [
             [
-              [1, 999.0, nil, @ps_array[0].id.to_s],
-              [2, 999.0, nil, @ps_array[1].id.to_s],
-              [3, 999.0, nil, @ps_array[2].id.to_s],
+              [1, 999.0, nil, @ps_array[0].id.to_s, 1],
+              [2, 999.0, nil, @ps_array[1].id.to_s, 1],
+              [3, 999.0, nil, @ps_array[2].id.to_s, 1],
             ]
           ]
         }.to_json
@@ -649,13 +649,13 @@ describe ParameterSetsController do
             plot_url: parameter_set_url(@ps_array.first) + "?plot_type=line&x_axis=L&y_axis=#{@analyzer.name}.ResultKey1&series=T&irrelevants=#!tab-plot",
             data: [
               [
-                [1, 999.0, nil, @ps_array[3].id.to_s],
-                [2, 999.0, nil, @ps_array[4].id.to_s],
+                [1, 999.0, nil, @ps_array[3].id.to_s, 1],
+                [2, 999.0, nil, @ps_array[4].id.to_s, 1],
               ],
               [
-                [1, 999.0, nil, @ps_array[0].id.to_s],
-                [2, 999.0, nil, @ps_array[1].id.to_s],
-                [3, 999.0, nil, @ps_array[2].id.to_s]
+                [1, 999.0, nil, @ps_array[0].id.to_s, 1],
+                [2, 999.0, nil, @ps_array[1].id.to_s, 1],
+                [3, 999.0, nil, @ps_array[2].id.to_s, 1]
               ]
             ]
           }.to_json
@@ -673,14 +673,14 @@ describe ParameterSetsController do
             plot_url: parameter_set_url(@ps_array.first) + "?plot_type=line&x_axis=L&y_axis=#{@analyzer.name}.ResultKey1&series=T&irrelevants=P#!tab-plot",
             data: [
               [
-                [1, 999.0, nil, @ps_array[3].id.to_s],
-                [2, 999.0, nil, @ps_array[4].id.to_s],
-                [3, 999.0, nil, @ps_array[5].id.to_s]
+                [1, 999.0, nil, @ps_array[3].id.to_s, 1],
+                [2, 999.0, nil, @ps_array[4].id.to_s, 1],
+                [3, 999.0, nil, @ps_array[5].id.to_s, 1]
               ],
               [
-                [1, 999.0, nil, @ps_array[0].id.to_s],
-                [2, 999.0, nil, @ps_array[1].id.to_s],
-                [3, 999.0, nil, @ps_array[2].id.to_s]
+                [1, 999.0, nil, @ps_array[0].id.to_s, 1],
+                [2, 999.0, nil, @ps_array[1].id.to_s, 1],
+                [3, 999.0, nil, @ps_array[2].id.to_s, 1]
               ]
             ]
           }.to_json
@@ -719,9 +719,9 @@ describe ParameterSetsController do
           plot_url: parameter_set_url(@ps_array.first) + "?plot_type=line&x_axis=L&y_axis=#{@analyzer.name}.ResultKey1&series=&irrelevants=#!tab-plot",
           data: [
             [
-              [1, 9999, nil, @ps_array[0].id.to_s],
-              [2, 9999, nil, @ps_array[1].id.to_s],
-              [3, 9999, nil, @ps_array[2].id.to_s],
+              [1, 9999, nil, @ps_array[0].id.to_s, 1],
+              [2, 9999, nil, @ps_array[1].id.to_s, 1],
+              [3, 9999, nil, @ps_array[2].id.to_s, 1],
             ]
           ]
         }.to_json
@@ -738,13 +738,13 @@ describe ParameterSetsController do
             plot_url: parameter_set_url(@ps_array.first) + "?plot_type=line&x_axis=L&y_axis=#{@analyzer.name}.ResultKey1&series=T&irrelevants=#!tab-plot",
             data: [
               [
-                [1, 9999, nil, @ps_array[3].id.to_s],
-                [2, 9999, nil, @ps_array[4].id.to_s],
+                [1, 9999, nil, @ps_array[3].id.to_s, 1],
+                [2, 9999, nil, @ps_array[4].id.to_s, 1],
               ],
               [
-                [1, 9999, nil, @ps_array[0].id.to_s],
-                [2, 9999, nil, @ps_array[1].id.to_s],
-                [3, 9999, nil, @ps_array[2].id.to_s]
+                [1, 9999, nil, @ps_array[0].id.to_s, 1],
+                [2, 9999, nil, @ps_array[1].id.to_s, 1],
+                [3, 9999, nil, @ps_array[2].id.to_s, 1]
               ]
             ]
           }.to_json
@@ -762,14 +762,14 @@ describe ParameterSetsController do
             plot_url: parameter_set_url(@ps_array.first) + "?plot_type=line&x_axis=L&y_axis=#{@analyzer.name}.ResultKey1&series=T&irrelevants=P#!tab-plot",
             data: [
               [
-                [1, 9999, nil, @ps_array[3].id.to_s],
-                [2, 9999, nil, @ps_array[4].id.to_s],
-                [3, 9999, nil, @ps_array[5].id.to_s]
+                [1, 9999, nil, @ps_array[3].id.to_s, 1],
+                [2, 9999, nil, @ps_array[4].id.to_s, 1],
+                [3, 9999, nil, @ps_array[5].id.to_s, 1]
               ],
               [
-                [1, 9999, nil, @ps_array[0].id.to_s],
-                [2, 9999, nil, @ps_array[1].id.to_s],
-                [3, 9999, nil, @ps_array[2].id.to_s]
+                [1, 9999, nil, @ps_array[0].id.to_s, 1],
+                [2, 9999, nil, @ps_array[1].id.to_s, 1],
+                [3, 9999, nil, @ps_array[2].id.to_s, 1]
               ]
             ]
           }.to_json
@@ -822,11 +822,11 @@ describe ParameterSetsController do
       get :_scatter_plot,
         params: {id: @ps_array.first, x_axis_key: "L", y_axis_key: "T", result: ".ResultKey1", irrelevants: "", format: :json}
       expected_data = [
-        [@ps_array[0].v, 99.0, nil, @ps_array[0].id.to_s],
-        [@ps_array[3].v, 99.0, nil, @ps_array[3].id.to_s],
-        [@ps_array[1].v, 99.0, nil, @ps_array[1].id.to_s],
-        [@ps_array[4].v, 99.0, nil, @ps_array[4].id.to_s],
-        [@ps_array[2].v, 99.0, nil, @ps_array[2].id.to_s]
+        [@ps_array[0].v, 99.0, nil, @ps_array[0].id.to_s, 1],
+        [@ps_array[3].v, 99.0, nil, @ps_array[3].id.to_s, 1],
+        [@ps_array[1].v, 99.0, nil, @ps_array[1].id.to_s, 1],
+        [@ps_array[4].v, 99.0, nil, @ps_array[4].id.to_s, 1],
+        [@ps_array[2].v, 99.0, nil, @ps_array[2].id.to_s, 1]
       ]
 
       loaded = JSON.load(response.body)
@@ -844,10 +844,10 @@ describe ParameterSetsController do
           irrelevants: "", range: {"L" => [1,2]}.to_json,
           format: :json}
       expected_data = [
-        [@ps_array[0].v, 99.0, nil, @ps_array[0].id.to_s],
-        [@ps_array[3].v, 99.0, nil, @ps_array[3].id.to_s],
-        [@ps_array[1].v, 99.0, nil, @ps_array[1].id.to_s],
-        [@ps_array[4].v, 99.0, nil, @ps_array[4].id.to_s]
+        [@ps_array[0].v, 99.0, nil, @ps_array[0].id.to_s, 1],
+        [@ps_array[3].v, 99.0, nil, @ps_array[3].id.to_s, 1],
+        [@ps_array[1].v, 99.0, nil, @ps_array[1].id.to_s, 1],
+        [@ps_array[4].v, 99.0, nil, @ps_array[4].id.to_s, 1]
       ]
 
       loaded = JSON.load(response.body)
@@ -862,11 +862,11 @@ describe ParameterSetsController do
       get :_scatter_plot,
         params: {id: @ps_array.first, x_axis_key: "L", y_axis_key: "T", result: "cpu_time", irrelevants: "", format: :json}
       expected_data = [
-        [@ps_array[0].v, 10.0, nil, @ps_array[0].id.to_s],
-        [@ps_array[3].v, 10.0, nil, @ps_array[3].id.to_s],
-        [@ps_array[1].v, 10.0, nil, @ps_array[1].id.to_s],
-        [@ps_array[4].v, 10.0, nil, @ps_array[4].id.to_s],
-        [@ps_array[2].v, 10.0, nil, @ps_array[2].id.to_s]
+        [@ps_array[0].v, 10.0, nil, @ps_array[0].id.to_s, nil],
+        [@ps_array[3].v, 10.0, nil, @ps_array[3].id.to_s, nil],
+        [@ps_array[1].v, 10.0, nil, @ps_array[1].id.to_s, nil],
+        [@ps_array[4].v, 10.0, nil, @ps_array[4].id.to_s, nil],
+        [@ps_array[2].v, 10.0, nil, @ps_array[2].id.to_s, nil]
       ]
 
       loaded = JSON.load(response.body)
@@ -886,7 +886,7 @@ describe ParameterSetsController do
       expect(loaded["ylabel"]).to eq "T"
       expect(loaded["result"]).to eq "cpu_time"
       expect(loaded["irrelevants"]).to eq ["P"]
-      expect(loaded["data"]).to include( [@ps_array[5].v, 10.0, nil, @ps_array[5].id.to_s] )
+      expect(loaded["data"]).to include( [@ps_array[5].v, 10.0, nil, @ps_array[5].id.to_s, nil] )
     end
 
     it "contains url for the plot" do
@@ -924,11 +924,11 @@ describe ParameterSetsController do
         get :_scatter_plot,
           params: {id: @ps_array.first, x_axis_key: "L", y_axis_key: "T", result: "#{@analyzer.name}.ResultKey1", irrelevants: "", format: :json}
         expected_data = [
-          [@ps_array[0].v, 999.0, nil, @ps_array[0].id.to_s],
-          [@ps_array[3].v, 999.0, nil, @ps_array[3].id.to_s],
-          [@ps_array[1].v, 999.0, nil, @ps_array[1].id.to_s],
-          [@ps_array[4].v, 999.0, nil, @ps_array[4].id.to_s],
-          [@ps_array[2].v, 999.0, nil, @ps_array[2].id.to_s]
+          [@ps_array[0].v, 999.0, nil, @ps_array[0].id.to_s, 1],
+          [@ps_array[3].v, 999.0, nil, @ps_array[3].id.to_s, 1],
+          [@ps_array[1].v, 999.0, nil, @ps_array[1].id.to_s, 1],
+          [@ps_array[4].v, 999.0, nil, @ps_array[4].id.to_s, 1],
+          [@ps_array[2].v, 999.0, nil, @ps_array[2].id.to_s, 1]
         ]
 
         loaded = JSON.load(response.body)
@@ -946,10 +946,10 @@ describe ParameterSetsController do
             irrelevants: "", range: {"L" => [1,2]}.to_json,
             format: :json}
           expected_data = [
-            [@ps_array[0].v, 999.0, nil, @ps_array[0].id.to_s],
-            [@ps_array[3].v, 999.0, nil, @ps_array[3].id.to_s],
-            [@ps_array[1].v, 999.0, nil, @ps_array[1].id.to_s],
-            [@ps_array[4].v, 999.0, nil, @ps_array[4].id.to_s]
+            [@ps_array[0].v, 999.0, nil, @ps_array[0].id.to_s, 1],
+            [@ps_array[3].v, 999.0, nil, @ps_array[3].id.to_s, 1],
+            [@ps_array[1].v, 999.0, nil, @ps_array[1].id.to_s, 1],
+            [@ps_array[4].v, 999.0, nil, @ps_array[4].id.to_s, 1]
           ]
 
           loaded = JSON.load(response.body)
@@ -969,7 +969,7 @@ describe ParameterSetsController do
         expect(loaded["ylabel"]).to eq "T"
         expect(loaded["result"]).to eq "ResultKey1"
         expect(loaded["irrelevants"]).to eq ["P"]
-        expect(loaded["data"]).to include( [@ps_array[5].v, 999.0, nil, @ps_array[5].id.to_s] )
+        expect(loaded["data"]).to include( [@ps_array[5].v, 999.0, nil, @ps_array[5].id.to_s, 1] )
       end
 
       it "contains url for the plot" do
@@ -1006,11 +1006,11 @@ describe ParameterSetsController do
         get :_scatter_plot,
           params: {id: @ps_array.first, x_axis_key: "L", y_axis_key: "T", result: "#{@analyzer.name}.ResultKey1", irrelevants: "", format: :json}
         expected_data = [
-          [@ps_array[0].v, 9999, nil, @ps_array[0].id.to_s],
-          [@ps_array[3].v, 9999, nil, @ps_array[3].id.to_s],
-          [@ps_array[1].v, 9999, nil, @ps_array[1].id.to_s],
-          [@ps_array[4].v, 9999, nil, @ps_array[4].id.to_s],
-          [@ps_array[2].v, 9999, nil, @ps_array[2].id.to_s]
+          [@ps_array[0].v, 9999, nil, @ps_array[0].id.to_s, 1],
+          [@ps_array[3].v, 9999, nil, @ps_array[3].id.to_s, 1],
+          [@ps_array[1].v, 9999, nil, @ps_array[1].id.to_s, 1],
+          [@ps_array[4].v, 9999, nil, @ps_array[4].id.to_s, 1],
+          [@ps_array[2].v, 9999, nil, @ps_array[2].id.to_s, 1]
         ]
 
         loaded = JSON.load(response.body)
@@ -1028,10 +1028,10 @@ describe ParameterSetsController do
             irrelevants: "", range: {"L" => [1,2]}.to_json,
             format: :json}
           expected_data = [
-            [@ps_array[0].v, 9999, nil, @ps_array[0].id.to_s],
-            [@ps_array[3].v, 9999, nil, @ps_array[3].id.to_s],
-            [@ps_array[1].v, 9999, nil, @ps_array[1].id.to_s],
-            [@ps_array[4].v, 9999, nil, @ps_array[4].id.to_s]
+            [@ps_array[0].v, 9999, nil, @ps_array[0].id.to_s, 1],
+            [@ps_array[3].v, 9999, nil, @ps_array[3].id.to_s, 1],
+            [@ps_array[1].v, 9999, nil, @ps_array[1].id.to_s, 1],
+            [@ps_array[4].v, 9999, nil, @ps_array[4].id.to_s, 1]
           ]
 
           loaded = JSON.load(response.body)
@@ -1051,7 +1051,7 @@ describe ParameterSetsController do
         expect(loaded["ylabel"]).to eq "T"
         expect(loaded["result"]).to eq "ResultKey1"
         expect(loaded["irrelevants"]).to eq ["P"]
-        expect(loaded["data"]).to include( [@ps_array[5].v, 9999, nil, @ps_array[5].id.to_s] )
+        expect(loaded["data"]).to include( [@ps_array[5].v, 9999, nil, @ps_array[5].id.to_s, 1] )
       end
 
       it "contains url for the plot" do


### PR DESCRIPTION
The number of runs is shown in the tooltip of a line plot or a scatter plot.

<img width="246" alt="image" src="https://user-images.githubusercontent.com/718731/168408732-bb4706bd-3e15-4d53-8bed-17062f47e2bb.png">

<img width="235" alt="image" src="https://user-images.githubusercontent.com/718731/168408751-eb752854-5281-4269-8f1f-d2cc4d06623d.png">

