### PR TITLE
Popen ssh

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -140,6 +140,7 @@ class HostsController < ApplicationController
                                            :max_mpi_procs,
                                            :min_omp_threads,
                                            :max_omp_threads,
+                                           :ssh_backend,
                                            executable_simulator_ids: [],
                                            executable_analyzer_ids: []
                                           ) : {}

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -139,8 +139,8 @@ class Host
     if @ssh
       yield @ssh
     else
-      ssh_logger.debug("starting SSH: " + self.name ) if ssh_logger
       ssh_module = ssh_backend == "popen_ssh" ? PopenSSH : Net::SSH
+      ssh_logger.debug("starting SSH: #{self.name} using #{ssh_module}" ) if ssh_logger
       ssh_module.start(name, nil, password: nil, timeout: 1, non_interactive: true, logger: ssh_logger) do |ssh|
         @ssh = ssh
         begin

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -159,13 +159,13 @@ class Host
         yield @ssh_shell
       else
         logger&.debug("starting SSH shell: " + self.name )
-        SSHUtil::ShellSession.start(ssh, logger: logger) do |sh|
-          @ssh_shell = sh
-          begin
+        begin
+          SSHUtil::ShellSession.start(ssh, logger: logger) do |sh|
+            @ssh_shell = sh
             yield sh
-          ensure
-            @ssh_shell = nil
           end
+        ensure
+          @ssh_shell = nil
         end
       end
     end

--- a/app/models/submittable.rb
+++ b/app/models/submittable.rb
@@ -133,9 +133,9 @@ module Submittable
   def omp_threads_is_in_range
     if submitted_to
       if omp_threads.to_i < submitted_to.min_omp_threads
-        errors.add(:omp_threads, "must be equal to or larger than #{submitted_to.min_mpi_procs}")
+        errors.add(:omp_threads, "must be equal to or larger than #{submitted_to.min_omp_threads}")
       elsif omp_threads.to_i > submitted_to.max_omp_threads
-        errors.add(:omp_threads, "must be equal to or smaller than #{submitted_to.max_mpi_procs}")
+        errors.add(:omp_threads, "must be equal to or smaller than #{submitted_to.max_omp_threads}")
       end
     end
   end

--- a/app/views/hosts/_about.html.haml
+++ b/app/views/hosts/_about.html.haml
@@ -55,8 +55,9 @@
                     = host_prm.options
                   - else
                     = host_prm.format
-
-
+    %tr
+      %th SSH Backend
+      %td= @host.ssh_backend == 'net_ssh' ? 'Net::SSH (Ruby)' : 'PopenSSH (Shell)'
     %tr
       %th Executable simulators
       %td= raw( @host.executable_simulators.map {|sim| h(sim.name) }.join('<br />') )

--- a/app/views/hosts/_form.html.haml
+++ b/app/views/hosts/_form.html.haml
@@ -44,6 +44,10 @@
       .col-md-5
         = f.number_field(:max_omp_threads, class: 'form-control', data: tooltip_data(:host,:min_omp_threads))
   .form-group
+    = f.label_c(:ssh_backend, 'SSH Backend')
+    .col-md-3
+      = f.select(:ssh_backend, options_for_select([['Net::SSH (Ruby)', 'net_ssh'], ['PopenSSH (Shell)', 'popen_ssh']], @host.ssh_backend), {}, class: 'form-control', data: tooltip_data(:host, :ssh_backend))
+  .form-group
     = raw(label_c('Executable Simulators'))
     .col-md-10
       = hidden_field_tag "host[executable_simulator_ids][]", nil

--- a/docs/en/configuring_host.md
+++ b/docs/en/configuring_host.md
@@ -53,6 +53,7 @@ We will explain the list of information which you need to specify when registeri
 | OMP threads                | The available range of the number of OpenMP threads. |
 | Executable simulators      | List of executable simulators on that host. |
 | Executable analyzers       | List of executable analyzers on that host. |
