### PR TITLE
correct error message for `omp_threads_is_in_range`

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -140,6 +140,7 @@ class HostsController < ApplicationController
                                            :max_mpi_procs,
                                            :min_omp_threads,
                                            :max_omp_threads,
+                                           :ssh_backend,
                                            executable_simulator_ids: [],
                                            executable_analyzer_ids: []
                                           ) : {}

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -139,8 +139,8 @@ class Host
     if @ssh
       yield @ssh
     else
-      ssh_logger.debug("starting SSH: " + self.name ) if ssh_logger
       ssh_module = ssh_backend == "popen_ssh" ? PopenSSH : Net::SSH
+      ssh_logger.debug("starting SSH: #{self.name} using #{ssh_module}" ) if ssh_logger
       ssh_module.start(name, nil, password: nil, timeout: 1, non_interactive: true, logger: ssh_logger) do |ssh|
         @ssh = ssh
         begin

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -159,13 +159,13 @@ class Host
         yield @ssh_shell
       else
         logger&.debug("starting SSH shell: " + self.name )
-        SSHUtil::ShellSession.start(ssh, logger: logger) do |sh|
-          @ssh_shell = sh
-          begin
+        begin
+          SSHUtil::ShellSession.start(ssh, logger: logger) do |sh|
+            @ssh_shell = sh
             yield sh
-          ensure
-            @ssh_shell = nil
           end
+        ensure
+          @ssh_shell = nil
         end
       end
     end

--- a/app/models/submittable.rb
+++ b/app/models/submittable.rb
@@ -133,9 +133,9 @@ module Submittable
   def omp_threads_is_in_range
     if submitted_to
       if omp_threads.to_i < submitted_to.min_omp_threads
-        errors.add(:omp_threads, "must be equal to or larger than #{submitted_to.min_mpi_procs}")
+        errors.add(:omp_threads, "must be equal to or larger than #{submitted_to.min_omp_threads}")
       elsif omp_threads.to_i > submitted_to.max_omp_threads
-        errors.add(:omp_threads, "must be equal to or smaller than #{submitted_to.max_mpi_procs}")
+        errors.add(:omp_threads, "must be equal to or smaller than #{submitted_to.max_omp_threads}")
       end
     end
   end

--- a/app/views/hosts/_about.html.haml
+++ b/app/views/hosts/_about.html.haml
@@ -55,8 +55,9 @@
                     = host_prm.options
                   - else
                     = host_prm.format
-
-
+    %tr
+      %th SSH Backend
+      %td= @host.ssh_backend == 'net_ssh' ? 'Net::SSH (Ruby)' : 'PopenSSH (Shell)'
     %tr
       %th Executable simulators
       %td= raw( @host.executable_simulators.map {|sim| h(sim.name) }.join('<br />') )

--- a/app/views/hosts/_form.html.haml
+++ b/app/views/hosts/_form.html.haml
@@ -44,6 +44,10 @@
       .col-md-5
         = f.number_field(:max_omp_threads, class: 'form-control', data: tooltip_data(:host,:min_omp_threads))
   .form-group
+    = f.label_c(:ssh_backend, 'SSH Backend')
+    .col-md-3
+      = f.select(:ssh_backend, options_for_select([['Net::SSH (Ruby)', 'net_ssh'], ['PopenSSH (Shell)', 'popen_ssh']], @host.ssh_backend), {}, class: 'form-control', data: tooltip_data(:host, :ssh_backend))
+  .form-group
     = raw(label_c('Executable Simulators'))
     .col-md-10
       = hidden_field_tag "host[executable_simulator_ids][]", nil

--- a/lib/popen_ssh.rb
+++ b/lib/popen_ssh.rb
@@ -82,7 +82,6 @@ module PopenSSH
 
     def wait(timeout: nil)
       ios = [@stdout, @stderr]
-      timeout ||= @opts[:timeout]
 
       loop do
         ready = IO.select(ios, nil, nil, timeout)

