### PR TITLE
Update the Redis configuration to use environment variables

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,6 +1,6 @@
 redis: &redis
   adapter: redis
-  url: redis://localhost:6379/1
+  url: redis://<%= ENV['OACIS_REDIS_URL'] || 'localhost:6379' %>/1
 
 production: *redis
 development: *redis


### PR DESCRIPTION
This pull request updates the `config/cable.yml` file to make the Redis URL configurable via an environment variable, enhancing flexibility for different deployment environments.

* [`config/cable.yml`](diffhunk://#diff-661620ae7be69a63f01b319f70bb6e3e0f6183b59258e9ed7aee623d75f17d90L3-R3): Replaced the hardcoded Redis URL with a dynamic value that defaults to `localhost:6379` but can be overridden using the `OACIS_REDIS_URL` environment variable.