+| SSH Backend                | The SSH implementation to use, either Net::SSH (Ruby) or PopenSSH (Shell). |
 |----------------------------|---------------------------------------------------------------------|
 
 The SSH setting must be written in "~/.ssh/config" file. For instance, setting of "MyHost" may be written as the following.
@@ -70,7 +71,7 @@ If you specify *"Mounted work base dir"*, OACIS uses copy instead of SFTP to dow
 This may significantly improve the performance of the file transfer.
 For "localhost", always specify the same value as "Work base dir". The performance will be much improved.
 If the "Work base dir" on the computational host is mounted by NFS, specify the mounted path.
-If the directory is not accessible from OACIS, leave it blank. 
+If the directory is not accessible from OACIS, leave it blank.
 {% endcapture %}{% include tips %}
 
 {% capture tips %}
@@ -103,4 +104,25 @@ Set the execution command as follows.
 By setting "command" and "pre-process" like these, we can submit jobs to the K-computer.
 All the simulation results are properly staged-out if all the output files are generated in the current directory because all the files in the current directory are staged-out.
 
+## Using SSH Multiplexing
 
+SSH multiplexing allows re-use of the SSH connection after an initial login.
+The re-use of the connection means that you can log in one time, leave the connection open, and then connect again without having to reauthenticate.
+Therefore, you can authenticate using a password or Multi-Factor Authentication (MFA), and then you can access the same system using OACIS without using your password or MFA token in OACIS.
+
+In order to use the multiplexing, when creating your `~/.ssh/config` file, add `controlmaster auto` and `controlpath /tmp/ssh-%r@%h:%p`. The configuration may be as the following:
+
+```
+Host MyHost
+  HostName example.com
+  User user_ABC
+  IdentityFile ~/.ssh/id_rsa
+  port 22
+  controlmaster auto
+  controlpath /tmp/ssh-%r@%h:%p
+```
+In the terminal, log in to the host using `ssh MyHost`.
+
+In OACIS, select `PopenSSH (Shell)` for the SSH Backend, which will use OpenSSH, which includes ControlMaster, unlike Net::SSH (Ruby).
+
+Then, OACIS should be connected to the host and be able to show the Host status and submit jobs.

--- a/docs/en/configuring_simulator.md
+++ b/docs/en/configuring_simulator.md
@@ -378,3 +378,20 @@ cd ~/path/to; git describe --always
 You can delete or replace the runs having a specified by version at once using the command line interface (CLI).
 Please refer to the page for [CLI]({{ site.baseurl }}/ja/cli.html) for details.
 
