### PR TITLE
fix: avoid crash when colorizing boolean parameters in the similar parameter sets list

### DIFF
--- a/app/datatables/parameter_sets_list_datatable.rb
+++ b/app/datatables/parameter_sets_list_datatable.rb
@@ -84,15 +84,16 @@ private
       return red
     end
 
-    if val == compared_val
-      escaped
-    elsif val < compared_val
-      blue
-    elsif val > compared_val
-      red
-    else
-      escaped
-    end
+    return escaped if val == compared_val
+
+    # Booleans and other non-comparable types don't support < / > (e.g.
+    # `true <=> false` is nil, not a number), so guard the spaceship result
+    # instead of calling the operators directly. Values that can't be ordered
+    # fall through uncolored, matching the original else branch.
+    cmp = (val <=> compared_val)
+    return escaped if cmp.nil?
+
+    cmp < 0 ? blue : red
   end
 
   def colorize_unique_param_values


### PR DESCRIPTION
## 概要

Object 型で真偽値（`true`/`false`）を取るパラメータを定義したシミュレータで、ParameterSet 詳細ページの「類似 ParameterSet 一覧（similar parameter sets list）」が 500 エラーになり、画面上は次の DataTables 警告が表示されます。

> DataTables warning: table id=similar_params_list - Ajax error.

## 再現手順

1. Object 型のパラメータ（例: `show_legends`、値は `true`/`false`）を持つシミュレータを登録する。
2. その真偽値だけが異なる ParameterSet を 2 つ以上作成する。
3. いずれかの ParameterSet の詳細ページを開く。
   → 「類似 ParameterSet 一覧」テーブルの Ajax 取得が失敗する。

## エラー内容

```
NoMethodError (undefined method `<' for true:TrueClass):
  app/datatables/parameter_sets_list_datatable.rb:89:in `colorize_param_value'
  app/datatables/parameter_sets_list_datatable.rb:60:in `block (2 levels) in data'
  ...
  app/controllers/parameter_sets_controller.rb:263:in `_similar_parameter_sets_list'
```

## 原因

`colorize_param_value` が基準 ParameterSet との差分を `<` / `>` で比較して色付け（小さい→青／大きい→赤）していますが、真偽値（`TrueClass`/`FalseClass`）は `<` / `>` を持たないため、`true < false` の時点で `NoMethodError` になります。`Hash` / `Array` はガード済みでしたが、真偽値は考慮されていませんでした。

## 修正内容

比較演算子を直接呼ぶ代わりに宇宙船演算子 `<=>` を使い、結果が `nil`（＝順序が定義できない型）の場合をガードしました。`true <=> false` は例外を投げず `nil` を返します。順序付けできない値は **色を付けずにそのまま返す**ようにしており、これは元の `else` 分岐の挙動と一致します。数値・文字列の大小に応じた色付けは従来どおりです。

```ruby
return escaped if val == compared_val

cmp = (val <=> compared_val)
return escaped if cmp.nil?

cmp < 0 ? blue : red
```

## 動作確認

- 真偽値が異なる ParameterSet 間でも「類似 ParameterSet 一覧」がエラーなく表示されることを確認しました。
- 数値・文字列パラメータの色付け（青/赤）が従来どおりであることを確認しました。

マージしていただけると幸いです。
