### PR TITLE
introduced "options" for host parameters

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -193,7 +193,7 @@ class Host
       self.host_parameter_definitions = JSON.load(xsub_out)["parameters"].reject do |key,val|
         key == "mpi_procs" or key == "omp_threads"
       end.map do |key,val|
-        HostParameterDefinition.new(key: key, default: val["default"], format: val["format"])
+        HostParameterDefinition.new(key: key, default: val["default"], format: val["format"], options: val["options"].to_a)
       end
     end
 

--- a/app/models/host_parameter_definition.rb
+++ b/app/models/host_parameter_definition.rb
@@ -2,12 +2,21 @@ class HostParameterDefinition
   include Mongoid::Document
   field :key, type: String
   field :default, type: String
-  field :format, type: String
+  field :format, type: String  # when options is not nil, format is ignored
+  field :options, type: Array
 
   embedded_in :host
 
+  before_validation do
+    if self.options.present?
+      self.format = nil
+      self.default = self.options.first if self.default.blank?
+    end
+  end
   validates :key, presence: true, uniqueness: true, format: {with: /\A\w+\z/}
-  validate :default_value_conform_to_format
+  validate :default_value_conform_to_format, if: -> { format.present? }
+  validate :options_must_be_string_array, if: -> { options.present? }
+  validate :default_must_be_in_options, if: -> { options.present? }
   validate :reserved_words_are_not_used_in_key
 
   private
@@ -21,6 +30,18 @@ class HostParameterDefinition
   def reserved_words_are_not_used_in_key
     if JobScriptUtil::EXPANDED_VARIABLES.include?(key)
       errors[:base] << "#{key} is a reserved word. Cannot use it as a key."
+    end
+  end
+
+  def options_must_be_string_array
+    unless self.options.is_a?(Array) && self.options.all? {|opt| opt.is_a?(String)}
+      errors.add(:options, "must be an array of strings")
+    end
+  end
+
+  def default_must_be_in_options
+    unless self.options.include?(self.default)
+      errors.add(:default, "must be one of #{self.options}")
     end
   end
 end

--- a/app/views/hosts/_about.html.haml
+++ b/app/views/hosts/_about.html.haml
@@ -44,13 +44,19 @@
           %thead
             %th Name
             %th Default
-            %th Format
+            %th Format/Options
           %tbody
             - @host.host_parameter_definitions.each do |host_prm|
               %tr
                 %td= host_prm.key
                 %td= host_prm.default
-                %td= host_prm.format
+                %td
+                  - if host_prm.options.present?
+                    = host_prm.options
+                  - else
+                    = host_prm.format
+
+
     %tr
       %th Executable simulators
       %td= raw( @host.executable_simulators.map {|sim| h(sim.name) }.join('<br />') )

--- a/app/views/runs/_host_parameter_fields.html.haml
+++ b/app/views/runs/_host_parameter_fields.html.haml
@@ -1,10 +1,15 @@
 - if host
   - simulator.get_default_host_parameter(host).each do |key, val|
+    - host_param_def = host.host_parameter_definitions.select {|hpd| hpd.key == key}.first
     .form-group
       = label_tag(:"run[host_parameters][#{key}]", key, class: 'col-md-2 control-label')
       .col-md-3
         - value = (defined?(run) && run.host_parameters[key]) || val
-        = text_field_tag(:"run[host_parameters][#{key}]", value, id: "run_host_parameters_#{key}_#{host.id}", class: "form-control", 'aria-describedby': "desc_host_param_#{key}")
+        - if host_param_def.options.present?
+          = select_tag(:"run[host_parameters][#{key}]", options_for_select(host_param_def.options, selected: value), id: "run_host_parameters_#{key}_#{host.id}", class: "form-control", 'aria-describedby': "desc_host_param_#{key}")
+        - else
+          = text_field_tag(:"run[host_parameters][#{key}]", value, id: "run_host_parameters_#{key}_#{host.id}", class: "form-control", 'aria-describedby': "desc_host_param_#{key}")
       .col-md-4
         %span{id: "desc_host_param_#{key}", class: "help-block"}
-          = "Format: /#{host.host_parameter_definitions.select {|hpd| hpd.key == key}.first.format }/"
+          - if host_param_def.format.present?
+            = "Format: /#{host_param_def.format}/"