+## [Advanced] Viewing GPU Profiling Results
+
+If you are using GPUs with OACIS, the nsight2pyplot provides options to view profiling information. nsight2pyplot is an external tool, so its repo needs to be cloned on the Host. The repo is available at: [https://github.com/kodingkoning/nsight2pyplot](https://github.com/kodingkoning/nsight2pyplot).
+
+nsight2pyplot generates figues for the timeline of the kernels in the profiled run, and a boxplot of the kernel runtimes. The timeline may look like:
+
+![Example timeline of nsight2pyplot](https://github.com/kodingkoning/nsight2pyplot/blob/main/figures/report1_timeline.png)
+
+The commands to create and process a profile must be added to the Simulator command. `nsys profile` is required to create the profile, and then the `plot_profile.sh` script from nsight2pyplot can be run on the profiling output. The commands for the similar will look like the follow, with the name of the simulator script and the path to nsight2pyplot specified:
+
+```
+nsys profile --stats=true --cuda-memory-usage true SIM_SCRIPT && ~/path/to/nsight2pyplot/plot_profile.sh report1
+```
+
+These commands do assume that the profile will have the prefix of `report1`, which will be the case if `nsys profile` is running in the directory created by OACIS.
+
+More information and examples are available in the documentation for nsight2pyplot.

--- a/lib/popen_ssh.rb
+++ b/lib/popen_ssh.rb
@@ -82,7 +82,6 @@ module PopenSSH
 
     def wait(timeout: nil)
       ios = [@stdout, @stderr]
-      timeout ||= @opts[:timeout]
 
       loop do
         ready = IO.select(ios, nil, nil, timeout)

--- a/lib/popen_ssh.rb
+++ b/lib/popen_ssh.rb
@@ -1,0 +1,111 @@
+require 'open3'
+
+module PopenSSH
+  def self.start(host, user, **opts, &block)
+    session = Session.new(host, user, opts)
+    yield session if block
+  end
+
+  class Session
+    attr_reader :host, :user, :channel
+
+    def initialize(host, user, opts = {})
+      @host = host
+      @user = user
+      @opts = opts
+    end
+
+    def open_channel(&block)
+      @channel = Channel.new(self, @opts)
+      yield @channel if block
+      @channel
+    end
+
+    def loop
+      @channel.wait(timeout: @opts[:timeout])
+    end
+  end
+
+  class Channel
+    def initialize(session, opts = {})
+      @session = session
+      @opts = opts
+      @logger = opts[:logger]
+    end
+
+    def exec(command, &block)
+      args = ["ssh"]
+
+      # Apply BatchMode for non-interactive SSH
+      args += ["-o", "BatchMode=yes"] if @opts[:non_interactive]
+      args += ["-l", @session.user] if @session.user
+      args += [@session.host, "--"]
+      args.concat(Shellwords.split(command))
+
+      @logger&.debug("[PopenSSH] exec: #{args.join(' ')}")
+
+      @stdin, @stdout, @stderr, @wait_thr = *Open3.popen3(*args)
+      yield self, true if block
+    end
+
+    def send_data(data)
+      @stdin.write(data)
+      @stdin.flush
+    end
+
+    def on_data(&block)
+      @on_data_block = block
+    end
+
+    def on_extended_data(&block)
+      @on_extended_data_block = block
+    end
+
+    def on_close(&block)
+      @on_close_block = block
+    end
+
+    def wait(timeout: nil)
+      ios = [@stdout, @stderr]
+      start_time = Time.now
+
+      loop do
+        if timeout
+          elapsed = Time.now - start_time
+          raise Timeout::Error, "SSH command timed out (stdout/stderr)" if elapsed > timeout
+        end
+
+        remaining = timeout ? [timeout - (Time.now - start_time), 0.1].max : nil
+        ready = IO.select(ios, nil, nil, remaining)
+
+        break unless ready
+
+        ready[0].each do |io|
+          begin
+            data = io.read_nonblock(1024)
+            case io
+            when @stdout
+              @on_data_block&.call(self, data)
+            when @stderr
+              @on_extended_data_block&.call(self, 1, data)
+            end
+          rescue IO::WaitReadable
+            next
+          rescue EOFError
+            ios.delete(io)
+            io.close
+          end
+        end
+
+        break if ios.empty?
+      end
+
+      unless @wait_thr.join(timeout)
+        Process.kill("TERM", @wait_thr.pid)
+        raise Timeout::Error, "SSH process did not exit in time"
+      end
+
+      @on_close_block&.call
+    end
+  end
+end

--- a/spec/lib/popen_ssh_spec.rb
+++ b/spec/lib/popen_ssh_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe PopenSSH do
+  let(:host) { 'example.com' }
+  let(:user) { 'test_user' }
+  let(:command) { 'echo Hello' }
+  let(:logger) { double('Logger', debug: nil) }
+
+  describe '.start' do
+    it 'yields a session object' do
+      PopenSSH.start(host, user) do |session|
+        expect(session).to be_a(PopenSSH::Session)
+        expect(session.host).to eq(host)
+        expect(session.user).to eq(user)
+      end
+    end
+  end
+
+  describe PopenSSH::Session do
+    let(:session) { PopenSSH::Session.new(host, user, logger: logger) }
+
+    describe '#open_channel' do
+      it 'yields a channel object' do
+        session.open_channel do |channel|
+          expect(channel).to be_a(PopenSSH::Channel)
+        end
+      end
+
+      it 'returns a channel object' do
+        channel = session.open_channel
+        expect(channel).to be_a(PopenSSH::Channel)
+      end
+    end
+  end
+
+  describe PopenSSH::Channel do
+    let(:session) { PopenSSH::Session.new(host, user, logger: logger, non_interactive: true) }
+    let(:channel) { session.open_channel }
+
+    describe '#exec' do
+      it 'executes the command via SSH' do
+        expect(Open3).to receive(:popen3).with('ssh', '-o', 'BatchMode=yes', '-l', user, host, '--', 'echo', 'Hello')
+        channel.exec(command)
+      end
+
+      it 'logs the command execution' do
+        expect(logger).to receive(:debug).with("[PopenSSH] exec: ssh -o BatchMode=yes -l test_user example.com -- echo Hello")
+        channel.exec(command)
+      end
+    end
+
+    describe '#send_data' do
+      it 'writes data to stdin' do
+        stdin = double('stdin', write: nil, flush: nil)
+        allow(Open3).to receive(:popen3).and_return([stdin, nil, nil, nil])
+        channel.exec(command)
+        channel.send_data('test data')
+        expect(stdin).to have_received(:write).with('test data')
+        expect(stdin).to have_received(:flush)
+      end
+    end
+  end
+end

--- a/spec/lib/popen_ssh_spec.rb
+++ b/spec/lib/popen_ssh_spec.rb
@@ -39,11 +39,13 @@ describe PopenSSH do
 
     describe '#exec' do
       it 'executes the command via SSH' do
+        allow(channel).to receive(:check_ssh_startup_failure!) # stub it out
         expect(Open3).to receive(:popen3).with('ssh', '-o', 'BatchMode=yes', '-l', user, host, '--', 'echo', 'Hello')
         channel.exec(command)
       end
 
       it 'logs the command execution' do
+        allow(channel).to receive(:check_ssh_startup_failure!) # stub it out
         expect(logger).to receive(:debug).with("[PopenSSH] exec: ssh -o BatchMode=yes -l test_user example.com -- echo Hello")
         channel.exec(command)
       end
@@ -52,6 +54,7 @@ describe PopenSSH do
     describe '#send_data' do
       it 'writes data to stdin' do
         stdin = double('stdin', write: nil, flush: nil)
+        allow(channel).to receive(:check_ssh_startup_failure!) # stub it out
         allow(Open3).to receive(:popen3).and_return([stdin, nil, nil, nil])
         channel.exec(command)
         channel.send_data('test data')

--- a/spec/lib/ssh_util_spec.rb
+++ b/spec/lib/ssh_util_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe SSHUtil do
+RSpec.shared_examples "SSHUtil backend" do |backend_name, ssh_module|
 
   around(:each) do |example|
     @temp_dir = Pathname.new('__temp__').expand_path
     FileUtils.mkdir_p(@temp_dir)
     @hostname = 'localhost'
-    Net::SSH.start(@hostname, ENV['USER'], password: "", timeout: 1) do |ssh|
+    ssh_module.start(@hostname, ENV['USER'], non_interactive: true, timeout: 1) do |ssh|
       SSHUtil::ShellSession.start(ssh) do |sh|
         @sh = sh
         example.run
@@ -273,5 +273,15 @@ describe SSHUtil do
       remote_path = @temp_dir.join('abc').expand_path
       expect(SSHUtil.directory?(@sh, remote_path)).to be_falsey
     end
+  end
+end
+
+describe SSHUtil do
+  context "with Net::SSH backend" do
+    it_behaves_like "SSHUtil backend", "Net::SSH", Net::SSH
+  end
+
+  context "with PopenSSH backend" do
+    it_behaves_like "SSHUtil backend", "PopenSSH", PopenSSH
   end
 end

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -140,6 +140,30 @@ describe Host do
     end
   end
 
+  describe "ssh_backend field" do
+    before(:each) do
+      @valid_attr = {
+        name: "nameABC",
+        work_base_dir: '~/__cm_work__',
+        status: :enabled,
+        ssh_backend: "net_ssh"
+      }
+    end
+
+    it "must be either 'net_ssh' or 'popen_ssh'" do
+      @valid_attr.update(ssh_backend: "invalid_backend")
+      host = Host.new(@valid_attr)
+      expect(host).not_to be_valid
+      expect(host.errors[:ssh_backend]).to include("is not included in the list")
+    end
+
+    it "defaults to 'net_ssh'" do
+      @valid_attr.delete(:ssh_backend)
+      host = Host.new(@valid_attr)
+      expect(host.ssh_backend).to eq("net_ssh")
+    end
+  end
+
   describe ".find_by_name" do
 
     it "returns the host with the given name" do


### PR DESCRIPTION
This pull request introduces support for an alternative SSH backend (`PopenSSH`) alongside the existing `Net::SSH` backend, allowing users to choose between them for SSH connections. It includes changes to the `Host` model, controller, views, and tests, as well as the addition of a new `PopenSSH` module. The most important changes are grouped below by theme:

### SSH Backend Support:

* **Model Updates**: Added a new `ssh_backend` field to the `Host` model with validation to ensure it is either `net_ssh` or `popen_ssh`, and set its default value to `net_ssh`. [[1]](diffhunk://#diff-9daa2c365cb8a7cb177648fe53854dae6588080e089b01333768fcb5da8ff4aeR17) [[2]](diffhunk://#diff-9daa2c365cb8a7cb177648fe53854dae6588080e089b01333768fcb5da8ff4aeR33)
* **Controller Updates**: Updated the `permitted_host_params` method in `HostsController` to include the `ssh_backend` parameter.
* **View Updates**: Added UI elements for selecting the SSH backend in the host form and displaying the selected backend in the host details view. [[1]](diffhunk://#diff-2d267bc0327c76db127c73ebbf5faf5e1d1e8eb464536838bc51bb391f147c6dR46-R49) [[2]](diffhunk://#diff-92fe7875132425462bf41bd11ad2ae5d31564a9ee0a17dce16683dcd5abe8589L58-R60)

### PopenSSH Module:

* **New Module**: Added the `PopenSSH` module to provide an alternative SSH backend using shell commands (`Open3`). Includes classes for managing SSH sessions and channels, with support for non-interactive mode and timeout handling.
* **Exception Handling**: Added `PopenSSH::ConnectionError` to the list of connection exceptions in the `Host` model.

### SSH Connection Logic:

* **Connection Updates**: Modified the `start_ssh` method in the `Host` model to dynamically select the SSH backend (`Net::SSH` or `PopenSSH`) based on the `ssh_backend` field.
* **Connection Validation**: Updated the `connected?` method to validate SSH connections by executing a test command (`echo OACIS-SSH-CONNECTED`) and checking its output.

### Tests:

* **PopenSSH Tests**: Added comprehensive tests for the `PopenSSH` module, including session and channel behavior, command execution, and error handling.
* **Host Model Tests**: Added tests for the `ssh_backend` field in the `Host` model to verify default values and validation rules.
* **SSHUtil Tests**: Updated `SSHUtil` tests to include shared examples for both `Net::SSH` and `PopenSSH` backends. [[1]](diffhunk://#diff-f97719ab9c52ba5eb9f2965340e3254d78c84cad813949535f6f099324845e52L3-R9) [[2]](diffhunk://#diff-f97719ab9c52ba5eb9f2965340e3254d78c84cad813949535f6f099324845e52R278-R287)