### PR TITLE
added a checkbox to toggle single/multiple selection

### DIFF
--- a/app/controllers/parameter_sets_controller.rb
+++ b/app/controllers/parameter_sets_controller.rb
@@ -69,7 +69,7 @@ class ParameterSetsController < ApplicationController
           ParametersUtil.cast_value(x.strip, defn.type)
         }
       elsif defn.type == "Selection"
-        casted[key] = parameters[key].to_a
+        casted[key] = parameters[key]
       else
         casted[key] = [parameters.has_key?(key) ? ParametersUtil.cast_value(parameters[key], defn.type) : defn.default]
       end
@@ -195,7 +195,7 @@ class ParameterSetsController < ApplicationController
       key = defn.key
       casted = nil
       if defn.type == "Selection"
-        casted = parameters[key].to_a
+        casted = parameters[key]
       elsif parameters[key] and JSON.is_not_json?(parameters[key]) and parameters[key].include?(',')
         casted = parameters[key].split(',').map {|x|
           ParametersUtil.cast_value( x.strip, defn["type"] )

--- a/app/views/parameter_sets/_form.html.haml
+++ b/app/views/parameter_sets/_form.html.haml
@@ -10,7 +10,11 @@
       = label_tag(property, "#{key} (#{pd.type})", class: 'col-md-2 control-label')
       .col-md-3
         - if pd.type == "Selection"
-          = select_tag(property, options_for_select(pd.options_array, selected: value), multiple: true, class: 'form-control', 'aria-describedby': "desc_#{key}")
+          = check_box_tag("v_#{key}_multi_toggle", "1", false, id: "v_#{key}_multi_toggle")
+          = label_tag("v_#{key}_multi_toggle", "multiple selection")
+          %br/
+          = select_tag("v[#{key}][]", options_for_select(pd.options_array, selected: value), id: "v_#{key}_select", class: 'form-control', 'aria-describedby': "desc_#{key}")
+          -# to make sure that the select_tag returns an array, the name must be "v[#{key}][]"
         - elsif pd.type == "Object"
           = text_area_tag(property, value.to_s, class: 'form-control', 'aria-describedby': "desc_#{key}", data: {html: 'true', toggle: 'tooltip', placement: 'bottom', 'original-title': "use JSON format"})
         - else
@@ -55,4 +59,19 @@
     }
     $('#new_parameter_set').change(show_cli_command);
     show_cli_command();
+  });
+
+  $(function() {
+    $('input[id$="_multi_toggle"]').change(function() {
+      const selectId = this.id.replace('_multi_toggle', '_select');
+      const $select = $('#' + selectId);
+
+      if ($(this).is(':checked')) {
+        $select.attr('multiple', 'multiple');
+        $select.addClass('multi-select');
+      } else {
+        $select.removeAttr('multiple');
+        $select.removeClass('multi-select');
+      }
+    });
   });


### PR DESCRIPTION
This pull request focuses on improving the handling of "Selection" type parameters in both the backend and frontend, enabling dynamic toggling between single and multiple selection modes in forms. Key changes include updates to parameter casting logic, form rendering, and client-side behavior.

<img width="757" alt="image" src="https://github.com/user-attachments/assets/cbb7836e-9615-400a-b6cc-04f15c5116e3" />
<img width="756" alt="image" src="https://github.com/user-attachments/assets/790a1c7a-6793-4ba7-ab72-8e3f1eeaebcd" />


### Backend changes to parameter casting:
* Updated `def create` and `def _create_cli` in `app/controllers/parameter_sets_controller.rb` to stop coercing "Selection" type parameters into arrays, allowing for more flexible handling of single or multiple values. [[1]](diffhunk://#diff-c48e4b278793caf314a02f41137a4a170f4c435cee5ebcd7d41afae214de7007L72-R72) [[2]](diffhunk://#diff-c48e4b278793caf314a02f41137a4a170f4c435cee5ebcd7d41afae214de7007L198-R198)

### Frontend changes to form rendering and behavior:
* Modified `app/views/parameter_sets/_form.html.haml` to include a checkbox (`check_box_tag`) for toggling between single and multiple selection modes for "Selection" type parameters. Updated the `select_tag` to ensure it supports multiple values when toggled.
* Added JavaScript logic in `app/views/parameter_sets/_form.html.haml` to dynamically update the `select` element's `multiple` attribute and CSS class based on the state of the toggle checkbox, improving the user experience.