--- a/lib/popen_ssh.rb
+++ b/lib/popen_ssh.rb
@@ -1,0 +1,111 @@
+require 'open3'
+
+module PopenSSH
+  def self.start(host, user, **opts, &block)
+    session = Session.new(host, user, opts)
+    yield session if block
+  end
+
+  class Session
+    attr_reader :host, :user, :channel
+
+    def initialize(host, user, opts = {})
+      @host = host
+      @user = user
+      @opts = opts
+    end
+
+    def open_channel(&block)
+      @channel = Channel.new(self, @opts)
+      yield @channel if block
+      @channel
+    end
+
+    def loop
+      @channel.wait(timeout: @opts[:timeout])
+    end
+  end
+
+  class Channel
+    def initialize(session, opts = {})
+      @session = session
+      @opts = opts
+      @logger = opts[:logger]
+    end
+
+    def exec(command, &block)
+      args = ["ssh"]
+
+      # Apply BatchMode for non-interactive SSH
+      args += ["-o", "BatchMode=yes"] if @opts[:non_interactive]
+      args += ["-l", @session.user] if @session.user
+      args += [@session.host, "--"]
+      args.concat(Shellwords.split(command))
+
+      @logger&.debug("[PopenSSH] exec: #{args.join(' ')}")
+
+      @stdin, @stdout, @stderr, @wait_thr = *Open3.popen3(*args)
+      yield self, true if block
+    end
+
+    def send_data(data)
+      @stdin.write(data)
+      @stdin.flush
+    end
+
+    def on_data(&block)
+      @on_data_block = block
+    end
+
+    def on_extended_data(&block)
+      @on_extended_data_block = block
+    end
+
+    def on_close(&block)
+      @on_close_block = block
+    end
+
+    def wait(timeout: nil)
+      ios = [@stdout, @stderr]
+      start_time = Time.now
+
+      loop do
+        if timeout
+          elapsed = Time.now - start_time
+          raise Timeout::Error, "SSH command timed out (stdout/stderr)" if elapsed > timeout
+        end
+
+        remaining = timeout ? [timeout - (Time.now - start_time), 0.1].max : nil
+        ready = IO.select(ios, nil, nil, remaining)
+
+        break unless ready
+
+        ready[0].each do |io|
+          begin
+            data = io.read_nonblock(1024)
+            case io
+            when @stdout
+              @on_data_block&.call(self, data)
+            when @stderr
+              @on_extended_data_block&.call(self, 1, data)
+            end
+          rescue IO::WaitReadable
+            next
+          rescue EOFError
+            ios.delete(io)
+            io.close
+          end
+        end
+
+        break if ios.empty?
+      end
+
+      unless @wait_thr.join(timeout)
+        Process.kill("TERM", @wait_thr.pid)
+        raise Timeout::Error, "SSH process did not exit in time"
+      end
+
+      @on_close_block&.call
+    end
+  end
+end

--- a/spec/lib/popen_ssh_spec.rb
+++ b/spec/lib/popen_ssh_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe PopenSSH do
+  let(:host) { 'example.com' }
+  let(:user) { 'test_user' }
+  let(:command) { 'echo Hello' }
+  let(:logger) { double('Logger', debug: nil) }
+
+  describe '.start' do
+    it 'yields a session object' do
+      PopenSSH.start(host, user) do |session|
+        expect(session).to be_a(PopenSSH::Session)
+        expect(session.host).to eq(host)
+        expect(session.user).to eq(user)
+      end
+    end
+  end
+
+  describe PopenSSH::Session do
+    let(:session) { PopenSSH::Session.new(host, user, logger: logger) }
+
+    describe '#open_channel' do
+      it 'yields a channel object' do
+        session.open_channel do |channel|
+          expect(channel).to be_a(PopenSSH::Channel)
+        end
+      end
+
+      it 'returns a channel object' do
+        channel = session.open_channel
+        expect(channel).to be_a(PopenSSH::Channel)
+      end
+    end
+  end
+
+  describe PopenSSH::Channel do
+    let(:session) { PopenSSH::Session.new(host, user, logger: logger, non_interactive: true) }
+    let(:channel) { session.open_channel }
+
+    describe '#exec' do
+      it 'executes the command via SSH' do
+        expect(Open3).to receive(:popen3).with('ssh', '-o', 'BatchMode=yes', '-l', user, host, '--', 'echo', 'Hello')
+        channel.exec(command)
+      end
+
+      it 'logs the command execution' do
+        expect(logger).to receive(:debug).with("[PopenSSH] exec: ssh -o BatchMode=yes -l test_user example.com -- echo Hello")
+        channel.exec(command)
+      end
+    end
+
+    describe '#send_data' do
+      it 'writes data to stdin' do
+        stdin = double('stdin', write: nil, flush: nil)
+        allow(Open3).to receive(:popen3).and_return([stdin, nil, nil, nil])
+        channel.exec(command)
+        channel.send_data('test data')
+        expect(stdin).to have_received(:write).with('test data')
+        expect(stdin).to have_received(:flush)
+      end
+    end
+  end
+end

