### PR TITLE
Add selections of 50, 100 for the number of simulation runs

### DIFF
--- a/app/views/parameter_sets/_form.html.haml
+++ b/app/views/parameter_sets/_form.html.haml
@@ -19,7 +19,7 @@
   .form-group
     = label_tag('num_runs', 'Target # of Runs', class: 'col-md-2 control-label')
     .col-md-3
-      = select_tag('num_runs', options_for_select([0,1,2,3,4,5,10,20], selected: (@num_runs || 1)), class: 'form-control')
+      = select_tag('num_runs', options_for_select([0,1,2,3,4,5,10,20,100,1000], selected: (@num_runs || 1)), class: 'form-control')
   #runs_fields
     = fields_for run do |builder|
       = render 'runs/fields', run: builder.object, f: builder

--- a/app/views/parameter_sets/_form.html.haml
+++ b/app/views/parameter_sets/_form.html.haml
@@ -19,7 +19,7 @@
   .form-group
     = label_tag('num_runs', 'Target # of Runs', class: 'col-md-2 control-label')
     .col-md-3
-      = select_tag('num_runs', options_for_select([0,1,2,3,4,5,10,20,100,1000], selected: (@num_runs || 1)), class: 'form-control')
+      = select_tag('num_runs', options_for_select([0,1,2,3,4,5,10,20,50,100], selected: (@num_runs || 1)), class: 'form-control')
   #runs_fields
     = fields_for run do |builder|
       = render 'runs/fields', run: builder.object, f: builder

--- a/app/views/parameter_sets/_runs.html.haml
+++ b/app/views/parameter_sets/_runs.html.haml
@@ -14,7 +14,7 @@
     .form-group
       = label_tag('num_runs', '# of Runs', class: 'col-md-2 control-label')
       .col-md-3
-        = select_tag('num_runs', options_for_select([1,2,3,4,5,10,20]), {class: 'form-control'})
+        = select_tag('num_runs', options_for_select([1,2,3,4,5,10,20,100,1000]), {class: 'form-control'})
     = render 'runs/fields', run: run, f: f
     .form-group
       .col-md-4.col-md-offset-2

--- a/app/views/parameter_sets/_runs.html.haml
+++ b/app/views/parameter_sets/_runs.html.haml
@@ -14,7 +14,7 @@
     .form-group
       = label_tag('num_runs', '# of Runs', class: 'col-md-2 control-label')
       .col-md-3
-        = select_tag('num_runs', options_for_select([1,2,3,4,5,10,20,100,1000]), {class: 'form-control'})
+        = select_tag('num_runs', options_for_select([1,2,3,4,5,10,20,50,100]), {class: 'form-control'})
     = render 'runs/fields', run: run, f: f
     .form-group
       .col-md-4.col-md-offset-2

--- a/app/views/simulators/_create_runs_on_selected_modal.haml
+++ b/app/views/simulators/_create_runs_on_selected_modal.haml
@@ -13,7 +13,7 @@
           .form-group
             = label_tag('num_runs', '# of Runs', class: 'col-md-2 control-label')
             .col-md-3
-              = select_tag('num_runs', options_for_select([1,2,3,4,5,10,20,100,1000]), {class: 'form-control'})
+              = select_tag('num_runs', options_for_select([1,2,3,4,5,10,20,50,100]), {class: 'form-control'})
           = fields_for run do |builder|
             = render 'runs/fields', run: run, f: builder
           = hidden_field_tag "ps_ids",""

--- a/app/views/simulators/_create_runs_on_selected_modal.haml
+++ b/app/views/simulators/_create_runs_on_selected_modal.haml
@@ -13,7 +13,7 @@
           .form-group
             = label_tag('num_runs', '# of Runs', class: 'col-md-2 control-label')
             .col-md-3
-              = select_tag('num_runs', options_for_select([1,2,3,4,5,10,20]), {class: 'form-control'})
+              = select_tag('num_runs', options_for_select([1,2,3,4,5,10,20,100,1000]), {class: 'form-control'})
           = fields_for run do |builder|
             = render 'runs/fields', run: run, f: builder
           = hidden_field_tag "ps_ids",""


### PR DESCRIPTION
In some simulations, a bigger number of runs of simulations are required to reduce the deviations. Currently, the maximum number of runs is set to 20. But, this PR extends it to 1000.