### PR TITLE
update mongoid.yml to use environment variable for MongoDB hosts

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -9,7 +9,7 @@ development:
       # Provides the hosts the default client can connect to. Must be an array
       # of host:port pairs. (required)
       hosts:
-        - 127.0.0.1:27017
+        - <%= ENV['OACIS_MONGODB_URL'] || '127.0.0.1:27017' %>
       options:
         # Change the default write concern. (default = { w: 1 })
         write:
@@ -136,7 +136,7 @@ test:
     default:
       database: oacis_test
       hosts:
-        - 127.0.0.1:27017
+        - <%= ENV['OACIS_MONGODB_URL'] || '127.0.0.1:27017' %>
       options:
         write:
           w: 1
@@ -156,7 +156,7 @@ production:
       # Provides the hosts the default client can connect to. Must be an array
       # of host:port pairs. (required)
       hosts:
-        - 127.0.0.1:27017
+        - <%= ENV['OACIS_MONGODB_URL'] || '127.0.0.1:27017' %>
       options:
         # Change the default write concern. (default = { w: 1 })
         write:


### PR DESCRIPTION
This pull request updates the `config/mongoid.yml` file to allow the MongoDB host to be configured via an environment variable (`OACIS_MONGODB_URL`) across all environments (development, test, and production). If the environment variable is not set, it defaults to `127.0.0.1:27017`.

### Configuration changes:

* Updated the `hosts` setting in the `development` environment to use `<%= ENV['OACIS_MONGODB_URL'] || '127.0.0.1:27017' %>` for dynamic configuration.
* Updated the `hosts` setting in the `test` environment to use `<%= ENV['OACIS_MONGODB_URL'] || '127.0.0.1:27017' %>` for dynamic configuration.
* Updated the `hosts` setting in the `production` environment to use `<%= ENV['OACIS_MONGODB_URL'] || '127.0.0.1:27017' %>` for dynamic configuration.