--- a/spec/lib/popen_ssh_spec.rb
+++ b/spec/lib/popen_ssh_spec.rb
@@ -39,11 +39,13 @@ describe PopenSSH do
 
     describe '#exec' do
       it 'executes the command via SSH' do
+        allow(channel).to receive(:check_ssh_startup_failure!) # stub it out
         expect(Open3).to receive(:popen3).with('ssh', '-o', 'BatchMode=yes', '-l', user, host, '--', 'echo', 'Hello')
         channel.exec(command)
       end
 
       it 'logs the command execution' do
+        allow(channel).to receive(:check_ssh_startup_failure!) # stub it out
         expect(logger).to receive(:debug).with("[PopenSSH] exec: ssh -o BatchMode=yes -l test_user example.com -- echo Hello")
         channel.exec(command)
       end
@@ -52,6 +54,7 @@ describe PopenSSH do
     describe '#send_data' do
       it 'writes data to stdin' do
         stdin = double('stdin', write: nil, flush: nil)
+        allow(channel).to receive(:check_ssh_startup_failure!) # stub it out
         allow(Open3).to receive(:popen3).and_return([stdin, nil, nil, nil])
         channel.exec(command)
         channel.send_data('test data')

--- a/spec/lib/ssh_util_spec.rb
+++ b/spec/lib/ssh_util_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe SSHUtil do
+RSpec.shared_examples "SSHUtil backend" do |backend_name, ssh_module|
 
   around(:each) do |example|
     @temp_dir = Pathname.new('__temp__').expand_path
     FileUtils.mkdir_p(@temp_dir)
     @hostname = 'localhost'
-    Net::SSH.start(@hostname, ENV['USER'], password: "", timeout: 1) do |ssh|
+    ssh_module.start(@hostname, ENV['USER'], non_interactive: true, timeout: 1) do |ssh|
       SSHUtil::ShellSession.start(ssh) do |sh|
         @sh = sh
         example.run
@@ -273,5 +273,15 @@ describe SSHUtil do
       remote_path = @temp_dir.join('abc').expand_path
       expect(SSHUtil.directory?(@sh, remote_path)).to be_falsey
     end
+  end
+end
+
+describe SSHUtil do
+  context "with Net::SSH backend" do
+    it_behaves_like "SSHUtil backend", "Net::SSH", Net::SSH
+  end
+
+  context "with PopenSSH backend" do
+    it_behaves_like "SSHUtil backend", "PopenSSH", PopenSSH
   end
 end

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -140,6 +140,30 @@ describe Host do
     end
   end
 
+  describe "ssh_backend field" do
+    before(:each) do
+      @valid_attr = {
+        name: "nameABC",
+        work_base_dir: '~/__cm_work__',
+        status: :enabled,
+        ssh_backend: "net_ssh"
+      }
+    end
+
+    it "must be either 'net_ssh' or 'popen_ssh'" do
+      @valid_attr.update(ssh_backend: "invalid_backend")
+      host = Host.new(@valid_attr)
+      expect(host).not_to be_valid
+      expect(host.errors[:ssh_backend]).to include("is not included in the list")
+    end
+
+    it "defaults to 'net_ssh'" do
+      @valid_attr.delete(:ssh_backend)
+      host = Host.new(@valid_attr)
+      expect(host.ssh_backend).to eq("net_ssh")
+    end
+  end
+
   describe ".find_by_name" do
 
     it "returns the host with the given name" do


### PR DESCRIPTION
Previously the error message for out of range OMP threads when creating runs displayed the thresholds for MPI processes, and this PR corrects it to display the min/max for OMP threads.