### PR TITLE
sort 'submitted_to' by host or host_group names

### DIFF
--- a/app/views/analyses/_parameters_form.html.haml
+++ b/app/views/analyses/_parameters_form.html.haml
@@ -1,8 +1,8 @@
 .form-group
   = label(:analysis, :submitted_to, 'submitted_to', class: 'col-md-2 control-label')
   .col-md-3
-    - host_names = analyzer.executable_on.map {|h| [h.name, h.id.to_s]}
-    - host_names += HostGroup.all.map {|hg| ["HostGroup:#{hg.name}", hg.id.to_s] }
+    - host_names = analyzer.executable_on.map {|h| [h.name, h.id.to_s]}.sort_by {|h| h[0]}
+    - host_names += HostGroup.all.map {|hg| ["HostGroup:#{hg.name}", hg.id.to_s] }.sort_by {|h| h[0]}
     - selected_id = host_names.first.last
     = select(:analysis, :submitted_to, options_for_select(host_names, selected: selected_id), {}, {class: 'form-control'})
 .form-group

--- a/app/views/runs/_fields.html.haml
+++ b/app/views/runs/_fields.html.haml
@@ -2,8 +2,8 @@
   .form-group
     = f.label(:submitted_to, class: 'col-md-2 control-label')
     .col-md-3
-      - host_names = run.simulator.executable_on.map {|h| [h.name, h.id.to_s]}
-      - host_names += HostGroup.all.map {|hg| ["HostGroup:#{hg.name}", hg.id.to_s] }
+      - host_names = run.simulator.executable_on.map {|h| [h.name, h.id.to_s]}.sort_by {|a| a[0]}
+      - host_names += HostGroup.all.map {|hg| ["HostGroup:#{hg.name}", hg.id.to_s] }.sort_by {|a| a[0]}
       - selected_id = run.submitted_to ? run.submitted_to.id.to_s : nil
       = f.select(:submitted_to, options_for_select(host_names, selected: selected_id), {}, {class: 'form-control'})
   .form-group


### PR DESCRIPTION
This pull request introduces sorting for dropdown options in two views to ensure a consistent and user-friendly display order. The sorting is applied to lists of host names and host groups.

Dropdown sorting improvements:

* [`app/views/analyses/_parameters_form.html.haml`](diffhunk://#diff-144ab4fd60852bdaa625f4d9d9f321433857cfff212cebb92b38ee1ad178ddbcL4-R5): Added sorting by name (`sort_by`) for the `host_names` array, which includes both individual hosts and host groups, ensuring the dropdown options are displayed in alphabetical order.
* [`app/views/runs/_fields.html.haml`](diffhunk://#diff-eb8fc6ed59d88d5c3e9a2846b092c8ab8f85cf7706a09329c61fdd4961051524L5-R6): Similarly, added sorting by name (`sort_by`) for the `host_names` array in the runs view, ensuring consistent alphabetical order for dropdown options.

<img width="734" alt="image" src="https://github.com/user-attachments/assets/6e5991dc-90e4-4d80-85bf-48ed0bff8a2e" />