--- a/spec/models/host_parameter_definition_spec.rb
+++ b/spec/models/host_parameter_definition_spec.rb
@@ -32,5 +32,49 @@ describe HostParameterDefinition do
       hpd = HostParameterDefinition.new(updated)
       expect(hpd).not_to be_valid
     end
+
+    describe "options field" do
+
+      it "is valid with an array of strings" do
+        hpd = HostParameterDefinition.new(@valid_attr)
+        expect(hpd).to be_valid
+      end
+
+      it "ignores options when options is an empty array" do
+        hpd = HostParameterDefinition.new(@valid_attr.update(options: []))
+        expect(hpd).to be_valid
+      end
+
+      it "ignores format when options are given" do
+        hpd = HostParameterDefinition.new(@valid_attr.update(format: "\\d+", options: ["option1", "option2"]))
+        expect(hpd).to be_valid
+        expect(hpd.format).to_not be_present
+      end
+
+      it "default value is the first element of the options" do
+        hpd = HostParameterDefinition.new(@valid_attr.update(default: nil, options: ["option1", "option2"]))
+        expect(hpd).to be_valid
+        expect(hpd.default).to eq "option1"
+      end
+
+      it "is raises an exception when options is not an array" do
+        expect {
+          hpd = HostParameterDefinition.new(@valid_attr.update(options: "option1"))
+        }.to raise_error(Mongoid::Errors::InvalidValue)
+      end
+
+      it "is not valid with an array containing non-string values" do
+        hpd = HostParameterDefinition.new(@valid_attr.update(options: ["option1", 2]))
+        expect(hpd).not_to be_valid
+      end
+
+      it "default value must be one of the options" do
+        hpd = HostParameterDefinition.new(@valid_attr.update(default: "option1", options: ["option1", "option2"]))
+        expect(hpd).to be_valid
+
+        hpd = HostParameterDefinition.new(@valid_attr.update(default: "option3", options: ["option1", "option2"]))
+        expect(hpd).not_to be_valid
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull request introduces several changes to the `HostParameterDefinition` model and its associated views and tests. The main goal is to add support for an `options` field, which allows specifying a predefined set of values for host parameters. The most important changes include updating the model to handle the new `options` field, modifying views to display and use these options, and adding tests to ensure the new functionality works correctly.

### Model Changes:
* [`app/models/host.rb`](diffhunk://#diff-9daa2c365cb8a7cb177648fe53854dae6588080e089b01333768fcb5da8ff4aeL196-R196): Updated `get_host_parameters` to include the `options` field when creating `HostParameterDefinition` instances.
* [`app/models/host_parameter_definition.rb`](diffhunk://#diff-1aa3f091287cae1d9d9a0c6e878a7ac00b8908d4478818e75096fcaa8c3fc2e5L5-R19): Added the `options` field, updated validations to handle the presence of `options`, and added methods to ensure the `options` field is an array of strings and that the default value is within the options. [[1]](diffhunk://#diff-1aa3f091287cae1d9d9a0c6e878a7ac00b8908d4478818e75096fcaa8c3fc2e5L5-R19) [[2]](diffhunk://#diff-1aa3f091287cae1d9d9a0c6e878a7ac00b8908d4478818e75096fcaa8c3fc2e5R35-R46)

### View Changes:
* [`app/views/hosts/_about.html.haml`](diffhunk://#diff-92fe7875132425462bf41bd11ad2ae5d31564a9ee0a17dce16683dcd5abe8589L47-R59): Modified to display `options` if present, otherwise display `format`.
* [`app/views/runs/_host_parameter_fields.html.haml`](diffhunk://#diff-f2d51ab11d667902d42129ce8cc2620a4a334a0e419b043ee1c4bd0fb0645efcR3-R15): Updated to use a dropdown for parameters with options, otherwise use a text field.

### Test Changes:
* [`spec/models/host_parameter_definition_spec.rb`](diffhunk://#diff-83d27f11ebfa55b3727d2beb59c91ca56edcca3a3c1051c7e02fd894fbfec984R35-R78): Added tests to validate the `options` field, ensuring it is an array of strings, that the default value is within the options, and that the format is ignored when options are present.