### PR TITLE
change file_watcher setting for M1 mac

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,7 +48,9 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # to run OACIS docker image on M1 mac, it must not be `EventedFileUpdateChecker`
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 
   # user code -----------
   class LoggerFormatWithTime


### PR DESCRIPTION
`EventedFileUpdateChecker` does not work on m1 mac (even on docker).
To avoid the issue, use `FileUpdateChecker`.