### PR TITLE
Add MCP server so AI agents can submit and monitor jobs

### DIFF
--- a/bin/oacis_mcp
+++ b/bin/oacis_mcp
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+
+# MCP (Model Context Protocol) server for OACIS, speaking JSON-RPC over stdio.
+# See docs/en/mcp.md for usage.
+
+ENV['BUNDLE_GEMFILE'] = File.join(File.dirname(__FILE__), '../Gemfile')
+require 'bundler/setup'
+
+# stdout is the protocol channel: reserve it before loading Rails so that
+# nothing printed during boot (warnings, logger output, pry) can corrupt it.
+PROTOCOL_OUT = $stdout.dup
+PROTOCOL_OUT.sync = true
+$stdout.reopen($stderr)
+
+require_relative '../config/environment'
+require_relative '../lib/mcp_server/server'
+
+logger = Logger.new($stderr)
+logger.level = Logger::WARN
+Rails.logger = logger
+Mongoid.logger = logger
+
+McpServer::Server.new(input: $stdin, output: PROTOCOL_OUT, logger: logger).run

--- a/docs/en/api_samples.md
+++ b/docs/en/api_samples.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Samples"
 lang: en
-next_page: tips
+next_page: mcp
 ---
 
 # Samples

--- a/docs/en/mcp.md
+++ b/docs/en/mcp.md
@@ -1,0 +1,80 @@
+---
+layout: default
+title: "MCP Server"
+lang: en
+next_page: tips
+---
+
+# MCP Server for AI agents
+
+---
+
+OACIS ships an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server, `bin/oacis_mcp`, which lets AI agents such as Claude submit and monitor simulation jobs.
+An agent connected to this server can explore parameter spaces autonomously: create parameter sets, submit runs, poll their status, read result files, and trigger analyzers.
+
+The server speaks JSON-RPC over stdio and accesses the OACIS database in-process, exactly like the [Ruby API]({{ site.baseurl }}/{{ page.lang }}/api.html). Jobs created through it are picked up and submitted to remote hosts by the ordinary OACIS background workers.
+
+## Setup
+
+The command must run on the machine where OACIS is installed (it loads the Rails environment).
+
+With [Claude Code](https://claude.com/claude-code):
+
+```shell
+claude mcp add oacis -- /path/to/oacis/bin/oacis_mcp
+```
+
+or in a project's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "oacis": { "command": "/path/to/oacis/bin/oacis_mcp" }
+  }
+}
+```
+
+If you run OACIS with docker (oacis_docker), connect through `docker exec` (note `-i`, without `-t`):
+
+```shell
+claude mcp add oacis -- docker exec -i -u oacis my_oacis /home/oacis/oacis/bin/oacis_mcp
+```
+
+## Security model
+
+- The server is stdio-only; it opens no network port. Whoever can execute `bin/oacis_mcp` gets the same database access as `bin/oacis_ruby`.
+- When `OACIS_ACCESS_LEVEL` is `0`, or when the environment variable `OACIS_MCP_READONLY=1` is set, the three write tools are hidden and rejected — the agent can only inspect.
+- There are no destructive tools: agents cannot delete simulators, parameter sets, runs, or analyses, and cannot modify simulator/host configurations.
+- File access is restricted to the result directories of runs and analyses, with size limits.
+
+## Tools
+
+| Tool | Type | Purpose |
+|------|------|---------|
+| `list_simulators` | read | Simulators with parameter definitions and analyzers |
+| `list_hosts` | read | Hosts/host groups with host parameter definitions |
+| `search_parameter_sets` | read | Query parameter sets by parameter values, with run status counts |
+| `get_parameter_set` | read | One parameter set, its runs, and average results |
+| `get_run` / `list_runs` | read | Run status, results, error messages |
+| `get_analysis` / `list_analyses` | read | Analysis status and results |
+| `list_result_files` / `read_result_file` | read | Inspect raw output files (text, size-capped) |
+| `find_or_create_parameter_set` | write | Idempotent parameter set creation |
+| `create_runs` | write | Idempotent run creation ("up to N runs") |
+| `create_analysis` | write | Run an analyzer on a finished run / parameter set |
+
+A typical agent workflow:
+
+1. `list_simulators` and `list_hosts` to learn what exists,
+2. `find_or_create_parameter_set` → `create_runs` to submit jobs,
+3. poll `get_parameter_set` (or `search_parameter_sets` for many) until runs finish — jobs are submitted asynchronously by the background workers, so results take a while,
+4. inspect `get_run`, `read_result_file`, or aggregate with `include_average_results`,
+5. `create_analysis` on the finished runs and poll `get_analysis`,
+6. decide the next parameter sets and repeat.
+
+All write tools are idempotent, so a retried tool call never duplicates parameter sets, runs, or analyses.
+
+## Notes
+
+- Validation errors are returned to the agent in a structured form including the expected format (e.g. the regexp a host parameter must match), so agents can self-correct.
+- `read_result_file` reads text files only, at most 256 kB per call, with `offset_bytes` for paging through long logs.
+- The server logs to stderr; stdout is reserved for the protocol.

--- a/lib/mcp_server/errors.rb
+++ b/lib/mcp_server/errors.rb
@@ -1,0 +1,60 @@
+module McpServer
+
+  # Raised by tool handlers. Serialized into the tools/call result body
+  # (isError: true) so that the calling agent can read and act on it.
+  class ToolError < StandardError
+    attr_reader :code, :details, :hint
+
+    def initialize(code, message, details: [], hint: nil)
+      super(message)
+      @code = code
+      @details = details
+      @hint = hint
+    end
+
+    def to_h
+      h = { "error" => code, "message" => message }
+      h["details"] = details if details.present?
+      h["hint"] = hint if hint
+      h
+    end
+  end
+
+  # Protocol-level problems: mapped to JSON-RPC error -32602 by the server,
+  # not to a tool result.
+  class UnknownToolError < StandardError; end
+  class InvalidArgumentsError < StandardError; end
+
+  module Errors
+    # Maps any exception raised by a tool handler to a ToolError.
+    def self.wrap(exception)
+      case exception
+      when ToolError
+        exception
+      when Mongoid::Errors::Validations
+        ToolError.new("validation_failed", "Validation failed: #{exception.document.class.name}",
+                      details: exception.document.errors.full_messages,
+                      hint: "Call list_hosts to see host_parameter_definitions (format regexps, defaults) and mpi/omp limits, or list_simulators for parameter_definitions.")
+      when Mongoid::Errors::DocumentNotFound, BSON::Error::InvalidObjectId
+        ToolError.new("not_found", exception.message.to_s.lines.first.to_s.strip,
+                      hint: "Check the id, or use the corresponding list/search tool to find it.")
+      when RuntimeError
+        msg = exception.message.to_s
+        if msg =~ /is not found\z/
+          ToolError.new("not_found", msg, hint: "Use list_simulators or list_hosts to see available names.")
+        elsif msg =~ /\A(Unknown keys|Missing keys)/
+          ToolError.new("invalid_parameters", msg,
+                        hint: "Call list_simulators to see the parameter_definitions of this simulator.")
+        else
+          internal(exception)
+        end
+      else
+        internal(exception)
+      end
+    end
+
+    def self.internal(exception)
+      ToolError.new("internal_error", "#{exception.class}: #{exception.message}")
+    end
+  end
+end

--- a/lib/mcp_server/resolvers.rb
+++ b/lib/mcp_server/resolvers.rb
@@ -1,0 +1,75 @@
+require_relative 'errors'
+
+module McpServer
+
+  # Resolves tool arguments to documents.
+  # Simulators, hosts, host groups and analyzers accept a name or an id;
+  # parameter sets, runs, and analyses are id-only.
+  module Resolvers
+
+    module_function
+
+    def simulator(name_or_id)
+      by_name_or_id(Simulator, name_or_id, "Simulator", "list_simulators")
+    end
+
+    def host(name_or_id)
+      by_name_or_id(Host, name_or_id, "Host", "list_hosts")
+    end
+
+    def host_group(name_or_id)
+      by_name_or_id(HostGroup, name_or_id, "HostGroup", "list_hosts")
+    end
+
+    def analyzer(simulator, name_or_id)
+      if BSON::ObjectId.legal?(name_or_id)
+        azr = Analyzer.find(name_or_id)
+        unless azr.simulator_id == simulator.id
+          raise ToolError.new("invalid_arguments",
+                              "Analyzer #{name_or_id} does not belong to simulator #{simulator.name}")
+        end
+        azr
+      else
+        simulator.find_analyzer_by_name(name_or_id)
+      end
+    rescue Mongoid::Errors::DocumentNotFound, RuntimeError => e
+      raise e if e.is_a?(ToolError)
+      raise ToolError.new("not_found", "Analyzer '#{name_or_id}' is not found",
+                          hint: "Call list_simulators to see the analyzers of each simulator.")
+    end
+
+    def parameter_set(id)
+      by_id(ParameterSet, id, "ParameterSet", "search_parameter_sets")
+    end
+
+    def run(id)
+      by_id(Run, id, "Run", "list_runs")
+    end
+
+    def analysis(id)
+      by_id(Analysis, id, "Analysis", "list_analyses")
+    end
+
+    def by_name_or_id(klass, name_or_id, label, list_tool)
+      if BSON::ObjectId.legal?(name_or_id)
+        klass.find(name_or_id)
+      else
+        klass.find_by_name(name_or_id)
+      end
+    rescue Mongoid::Errors::DocumentNotFound, RuntimeError
+      raise ToolError.new("not_found", "#{label} '#{name_or_id}' is not found",
+                          hint: "Call #{list_tool} to see available #{label.downcase}s.")
+    end
+
+    def by_id(klass, id, label, list_tool)
+      unless BSON::ObjectId.legal?(id)
+        raise ToolError.new("invalid_arguments",
+                            "'#{id}' is not a valid #{label} id (24-char hex string expected)")
+      end
+      klass.find(id)
+    rescue Mongoid::Errors::DocumentNotFound
+      raise ToolError.new("not_found", "#{label} #{id} is not found",
+                          hint: "Use #{list_tool} to find valid ids.")
+    end
+  end
+end

--- a/lib/mcp_server/serializers.rb
+++ b/lib/mcp_server/serializers.rb
@@ -1,0 +1,191 @@
+module McpServer
+
+  # Plain-hash JSON shapes shared by all tools.
+  # All ids are strings, symbols are strings, timestamps are ISO8601.
+  module Serializers
+
+    RESULT_JSON_LIMIT = 50_000  # bytes; larger results are elided from tool output
+
+    module_function
+
+    def simulator(sim, runs_status_count: nil)
+      {
+        "id" => sim.id.to_s,
+        "name" => sim.name,
+        "description" => sim.description,
+        "command" => sim.command,
+        "support_mpi" => sim.support_mpi,
+        "support_omp" => sim.support_omp,
+        "parameter_definitions" => sim.parameter_definitions.map {|pd| parameter_definition(pd) },
+        "executable_on" => sim.executable_on.map(&:name),
+        "analyzers" => sim.analyzers.map {|azr| analyzer(azr) },
+        "parameter_sets_count" => sim.parameter_sets.count,
+        "runs_status_count" => clean(runs_status_count || sim.runs_status_count)
+      }
+    end
+
+    def parameter_definition(pd)
+      h = {
+        "key" => pd.key,
+        "type" => pd.type,
+        "default" => clean(pd.default),
+        "description" => pd.description
+      }
+      h["options"] = pd.options_array if pd.type == "Selection"
+      h
+    end
+
+    def analyzer(azr)
+      {
+        "id" => azr.id.to_s,
+        "name" => azr.name,
+        "type" => azr.type.to_s,  # "on_run" or "on_parameter_set"
+        "description" => azr.description,
+        "command" => azr.command,
+        "auto_run" => azr.auto_run.to_s,
+        "files_to_copy" => azr.files_to_copy,
+        "support_mpi" => azr.support_mpi,
+        "support_omp" => azr.support_omp,
+        "parameter_definitions" => azr.parameter_definitions.map {|pd| parameter_definition(pd) },
+        "executable_on" => azr.executable_on.map(&:name)
+      }
+    end
+
+    def host(host)
+      {
+        "id" => host.id.to_s,
+        "name" => host.name,
+        "status" => host.status.to_s,
+        "max_num_jobs" => host.max_num_jobs,
+        "min_mpi_procs" => host.min_mpi_procs,
+        "max_mpi_procs" => host.max_mpi_procs,
+        "min_omp_threads" => host.min_omp_threads,
+        "max_omp_threads" => host.max_omp_threads,
+        "host_parameter_definitions" => host.host_parameter_definitions.map do |d|
+          { "key" => d.key, "default" => clean(d.default), "format" => d.format, "options" => d.options }
+        end,
+        "default_host_parameters" => clean(host.default_host_parameters)
+      }
+    end
+
+    def host_group(hg)
+      {
+        "id" => hg.id.to_s,
+        "name" => hg.name,
+        "hosts" => hg.hosts.map(&:name)
+      }
+    end
+
+    def parameter_set(ps, run_counts: nil)
+      h = {
+        "id" => ps.id.to_s,
+        "simulator" => ps.simulator.name,
+        "v" => clean(ps.v),
+        "created_at" => time(ps.created_at),
+        "updated_at" => time(ps.updated_at)
+      }
+      h["run_counts"] = clean(run_counts) if run_counts
+      h
+    end
+
+    def run(run, brief: false)
+      h = {
+        "id" => run.id.to_s,
+        "status" => run.status.to_s,
+        "priority" => run.priority,
+        "submitted_to" => run.submitted_to&.name,
+        "host_group" => run.host_group&.name,
+        "created_at" => time(run.created_at),
+        "updated_at" => time(run.updated_at)
+      }
+      h["error_present"] = true if brief && run.error_messages.present?
+      return h if brief
+      h.merge(
+        "parameter_set_id" => run.parameter_set_id.to_s,
+        "simulator" => run.simulator&.name,
+        "host_parameters" => clean(run.host_parameters),
+        "mpi_procs" => run.mpi_procs,
+        "omp_threads" => run.omp_threads,
+        "seed" => run.seed,
+        "job_id" => run.job_id,
+        "error_messages" => run.error_messages,
+        "hostname" => run.hostname,
+        "cpu_time" => run.cpu_time,
+        "real_time" => run.real_time,
+        "started_at" => time(run.started_at),
+        "finished_at" => time(run.finished_at),
+        "simulator_version" => run.simulator_version,
+        "result" => capped_result(run.result)
+      )
+    end
+
+    def analysis(anl, brief: false)
+      h = {
+        "id" => anl.id.to_s,
+        "analyzer" => anl.analyzer&.name,
+        "status" => anl.status.to_s,
+        "analyzable_type" => anl.analyzable_type,  # "Run" or "ParameterSet"
+        "analyzable_id" => anl.analyzable_id.to_s,
+        "parameters" => clean(anl.parameters),
+        "created_at" => time(anl.created_at),
+        "updated_at" => time(anl.updated_at)
+      }
+      return h if brief
+      h.merge(
+        "parameter_set_id" => anl.parameter_set_id.to_s,
+        "submitted_to" => anl.submitted_to&.name,
+        "host_group" => anl.host_group&.name,
+        "host_parameters" => clean(anl.host_parameters),
+        "mpi_procs" => anl.mpi_procs,
+        "omp_threads" => anl.omp_threads,
+        "priority" => anl.priority,
+        "job_id" => anl.job_id,
+        "error_messages" => anl.error_messages,
+        "hostname" => anl.hostname,
+        "cpu_time" => anl.cpu_time,
+        "real_time" => anl.real_time,
+        "started_at" => time(anl.started_at),
+        "finished_at" => time(anl.finished_at),
+        "analyzer_version" => anl.analyzer_version,
+        "result" => capped_result(anl.result)
+      )
+    end
+
+    def capped_result(result)
+      return nil if result.nil?
+      cleaned = clean(result)
+      json = JSON.generate(cleaned)
+      if json.bytesize > RESULT_JSON_LIMIT
+        {
+          "_truncated" => true,
+          "_note" => "result is #{json.bytesize} bytes of JSON (limit #{RESULT_JSON_LIMIT}); use list_result_files / read_result_file to inspect the raw output files.",
+          "_keys" => (cleaned.is_a?(Hash) ? cleaned.keys : nil)
+        }.compact
+      else
+        cleaned
+      end
+    end
+
+    def time(t)
+      t&.to_time&.utc&.iso8601
+    end
+
+    # Deep-converts BSON/Mongoid values into JSON-safe ones.
+    def clean(value)
+      case value
+      when Hash
+        value.each_with_object({}) {|(k, v), h| h[k.to_s] = clean(v) }
+      when Array
+        value.map {|v| clean(v) }
+      when BSON::ObjectId, Symbol
+        value.to_s
+      when Time, DateTime, Date
+        time(value)
+      when BigDecimal
+        value.to_f
+      else
+        value
+      end
+    end
+  end
+end

--- a/lib/mcp_server/server.rb
+++ b/lib/mcp_server/server.rb
@@ -1,0 +1,136 @@
+require 'json'
+require_relative 'errors'
+require_relative 'tool_registry'
+require_relative 'tools/simulator_tools'
+require_relative 'tools/host_tools'
+require_relative 'tools/parameter_set_tools'
+require_relative 'tools/run_tools'
+require_relative 'tools/analysis_tools'
+require_relative 'tools/file_tools'
+
+module McpServer
+
+  # A minimal MCP server: newline-delimited JSON-RPC 2.0 over stdio.
+  # Supports initialize / ping / tools/list / tools/call, which is the
+  # complete surface needed by MCP clients for a tools-only server.
+  class Server
+
+    PROTOCOL_VERSION = "2025-06-18"
+    SUPPORTED_PROTOCOL_VERSIONS = ["2025-06-18", "2025-03-26", "2024-11-05"].freeze
+
+    TOOL_MODULES = [
+      Tools::SimulatorTools,
+      Tools::HostTools,
+      Tools::ParameterSetTools,
+      Tools::RunTools,
+      Tools::AnalysisTools,
+      Tools::FileTools
+    ].freeze
+
+    def self.build_registry(**registry_options)
+      registry = ToolRegistry.new(**registry_options)
+      TOOL_MODULES.each {|mod| mod.register(registry) }
+      registry
+    end
+
+    def initialize(input:, output:, registry: nil, logger: nil)
+      @input = input
+      @output = output
+      @registry = registry || self.class.build_registry
+      @logger = logger
+    end
+
+    def run
+      @input.each_line do |line|
+        line = line.strip
+        next if line.empty?
+        handle_line(line)
+      end
+    end
+
+    def handle_line(line)
+      begin
+        message = JSON.parse(line)
+      rescue JSON::ParserError
+        write_error(nil, -32700, "Parse error")
+        return
+      end
+      # notifications (no id) require no response
+      return if message["id"].nil?
+      handle_request(message)
+    end
+
+    private
+    def handle_request(message)
+      id = message["id"]
+      params = message["params"] || {}
+      case message["method"]
+      when "initialize"
+        write_result(id, initialize_result(params))
+      when "ping"
+        write_result(id, {})
+      when "tools/list"
+        write_result(id, { "tools" => @registry.visible_tools })
+      when "tools/call"
+        write_result(id, call_tool(params))
+      else
+        write_error(id, -32601, "Method not found: #{message["method"]}")
+      end
+    rescue UnknownToolError, InvalidArgumentsError => e
+      write_error(id, -32602, e.message)
+    rescue => e
+      log_exception(e)
+      write_error(id, -32603, "Internal error: #{e.class}")
+    end
+
+    def initialize_result(params)
+      client_version = params["protocolVersion"]
+      version = SUPPORTED_PROTOCOL_VERSIONS.include?(client_version) ? client_version : PROTOCOL_VERSION
+      {
+        "protocolVersion" => version,
+        "capabilities" => { "tools" => {} },
+        "serverInfo" => { "name" => "oacis", "version" => oacis_version }
+      }
+    end
+
+    def call_tool(params)
+      payload = @registry.call(params["name"], params["arguments"])
+      tool_result(payload, is_error: false)
+    rescue UnknownToolError, InvalidArgumentsError
+      raise  # protocol-level: mapped to -32602 by the caller
+    rescue => e
+      tool_error = Errors.wrap(e)
+      log_exception(e) if tool_error.code == "internal_error"
+      tool_result(tool_error.to_h, is_error: true)
+    end
+
+    def tool_result(payload, is_error:)
+      {
+        "content" => [{ "type" => "text", "text" => JSON.pretty_generate(payload) }],
+        "isError" => is_error
+      }
+    end
+
+    def write_result(id, result)
+      write("jsonrpc" => "2.0", "id" => id, "result" => result)
+    end
+
+    def write_error(id, code, message)
+      write("jsonrpc" => "2.0", "id" => id, "error" => { "code" => code, "message" => message })
+    end
+
+    def write(hash)
+      @output.puts(JSON.generate(hash))
+      @output.flush
+    end
+
+    def oacis_version
+      defined?(::APP_VERSION) ? ::APP_VERSION.to_s.strip : ""
+    end
+
+    def log_exception(e)
+      return unless @logger
+      @logger.error("#{e.class}: #{e.message}\n  #{Array(e.backtrace).first(10).join("\n  ")}")
+    end
+  end
+end

--- a/lib/mcp_server/tool_registry.rb
+++ b/lib/mcp_server/tool_registry.rb
@@ -1,0 +1,83 @@
+require_relative 'errors'
+
+module McpServer
+
+  # Holds tool definitions (name -> schema + handler) and enforces
+  # write-permission gating and input validation.
+  class ToolRegistry
+
+    Tool = Struct.new(:name, :description, :input_schema, :write, :handler, keyword_init: true)
+
+    TYPE_CHECKS = {
+      "string"  => ->(v) { v.is_a?(String) },
+      "integer" => ->(v) { v.is_a?(Integer) },
+      "number"  => ->(v) { v.is_a?(Numeric) },
+      "boolean" => ->(v) { v == true || v == false },
+      "object"  => ->(v) { v.is_a?(Hash) },
+      "array"   => ->(v) { v.is_a?(Array) }
+    }.freeze
+
+    def initialize(access_level: OACIS_ACCESS_LEVEL, read_only: ENV['OACIS_MCP_READONLY'] == '1')
+      @tools = {}
+      @writable = access_level.to_i >= 1 && !read_only
+    end
+
+    def writable?
+      @writable
+    end
+
+    def register(name, description:, input_schema:, write: false, &handler)
+      @tools[name] = Tool.new(name: name, description: description,
+                              input_schema: input_schema, write: write, handler: handler)
+    end
+
+    # Tool list for tools/list. Write tools are hidden when not writable.
+    def visible_tools
+      @tools.values.reject {|t| t.write && !@writable }.map do |t|
+        { "name" => t.name, "description" => t.description, "inputSchema" => t.input_schema }
+      end
+    end
+
+    def call(name, arguments)
+      tool = @tools[name]
+      raise UnknownToolError, "Unknown tool: #{name}" unless tool
+      if tool.write && !@writable
+        raise ToolError.new("permission_denied",
+                            "Tool '#{name}' modifies data and is disabled on this server " \
+                            "(OACIS_ACCESS_LEVEL is 0 or OACIS_MCP_READONLY is set)")
+      end
+      arguments ||= {}
+      raise InvalidArgumentsError, "arguments must be an object" unless arguments.is_a?(Hash)
+      validate_arguments!(tool, arguments)
+      tool.handler.call(arguments)
+    end
+
+    private
+    def validate_arguments!(tool, args)
+      schema = tool.input_schema
+      properties = schema["properties"] || {}
+      required = schema["required"] || []
+
+      missing = required - args.keys
+      unless missing.empty?
+        raise InvalidArgumentsError, "#{tool.name}: missing required argument(s): #{missing.join(', ')}"
+      end
+      unknown = args.keys - properties.keys
+      unless unknown.empty?
+        raise InvalidArgumentsError,
+              "#{tool.name}: unknown argument(s): #{unknown.join(', ')} (accepted: #{properties.keys.join(', ')})"
+      end
+      args.each do |key, value|
+        prop = properties[key]
+        type_check = TYPE_CHECKS[prop["type"]]
+        if type_check && !type_check.call(value)
+          raise InvalidArgumentsError, "#{tool.name}: argument '#{key}' must be of type #{prop['type']}"
+        end
+        if prop["enum"] && !prop["enum"].include?(value)
+          raise InvalidArgumentsError,
+                "#{tool.name}: argument '#{key}' must be one of #{prop['enum'].join(', ')}"
+        end
+      end
+    end
+  end
+end

--- a/lib/mcp_server/tools/analysis_tools.rb
+++ b/lib/mcp_server/tools/analysis_tools.rb
@@ -1,0 +1,169 @@
+require_relative 'common'
+
+module McpServer
+  module Tools
+    module AnalysisTools
+      extend Common
+
+      def self.register(registry)
+        register_get(registry)
+        register_list(registry)
+        register_create(registry)
+      end
+
+      def self.register_get(registry)
+        registry.register(
+          "get_analysis",
+          description: "Get one analysis: status, analyzer, target (run or parameter set), parameters, " \
+                       "and the parsed result once finished. Use list_result_files/read_result_file " \
+                       "with analysis_id to inspect its raw output files.",
+          input_schema: {
+            "type" => "object",
+            "properties" => { "analysis_id" => { "type" => "string" } },
+            "required" => ["analysis_id"]
+          }
+        ) do |args|
+          Serializers.analysis(Resolvers.analysis(args["analysis_id"]))
+        end
+      end
+
+      def self.register_list(registry)
+        registry.register(
+          "list_analyses",
+          description: "List analyses on a run, on a parameter set (includes analyses on its runs), " \
+                       "or of a whole simulator (optionally restricted to one analyzer). " \
+                       "Filter by status to find failed or finished analyses.",
+          input_schema: {
+            "type" => "object",
+            "properties" => {
+              "run_id" => { "type" => "string" },
+              "parameter_set_id" => { "type" => "string" },
+              "simulator" => { "type" => "string", "description" => "Simulator name or id" },
+              "analyzer" => { "type" => "string", "description" => "Analyzer name or id (only with 'simulator')" },
+              "status" => { "type" => "string", "enum" => %w[created submitted running failed finished] }
+            }.merge(Common::PAGINATION_PROPERTIES),
+            "required" => []
+          }
+        ) do |args|
+          scope_key = exactly_one_of!(args.slice("run_id", "parameter_set_id", "simulator"),
+                                      "run_id", "parameter_set_id", "simulator")
+          query =
+            case scope_key
+            when "run_id"
+              Resolvers.run(args["run_id"]).analyses
+            when "parameter_set_id"
+              ps = Resolvers.parameter_set(args["parameter_set_id"])
+              Analysis.where(parameter_set_id: ps.id)
+            else
+              sim = Resolvers.simulator(args["simulator"])
+              if args["analyzer"]
+                Resolvers.analyzer(sim, args["analyzer"]).analyses
+              else
+                Analysis.in(analyzer_id: sim.analyzers.pluck(:id))
+              end
+            end
+          query = query.where(status: args["status"].to_sym) if args["status"]
+          limit, offset = pagination(args)
+          total = query.count
+          analyses = query.asc(:created_at).skip(offset).limit(limit).to_a
+          {
+            "total" => total,
+            "offset" => offset,
+            "analyses" => analyses.map {|a| Serializers.analysis(a, brief: true) }
+          }
+        end
+      end
+
+      def self.register_create(registry)
+        registry.register(
+          "create_analysis",
+          description: "Create an analysis by running an analyzer on a finished run (analyzer type 'on_run') " \
+                       "or on a parameter set with finished runs (type 'on_parameter_set'). Idempotent: if an " \
+                       "analysis with the same analyzer and parameters already exists on the target, it is " \
+                       "returned with created=false. Like runs, analyses start as 'created' and are executed " \
+                       "asynchronously by the background daemons — poll get_analysis. " \
+                       "Specify either a host or a host_group as destination.",
+          input_schema: {
+            "type" => "object",
+            "properties" => {
+              "analyzer" => { "type" => "string", "description" => "Analyzer name or id (see list_simulators)" },
+              "run_id" => { "type" => "string", "description" => "Target run (for analyzers of type on_run)" },
+              "parameter_set_id" => { "type" => "string", "description" => "Target parameter set (for analyzers of type on_parameter_set)" },
+              "parameters" => { "type" => "object", "description" => "Analyzer parameters; omitted keys use the analyzer's defaults" },
+              "host" => { "type" => "string", "description" => "Destination host name or id (give either this or host_group)" },
+              "host_group" => { "type" => "string", "description" => "Destination host group name or id" },
+              "host_parameters" => { "type" => "object", "description" => "Scheduler parameters; must match the host's host_parameter_definitions" },
+              "mpi_procs" => { "type" => "integer" },
+              "omp_threads" => { "type" => "integer" },
+              "priority" => { "type" => "integer", "enum" => [0, 1, 2], "description" => "0 = high, 1 = normal (default), 2 = low" }
+            },
+            "required" => ["analyzer"]
+          },
+          write: true
+        ) do |args|
+          target_key = exactly_one_of!(args.slice("run_id", "parameter_set_id"), "run_id", "parameter_set_id")
+          if target_key == "run_id"
+            target = Resolvers.run(args["run_id"])
+            simulator = target.simulator
+            expected_type = :on_run
+          else
+            target = Resolvers.parameter_set(args["parameter_set_id"])
+            simulator = target.simulator
+            expected_type = :on_parameter_set
+          end
+          analyzer = Resolvers.analyzer(simulator, args["analyzer"])
+          if analyzer.type != expected_type
+            other = expected_type == :on_run ? "parameter_set_id" : "run_id"
+            raise ToolError.new("invalid_arguments",
+                                "Analyzer '#{analyzer.name}' has type '#{analyzer.type}' — pass #{other} instead of #{target_key}")
+          end
+          check_target_finished!(target, expected_type)
+
+          defaults = analyzer.parameter_definitions.map {|pd| [pd.key, pd.default] }.to_h
+          merged = defaults.merge((args["parameters"] || {}).transform_keys(&:to_s))
+          parameters = cast_parameters!(analyzer, merged, analyzer.parameter_definitions)
+
+          existing = target.analyses.where(analyzer: analyzer, parameters: parameters).first
+          if existing
+            next Serializers.analysis(existing).merge("created" => false)
+          end
+
+          destination = exactly_one_of!(args.slice("host", "host_group"), "host", "host_group")
+          host = destination == "host" ? Resolvers.host(args["host"]) : nil
+          host_group = destination == "host_group" ? Resolvers.host_group(args["host_group"]) : nil
+
+          mpi_procs = args["mpi_procs"] || 1
+          omp_threads = args["omp_threads"] || 1
+          mpi_procs = 1 unless analyzer.support_mpi
+          omp_threads = 1 unless analyzer.support_omp
+
+          anl = target.analyses.build(
+            analyzer: analyzer,
+            parameters: parameters,
+            submitted_to: host,
+            host_group: host_group,
+            host_parameters: args["host_parameters"] || host&.default_host_parameters || {},
+            mpi_procs: mpi_procs,
+            omp_threads: omp_threads,
+            priority: args["priority"] || 1
+          )
+          anl.save!
+          Serializers.analysis(anl).merge("created" => true)
+        end
+      end
+
+      def self.check_target_finished!(target, expected_type)
+        if expected_type == :on_run && target.status != :finished
+          raise ToolError.new("invalid_state",
+                              "Run #{target.id} has status '#{target.status}'; analyses can only be created on finished runs",
+                              hint: "Poll get_run until status is 'finished'.")
+        end
+        if expected_type == :on_parameter_set && target.runs.where(status: :finished).count == 0
+          raise ToolError.new("invalid_state",
+                              "ParameterSet #{target.id} has no finished runs yet; on_parameter_set analyzers need at least one",
+                              hint: "Poll get_parameter_set until run_counts.finished > 0.")
+        end
+      end
+    end
+  end
+end

--- a/lib/mcp_server/tools/common.rb
+++ b/lib/mcp_server/tools/common.rb
@@ -1,0 +1,47 @@
+require_relative '../errors'
+require_relative '../resolvers'
+require_relative '../serializers'
+
+module McpServer
+  module Tools
+    module Common
+
+      DEFAULT_LIMIT = 25
+      MAX_LIMIT = 200
+
+      PAGINATION_PROPERTIES = {
+        "limit" => { "type" => "integer", "description" => "Max items to return (default #{DEFAULT_LIMIT}, max #{MAX_LIMIT})" },
+        "offset" => { "type" => "integer", "description" => "Number of items to skip (default 0)" }
+      }.freeze
+
+      def pagination(args)
+        limit = (args["limit"] || DEFAULT_LIMIT).clamp(1, MAX_LIMIT)
+        offset = [args["offset"].to_i, 0].max
+        [limit, offset]
+      end
+
+      # Requires that exactly one of the given keys is present in args.
+      def exactly_one_of!(args, *keys)
+        given = keys.select {|k| args.key?(k) }
+        unless given.size == 1
+          raise InvalidArgumentsError, "exactly one of #{keys.join(', ')} must be given"
+        end
+        given.first
+      end
+
+      # Casts user-given parameter values against embedded parameter definitions,
+      # raising a structured error listing every problem.
+      def cast_parameters!(owner, parameters, definitions)
+        errs = ActiveModel::Errors.new(owner)
+        casted = ParametersUtil.cast_parameter_values(parameters, definitions, errs)
+        if errs.any? || casted.nil?
+          raise ToolError.new("invalid_parameters", "Invalid parameter values",
+                              details: errs.full_messages,
+                              hint: "Expected keys: #{definitions.map(&:key).join(', ')}. " \
+                                    "See parameter_definitions from list_simulators.")
+        end
+        casted
+      end
+    end
+  end
+end

--- a/lib/mcp_server/tools/file_tools.rb
+++ b/lib/mcp_server/tools/file_tools.rb
@@ -1,0 +1,141 @@
+require_relative 'common'
+
+module McpServer
+  module Tools
+    module FileTools
+      extend Common
+
+      MAX_ENTRIES = 500
+      DEFAULT_READ_BYTES = 64_000
+      MAX_READ_BYTES = 256_000
+
+      def self.register(registry)
+        register_list(registry)
+        register_read(registry)
+      end
+
+      def self.register_list(registry)
+        registry.register(
+          "list_result_files",
+          description: "List the files in the result directory of a run or an analysis " \
+                       "(give exactly one of run_id / analysis_id). Pass relative_path to descend into a subdirectory.",
+          input_schema: {
+            "type" => "object",
+            "properties" => {
+              "run_id" => { "type" => "string" },
+              "analysis_id" => { "type" => "string" },
+              "relative_path" => { "type" => "string", "description" => "Subdirectory to list, relative to the result directory (default: the directory itself)" }
+            },
+            "required" => []
+          }
+        ) do |args|
+          base = result_dir(args)
+          dir = resolve_in_base(base, args["relative_path"] || ".")
+          unless dir.directory?
+            raise ToolError.new("invalid_arguments", "'#{args["relative_path"]}' is not a directory")
+          end
+          children = dir.children.sort
+          entries = children.first(MAX_ENTRIES).map do |child|
+            stat = child.stat
+            {
+              "path" => child.relative_path_from(base).to_s,
+              "directory" => stat.directory?,
+              "size" => stat.size,
+              "mtime" => stat.mtime.utc.iso8601
+            }
+          end
+          {
+            "base_dir" => base.to_s,
+            "entries" => entries,
+            "total" => children.size,
+            "truncated" => children.size > MAX_ENTRIES
+          }
+        end
+      end
+
+      def self.register_read(registry)
+        registry.register(
+          "read_result_file",
+          description: "Read a text file from the result directory of a run or an analysis " \
+                       "(give exactly one of run_id / analysis_id). Reads at most max_bytes " \
+                       "(default #{DEFAULT_READ_BYTES}, max #{MAX_READ_BYTES}) starting at offset_bytes; " \
+                       "when the response says truncated, call again with a larger offset_bytes to page through. " \
+                       "Binary files are rejected.",
+          input_schema: {
+            "type" => "object",
+            "properties" => {
+              "run_id" => { "type" => "string" },
+              "analysis_id" => { "type" => "string" },
+              "path" => { "type" => "string", "description" => "File path relative to the result directory, e.g. \"_stdout.txt\"" },
+              "offset_bytes" => { "type" => "integer" },
+              "max_bytes" => { "type" => "integer" }
+            },
+            "required" => ["path"]
+          }
+        ) do |args|
+          base = result_dir(args)
+          file = resolve_in_base(base, args["path"])
+          unless file.file?
+            raise ToolError.new("invalid_arguments", "'#{args["path"]}' is not a regular file")
+          end
+          offset = [args["offset_bytes"].to_i, 0].max
+          max_bytes = (args["max_bytes"] || DEFAULT_READ_BYTES).clamp(1, MAX_READ_BYTES)
+          size = file.size
+          data = file.open('rb') do |f|
+            f.seek(offset)
+            f.read(max_bytes) || ""
+          end
+          if data.include?("\x00")
+            raise ToolError.new("binary_file", "'#{args["path"]}' appears to be a binary file",
+                                hint: "Use list_result_files to see file sizes; only text files can be read with this tool.")
+          end
+          content = data.force_encoding(Encoding::UTF_8)
+          scrubbed = !content.valid_encoding?
+          content = content.scrub("�") if scrubbed
+          response = {
+            "path" => args["path"],
+            "size" => size,
+            "offset" => offset,
+            "bytes_read" => data.bytesize,
+            "truncated" => offset + data.bytesize < size,
+            "content" => content
+          }
+          response["encoding_scrubbed"] = true if scrubbed
+          response
+        end
+      end
+
+      def self.result_dir(args)
+        target_key = exactly_one_of!(args.slice("run_id", "analysis_id"), "run_id", "analysis_id")
+        target = target_key == "run_id" ? Resolvers.run(args["run_id"]) : Resolvers.analysis(args["analysis_id"])
+        target.dir
+      end
+
+      # Resolves rel against base and guarantees the result stays inside base,
+      # following symlinks (realpath), so neither "../" nor symlink escapes work.
+      def self.resolve_in_base(base, rel)
+        rel_path = Pathname.new(rel.to_s)
+        if rel_path.absolute? || rel_path.each_filename.include?("..")
+          raise ToolError.new("invalid_path", "'#{rel}' must be a relative path inside the result directory (no '..')")
+        end
+        base_real =
+          begin
+            base.realpath
+          rescue Errno::ENOENT
+            raise ToolError.new("not_found", "The result directory does not exist (no output has been produced yet)")
+          end
+        target_real =
+          begin
+            base_real.join(rel).realpath
+          rescue Errno::ENOENT
+            raise ToolError.new("not_found", "No such file or directory: '#{rel}'",
+                                hint: "Use list_result_files to see available files.")
+          end
+        unless target_real == base_real || target_real.to_s.start_with?(base_real.to_s + File::SEPARATOR)
+          raise ToolError.new("invalid_path", "'#{rel}' points outside the result directory")
+        end
+        target_real
+      end
+    end
+  end
+end

--- a/lib/mcp_server/tools/host_tools.rb
+++ b/lib/mcp_server/tools/host_tools.rb
@@ -1,0 +1,26 @@
+require_relative 'common'
+
+module McpServer
+  module Tools
+    module HostTools
+      extend Common
+
+      def self.register(registry)
+        registry.register(
+          "list_hosts",
+          description: "List the computation hosts and host groups jobs can be submitted to. " \
+                       "Each host lists its host_parameter_definitions: when creating runs or analyses, " \
+                       "host_parameters must include each key, matching its 'format' regexp (or one of 'options'). " \
+                       "mpi_procs/omp_threads must lie within the host's min/max. " \
+                       "A run needs either a host or a host_group as its destination.",
+          input_schema: { "type" => "object", "properties" => {} }
+        ) do |_args|
+          {
+            "hosts" => Host.asc(:position).map {|h| Serializers.host(h) },
+            "host_groups" => HostGroup.all.map {|hg| Serializers.host_group(hg) }
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/mcp_server/tools/parameter_set_tools.rb
+++ b/lib/mcp_server/tools/parameter_set_tools.rb
@@ -1,0 +1,133 @@
+require_relative 'common'
+
+module McpServer
+  module Tools
+    module ParameterSetTools
+      extend Common
+
+      RUNS_PREVIEW_LIMIT = 50
+
+      def self.register(registry)
+        register_search(registry)
+        register_get(registry)
+        register_find_or_create(registry)
+      end
+
+      def self.register_search(registry)
+        registry.register(
+          "search_parameter_sets",
+          description: "Search the parameter sets of a simulator, optionally filtering by exact parameter values " \
+                       "(a subset of keys is fine). Returns each parameter set with per-status run counts, " \
+                       "so this is also the cheapest way to poll the progress of many parameter sets at once.",
+          input_schema: {
+            "type" => "object",
+            "properties" => {
+              "simulator" => { "type" => "string", "description" => "Simulator name or id" },
+              "v" => { "type" => "object", "description" => "Exact-match filter on parameter values, e.g. {\"p1\": 1, \"p2\": 2.0}. Keys may be a subset of the parameter definitions." }
+            }.merge(Common::PAGINATION_PROPERTIES),
+            "required" => ["simulator"]
+          }
+        ) do |args|
+          sim = Resolvers.simulator(args["simulator"])
+          query = sim.parameter_sets
+          (args["v"] || {}).each do |key, value|
+            pd = sim.parameter_definition_for(key.to_s)
+            unless pd
+              raise ToolError.new("invalid_parameters", "Unknown parameter key '#{key}'",
+                                  hint: "Expected keys: #{sim.parameter_definitions.map(&:key).join(', ')}")
+            end
+            casted = ParametersUtil.cast_value(value, pd.type)
+            if casted.nil?
+              raise ToolError.new("invalid_parameters", "Value #{value.inspect} for '#{key}' cannot be cast to #{pd.type}")
+            end
+            query = query.where("v.#{key}" => casted)
+          end
+          limit, offset = pagination(args)
+          total = query.count
+          page = query.asc(:created_at).skip(offset).limit(limit).to_a
+          counts = ParameterSet.runs_status_count_batch(page)
+          {
+            "total" => total,
+            "offset" => offset,
+            "parameter_sets" => page.map {|ps| Serializers.parameter_set(ps, run_counts: counts[ps.id]) }
+          }
+        end
+      end
+
+      def self.register_get(registry)
+        registry.register(
+          "get_parameter_set",
+          description: "Get one parameter set with its run status counts, a preview of its runs and analyses, " \
+                       "and optionally the average of each numeric result over finished runs " \
+                       "(include_average_results). Poll this to track progress of the runs.",
+          input_schema: {
+            "type" => "object",
+            "properties" => {
+              "parameter_set_id" => { "type" => "string" },
+              "include_runs" => { "type" => "boolean", "description" => "Include a preview of runs (default true, first #{RUNS_PREVIEW_LIMIT})" },
+              "include_average_results" => { "type" => "boolean", "description" => "Include {result_key => {average, count, error}} over finished runs (default false)" }
+            },
+            "required" => ["parameter_set_id"]
+          }
+        ) do |args|
+          ps = Resolvers.parameter_set(args["parameter_set_id"])
+          counts = ParameterSet.runs_status_count_batch([ps])[ps.id]
+          h = Serializers.parameter_set(ps, run_counts: counts)
+          unless args["include_runs"] == false
+            runs = ps.runs.asc(:created_at).limit(RUNS_PREVIEW_LIMIT).to_a
+            h["runs"] = runs.map {|r| Serializers.run(r, brief: true) }
+            h["runs_truncated"] = true if counts.values.sum > runs.size
+          end
+          analyses = ps.analyses.asc(:created_at).limit(RUNS_PREVIEW_LIMIT).to_a
+          h["analyses"] = analyses.map {|a| Serializers.analysis(a, brief: true) }
+          if args["include_average_results"]
+            h["average_results"] = average_results(ps)
+          end
+          h
+        end
+      end
+
+      def self.register_find_or_create(registry)
+        registry.register(
+          "find_or_create_parameter_set",
+          description: "Find or create a parameter set of a simulator (idempotent). Give the parameter values in 'v'; " \
+                       "omitted keys are filled with the simulator's defaults. Returns the parameter set and " \
+                       "whether it was newly created. Creating a parameter set does not run anything — " \
+                       "call create_runs on it afterwards.",
+          input_schema: {
+            "type" => "object",
+            "properties" => {
+              "simulator" => { "type" => "string", "description" => "Simulator name or id" },
+              "v" => { "type" => "object", "description" => "Parameter values, e.g. {\"p1\": 1, \"p2\": 2.0}" }
+            },
+            "required" => ["simulator", "v"]
+          },
+          write: true
+        ) do |args|
+          sim = Resolvers.simulator(args["simulator"])
+          merged = sim.default_parameters.merge(args["v"])
+          casted = cast_parameters!(sim, merged, sim.parameter_definitions)
+          existing = sim.find_parameter_set(casted)
+          if existing
+            counts = ParameterSet.runs_status_count_batch([existing])[existing.id]
+            Serializers.parameter_set(existing, run_counts: counts).merge("created" => false)
+          else
+            ps = sim.parameter_sets.create!(v: casted)
+            Serializers.parameter_set(ps).merge("created" => true)
+          end
+        end
+      end
+
+      def self.average_results(ps)
+        first_finished = ps.runs.where(status: :finished).first
+        result = first_finished&.result
+        return {} unless result.is_a?(Hash)
+        numeric_keys = result.select {|_k, v| v.is_a?(Numeric) }.keys
+        numeric_keys.each_with_object({}) do |key, h|
+          average, count, error = ps.average_result(key, error: true)
+          h[key] = { "average" => average, "count" => count, "error" => error }
+        end
+      end
+    end
+  end
+end

--- a/lib/mcp_server/tools/run_tools.rb
+++ b/lib/mcp_server/tools/run_tools.rb
@@ -1,0 +1,137 @@
+require_relative 'common'
+
+module McpServer
+  module Tools
+    module RunTools
+      extend Common
+
+      MAX_NUM_RUNS_PER_CALL = 100
+
+      def self.register(registry)
+        register_get(registry)
+        register_list(registry)
+        register_create(registry)
+      end
+
+      def self.register_get(registry)
+        registry.register(
+          "get_run",
+          description: "Get one run: status, destination host, host parameters, seed, timings, error messages, " \
+                       "and the parsed result values once finished. Use list_result_files/read_result_file " \
+                       "to inspect its raw output files.",
+          input_schema: {
+            "type" => "object",
+            "properties" => { "run_id" => { "type" => "string" } },
+            "required" => ["run_id"]
+          }
+        ) do |args|
+          run = Resolvers.run(args["run_id"])
+          Serializers.run(run).merge("v" => Serializers.clean(run.parameter_set.v))
+        end
+      end
+
+      def self.register_list(registry)
+        registry.register(
+          "list_runs",
+          description: "List runs of a parameter set or of a whole simulator, optionally filtered by status. " \
+                       "Useful to find failed runs (status: failed) or count progress.",
+          input_schema: {
+            "type" => "object",
+            "properties" => {
+              "parameter_set_id" => { "type" => "string" },
+              "simulator" => { "type" => "string", "description" => "Simulator name or id (alternative to parameter_set_id)" },
+              "status" => { "type" => "string", "enum" => %w[created submitted running failed finished] }
+            }.merge(Common::PAGINATION_PROPERTIES),
+            "required" => []
+          }
+        ) do |args|
+          scope_key = exactly_one_of!(args.slice("parameter_set_id", "simulator"), "parameter_set_id", "simulator")
+          query =
+            if scope_key == "parameter_set_id"
+              Resolvers.parameter_set(args["parameter_set_id"]).runs
+            else
+              Resolvers.simulator(args["simulator"]).runs
+            end
+          query = query.where(status: args["status"].to_sym) if args["status"]
+          limit, offset = pagination(args)
+          total = query.count
+          runs = query.asc(:created_at).skip(offset).limit(limit).to_a
+          {
+            "total" => total,
+            "offset" => offset,
+            "runs" => runs.map {|r| Serializers.run(r, brief: true).merge("parameter_set_id" => r.parameter_set_id.to_s) }
+          }
+        end
+      end
+
+      def self.register_create(registry)
+        registry.register(
+          "create_runs",
+          description: "Ensure a parameter set has num_runs runs (idempotent 'up to' semantics: existing runs count " \
+                       "toward the total and only the shortfall is created). New runs start with status 'created' " \
+                       "and are submitted asynchronously by OACIS's background daemons via SSH — expect a delay; " \
+                       "poll get_parameter_set or list_runs every ~30-60 seconds rather than immediately. " \
+                       "Specify either a host or a host_group as destination. host_parameters defaults to the " \
+                       "host's default values (see list_hosts).",
+          input_schema: {
+            "type" => "object",
+            "properties" => {
+              "parameter_set_id" => { "type" => "string" },
+              "num_runs" => { "type" => "integer", "description" => "Desired total number of runs on this parameter set (1-#{MAX_NUM_RUNS_PER_CALL})" },
+              "host" => { "type" => "string", "description" => "Destination host name or id (give either this or host_group)" },
+              "host_group" => { "type" => "string", "description" => "Destination host group name or id" },
+              "host_parameters" => { "type" => "object", "description" => "Scheduler parameters, e.g. {\"ppn\": \"4\", \"walltime\": \"1:00:00\"}; must match the host's host_parameter_definitions" },
+              "mpi_procs" => { "type" => "integer" },
+              "omp_threads" => { "type" => "integer" },
+              "priority" => { "type" => "integer", "enum" => [0, 1, 2], "description" => "0 = high, 1 = normal (default), 2 = low" }
+            },
+            "required" => ["parameter_set_id", "num_runs"]
+          },
+          write: true
+        ) do |args|
+          ps = Resolvers.parameter_set(args["parameter_set_id"])
+          num_runs = args["num_runs"]
+          unless (1..MAX_NUM_RUNS_PER_CALL).cover?(num_runs)
+            raise InvalidArgumentsError, "num_runs must be between 1 and #{MAX_NUM_RUNS_PER_CALL}"
+          end
+          destination = exactly_one_of!(args.slice("host", "host_group"), "host", "host_group")
+          host = destination == "host" ? Resolvers.host(args["host"]) : nil
+          host_group = destination == "host_group" ? Resolvers.host_group(args["host_group"]) : nil
+
+          sim = ps.simulator
+          mpi_procs = args["mpi_procs"] || 1
+          omp_threads = args["omp_threads"] || 1
+          clamped = []
+          if !sim.support_mpi && mpi_procs != 1
+            mpi_procs = 1
+            clamped << "mpi_procs clamped to 1 (simulator does not support MPI)"
+          end
+          if !sim.support_omp && omp_threads != 1
+            omp_threads = 1
+            clamped << "omp_threads clamped to 1 (simulator does not support OpenMP)"
+          end
+
+          num_before = ps.runs.count
+          runs = ps.find_or_create_runs_upto(num_runs,
+                                             submitted_to: host,
+                                             host_param: args["host_parameters"],
+                                             host_group: host_group,
+                                             mpi_procs: mpi_procs,
+                                             omp_threads: omp_threads,
+                                             priority: args["priority"] || 1)
+          created_count = runs.size - [num_before, num_runs].min
+          found_count = runs.size - created_count
+          response = {
+            "runs" => runs.each_with_index.map do |r, i|
+              Serializers.run(r, brief: true).merge("created" => i >= found_count)
+            end,
+            "created_count" => created_count,
+            "total_runs_now" => ps.runs.count
+          }
+          response["notes"] = clamped unless clamped.empty?
+          response
+        end
+      end
+    end
+  end
+end

--- a/lib/mcp_server/tools/simulator_tools.rb
+++ b/lib/mcp_server/tools/simulator_tools.rb
@@ -1,0 +1,35 @@
+require_relative 'common'
+
+module McpServer
+  module Tools
+    module SimulatorTools
+      extend Common
+
+      def self.register(registry)
+        registry.register(
+          "list_simulators",
+          description: "List the simulators registered on OACIS, with their parameter definitions " \
+                       "(key, type, default), analyzers, executable hosts, and run status counts. " \
+                       "Call this first to learn what can be simulated and which parameters a simulator takes.",
+          input_schema: {
+            "type" => "object",
+            "properties" => {
+              "name_contains" => { "type" => "string", "description" => "Filter simulators whose name contains this substring (case-insensitive)" }
+            }
+          }
+        ) do |args|
+          sims = Simulator.asc(:position).to_a
+          if args["name_contains"]
+            pattern = Regexp.new(Regexp.escape(args["name_contains"]), Regexp::IGNORECASE)
+            sims = sims.select {|s| s.name =~ pattern }
+          end
+          counts = Simulator.runs_status_count_batch(sims)
+          {
+            "total" => sims.size,
+            "simulators" => sims.map {|s| Serializers.simulator(s, runs_status_count: counts[s.id]) }
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/mcp_server/file_tools_spec.rb
+++ b/spec/lib/mcp_server/file_tools_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper'
+require Rails.root.join('lib/mcp_server/server')
+
+describe "McpServer file tools" do
+
+  let(:registry) { McpServer::Server.build_registry(access_level: 2, read_only: false) }
+
+  before(:each) do
+    sim = FactoryBot.create(:simulator, parameter_sets_count: 1, runs_count: 1, analyzers_count: 0)
+    @run = sim.parameter_sets.first.runs.first
+    File.write(@run.dir.join("_stdout.txt"), "hello\nworld\n")
+    FileUtils.mkdir_p(@run.dir.join("data"))
+    File.write(@run.dir.join("data", "series.csv"), "1,2\n3,4\n")
+  end
+
+  describe "list_result_files" do
+    it "lists files and directories with metadata" do
+      result = registry.call("list_result_files", {"run_id" => @run.id.to_s})
+      paths = result["entries"].map {|e| e["path"] }
+      expect(paths).to include("_stdout.txt", "data")
+      stdout_entry = result["entries"].detect {|e| e["path"] == "_stdout.txt" }
+      expect(stdout_entry["directory"]).to be false
+      expect(stdout_entry["size"]).to eq 12
+      expect(result["truncated"]).to be false
+    end
+
+    it "descends into subdirectories via relative_path" do
+      result = registry.call("list_result_files", {"run_id" => @run.id.to_s, "relative_path" => "data"})
+      expect(result["entries"].map {|e| e["path"] }).to eq ["data/series.csv"]
+    end
+
+    it "requires exactly one of run_id and analysis_id" do
+      expect { registry.call("list_result_files", {}) }.to raise_error(McpServer::InvalidArgumentsError)
+    end
+  end
+
+  describe "read_result_file" do
+    it "reads a text file" do
+      result = registry.call("read_result_file", {"run_id" => @run.id.to_s, "path" => "_stdout.txt"})
+      expect(result["content"]).to eq "hello\nworld\n"
+      expect(result["truncated"]).to be false
+      expect(result["size"]).to eq 12
+    end
+
+    it "pages through a file with offset_bytes and max_bytes" do
+      first = registry.call("read_result_file",
+                            {"run_id" => @run.id.to_s, "path" => "_stdout.txt", "max_bytes" => 6})
+      expect(first["content"]).to eq "hello\n"
+      expect(first["truncated"]).to be true
+      rest = registry.call("read_result_file",
+                           {"run_id" => @run.id.to_s, "path" => "_stdout.txt", "offset_bytes" => 6})
+      expect(rest["content"]).to eq "world\n"
+      expect(rest["truncated"]).to be false
+    end
+
+    it "rejects binary files" do
+      File.binwrite(@run.dir.join("blob.bin"), "\x00\x01\x02")
+      expect {
+        registry.call("read_result_file", {"run_id" => @run.id.to_s, "path" => "blob.bin"})
+      }.to raise_error(McpServer::ToolError) {|e| expect(e.code).to eq "binary_file" }
+    end
+
+    it "raises not_found for a missing file" do
+      expect {
+        registry.call("read_result_file", {"run_id" => @run.id.to_s, "path" => "nope.txt"})
+      }.to raise_error(McpServer::ToolError) {|e| expect(e.code).to eq "not_found" }
+    end
+  end
+
+  describe "path traversal protection" do
+    it "rejects ../ escapes" do
+      # the parent (parameter set) directory exists, so realpath succeeds and the guard must catch it
+      expect {
+        registry.call("list_result_files", {"run_id" => @run.id.to_s, "relative_path" => ".."})
+      }.to raise_error(McpServer::ToolError) {|e| expect(e.code).to eq "invalid_path" }
+      expect {
+        registry.call("read_result_file", {"run_id" => @run.id.to_s, "path" => "../../../../etc/hosts"})
+      }.to raise_error(McpServer::ToolError) {|e| expect(e.code).to eq "invalid_path" }
+    end
+
+    it "rejects absolute paths outside the result directory" do
+      expect {
+        registry.call("read_result_file", {"run_id" => @run.id.to_s, "path" => "/etc/hosts"})
+      }.to raise_error(McpServer::ToolError) {|e| expect(e.code).to eq "invalid_path" }
+    end
+
+    it "rejects symlinks pointing outside the result directory" do
+      File.symlink("/etc", @run.dir.join("escape"))
+      expect {
+        registry.call("list_result_files", {"run_id" => @run.id.to_s, "relative_path" => "escape"})
+      }.to raise_error(McpServer::ToolError) {|e| expect(e.code).to eq "invalid_path" }
+      File.symlink("/etc/hosts", @run.dir.join("escape_file"))
+      expect {
+        registry.call("read_result_file", {"run_id" => @run.id.to_s, "path" => "escape_file"})
+      }.to raise_error(McpServer::ToolError) {|e| expect(e.code).to eq "invalid_path" }
+    end
+
+    it "allows symlinks that stay inside the result directory" do
+      File.symlink(@run.dir.join("_stdout.txt"), @run.dir.join("alias.txt"))
+      result = registry.call("read_result_file", {"run_id" => @run.id.to_s, "path" => "alias.txt"})
+      expect(result["content"]).to eq "hello\nworld\n"
+    end
+  end
+end

--- a/spec/lib/mcp_server/read_tools_spec.rb
+++ b/spec/lib/mcp_server/read_tools_spec.rb
@@ -1,0 +1,219 @@
+require 'spec_helper'
+require Rails.root.join('lib/mcp_server/server')
+
+describe "McpServer read tools" do
+
+  let(:registry) { McpServer::Server.build_registry(access_level: 2, read_only: false) }
+
+  describe "list_simulators" do
+    before(:each) do
+      @sim = FactoryBot.create(:simulator, parameter_sets_count: 1, runs_count: 2, analyzers_count: 1, run_analysis: false)
+    end
+
+    it "returns simulators with parameter definitions, analyzers, and run status counts" do
+      result = registry.call("list_simulators", {})
+      expect(result["total"]).to eq 1
+      sim = result["simulators"].first
+      expect(sim["name"]).to eq @sim.name
+      expect(sim["parameter_definitions"].map {|pd| pd["key"] }).to eq ["L", "T"]
+      expect(sim["parameter_definitions"].first).to include("type" => "Integer", "default" => 50)
+      expect(sim["analyzers"].size).to eq 1
+      expect(sim["executable_on"]).to be_present
+      expect(sim["runs_status_count"]).to include("created" => 2, "finished" => 0)
+    end
+
+    it "filters by name_contains" do
+      result = registry.call("list_simulators", {"name_contains" => "no_such_simulator"})
+      expect(result["total"]).to eq 0
+    end
+  end
+
+  describe "list_hosts" do
+    before(:each) do
+      @host = FactoryBot.create(:host_with_parameters)
+      @host_group = FactoryBot.create(:host_group)
+    end
+
+    it "returns hosts with host parameter definitions and host groups" do
+      result = registry.call("list_hosts", {})
+      host = result["hosts"].detect {|h| h["name"] == @host.name }
+      expect(host["host_parameter_definitions"].map {|d| d["key"] }).to eq ["param1", "param2"]
+      expect(host["default_host_parameters"]).to eq({"param1" => nil, "param2" => "XXX"})
+      expect(host).to include("min_mpi_procs", "max_mpi_procs", "max_num_jobs")
+      hg = result["host_groups"].detect {|h| h["name"] == @host_group.name }
+      expect(hg["hosts"]).to eq @host_group.hosts.map(&:name)
+    end
+  end
+
+  describe "search_parameter_sets" do
+    before(:each) do
+      @sim = FactoryBot.create(:simulator, parameter_sets_count: 3, runs_count: 1, analyzers_count: 0)
+    end
+
+    it "returns all parameter sets of the simulator with run counts" do
+      result = registry.call("search_parameter_sets", {"simulator" => @sim.name})
+      expect(result["total"]).to eq 3
+      ps = result["parameter_sets"].first
+      expect(ps["v"]).to be_a Hash
+      expect(ps["run_counts"]).to include("created" => 1)
+    end
+
+    it "filters by a subset of parameter values, casting types" do
+      target = @sim.parameter_sets.first
+      result = registry.call("search_parameter_sets",
+                             {"simulator" => @sim.name, "v" => {"L" => target.v["L"].to_s}})
+      expect(result["total"]).to eq 1
+      expect(result["parameter_sets"].first["id"]).to eq target.id.to_s
+    end
+
+    it "paginates" do
+      result = registry.call("search_parameter_sets", {"simulator" => @sim.name, "limit" => 2, "offset" => 2})
+      expect(result["total"]).to eq 3
+      expect(result["parameter_sets"].size).to eq 1
+    end
+
+    it "rejects unknown parameter keys" do
+      expect {
+        registry.call("search_parameter_sets", {"simulator" => @sim.name, "v" => {"bogus" => 1}})
+      }.to raise_error(McpServer::ToolError) {|e| expect(e.code).to eq "invalid_parameters" }
+    end
+
+    it "raises not_found for an unknown simulator" do
+      expect {
+        registry.call("search_parameter_sets", {"simulator" => "no_such_sim"})
+      }.to raise_error(McpServer::ToolError) {|e| expect(e.code).to eq "not_found" }
+    end
+  end
+
+  describe "get_parameter_set" do
+    before(:each) do
+      @sim = FactoryBot.create(:simulator, parameter_sets_count: 1, runs_count: 1, analyzers_count: 0)
+      @ps = @sim.parameter_sets.first
+      FactoryBot.create_list(:finished_run, 2, parameter_set: @ps)
+    end
+
+    it "returns the parameter set with run counts and a run preview" do
+      result = registry.call("get_parameter_set", {"parameter_set_id" => @ps.id.to_s})
+      expect(result["id"]).to eq @ps.id.to_s
+      expect(result["run_counts"]).to include("created" => 1, "finished" => 2)
+      expect(result["runs"].size).to eq 3
+      expect(result["runs"].first).to include("id", "status")
+    end
+
+    it "omits runs when include_runs is false" do
+      result = registry.call("get_parameter_set", {"parameter_set_id" => @ps.id.to_s, "include_runs" => false})
+      expect(result).not_to have_key("runs")
+    end
+
+    it "computes average results over finished runs when requested" do
+      result = registry.call("get_parameter_set",
+                             {"parameter_set_id" => @ps.id.to_s, "include_average_results" => true})
+      expect(result["average_results"].keys).to match_array ["Energy", "Flow"]
+      expect(result["average_results"]["Energy"]["count"]).to eq 2
+      expect(result["average_results"]["Energy"]["average"]).to be_a Float
+    end
+  end
+
+  describe "get_run" do
+    before(:each) do
+      sim = FactoryBot.create(:simulator, parameter_sets_count: 1, runs_count: 0, analyzers_count: 0)
+      @ps = sim.parameter_sets.first
+      @run = FactoryBot.create(:finished_run, parameter_set: @ps)
+    end
+
+    it "returns the full run including result and parameters" do
+      result = registry.call("get_run", {"run_id" => @run.id.to_s})
+      expect(result).to include(
+        "id" => @run.id.to_s,
+        "status" => "finished",
+        "parameter_set_id" => @ps.id.to_s
+      )
+      expect(result["result"].keys).to match_array ["Energy", "Flow"]
+      expect(result["v"]).to eq @ps.v
+      expect(result["submitted_to"]).to eq @run.submitted_to.name
+    end
+
+    it "raises not_found for a nonexistent id" do
+      expect {
+        registry.call("get_run", {"run_id" => "0" * 24})
+      }.to raise_error(McpServer::ToolError) {|e| expect(e.code).to eq "not_found" }
+    end
+
+    it "rejects a malformed id" do
+      expect {
+        registry.call("get_run", {"run_id" => "not-an-id"})
+      }.to raise_error(McpServer::ToolError) {|e| expect(e.code).to eq "invalid_arguments" }
+    end
+  end
+
+  describe "list_runs" do
+    before(:each) do
+      @sim = FactoryBot.create(:simulator, parameter_sets_count: 2, runs_count: 2, analyzers_count: 0)
+      @ps = @sim.parameter_sets.first
+      FactoryBot.create(:finished_run, parameter_set: @ps)
+    end
+
+    it "lists runs of a parameter set" do
+      result = registry.call("list_runs", {"parameter_set_id" => @ps.id.to_s})
+      expect(result["total"]).to eq 3
+    end
+
+    it "filters by status" do
+      result = registry.call("list_runs", {"parameter_set_id" => @ps.id.to_s, "status" => "finished"})
+      expect(result["total"]).to eq 1
+      expect(result["runs"].first["status"]).to eq "finished"
+    end
+
+    it "lists runs across a whole simulator" do
+      result = registry.call("list_runs", {"simulator" => @sim.name})
+      expect(result["total"]).to eq 5
+    end
+
+    it "requires exactly one scope" do
+      expect {
+        registry.call("list_runs", {})
+      }.to raise_error(McpServer::InvalidArgumentsError)
+      expect {
+        registry.call("list_runs", {"simulator" => @sim.name, "parameter_set_id" => @ps.id.to_s})
+      }.to raise_error(McpServer::InvalidArgumentsError)
+    end
+  end
+
+  describe "get_analysis / list_analyses" do
+    before(:each) do
+      @sim = FactoryBot.create(:simulator, parameter_sets_count: 1, runs_count: 1, analyzers_count: 1, run_analysis: true)
+      @ps = @sim.parameter_sets.first
+      @run = @ps.runs.first
+      @analysis = @run.analyses.first
+    end
+
+    it "gets one analysis with its target and result" do
+      result = registry.call("get_analysis", {"analysis_id" => @analysis.id.to_s})
+      expect(result).to include(
+        "id" => @analysis.id.to_s,
+        "analyzable_type" => "Run",
+        "analyzable_id" => @run.id.to_s,
+        "analyzer" => @analysis.analyzer.name
+      )
+      expect(result["result"]).to be_a Hash
+    end
+
+    it "lists analyses on a run" do
+      result = registry.call("list_analyses", {"run_id" => @run.id.to_s})
+      expect(result["total"]).to eq 1
+    end
+
+    it "lists analyses under a parameter set" do
+      result = registry.call("list_analyses", {"parameter_set_id" => @ps.id.to_s})
+      expect(result["total"]).to eq 1
+    end
+
+    it "lists analyses of a simulator filtered by analyzer" do
+      azr = @analysis.analyzer
+      result = registry.call("list_analyses", {"simulator" => @sim.name, "analyzer" => azr.name})
+      expect(result["total"]).to eq 1
+      result = registry.call("list_analyses", {"simulator" => @sim.name, "analyzer" => azr.name, "status" => "created"})
+      expect(result["total"]).to eq 0
+    end
+  end
+end

--- a/spec/lib/mcp_server/server_spec.rb
+++ b/spec/lib/mcp_server/server_spec.rb
@@ -1,0 +1,126 @@
+require 'spec_helper'
+require Rails.root.join('lib/mcp_server/server')
+
+describe McpServer::Server do
+
+  def run_server(requests, access_level: 2)
+    input = StringIO.new(requests.map {|r| JSON.generate(r) }.join("\n") + "\n")
+    output = StringIO.new
+    registry = McpServer::Server.build_registry(access_level: access_level, read_only: false)
+    McpServer::Server.new(input: input, output: output, registry: registry).run
+    output.string.each_line.map {|line| JSON.parse(line) }
+  end
+
+  def request(id, method, params = {})
+    { "jsonrpc" => "2.0", "id" => id, "method" => method, "params" => params }
+  end
+
+  it "answers the initialize handshake with server info and tools capability" do
+    responses = run_server([request(1, "initialize", {"protocolVersion" => "2025-06-18"})])
+    result = responses.first["result"]
+    expect(result["protocolVersion"]).to eq "2025-06-18"
+    expect(result["capabilities"]).to have_key "tools"
+    expect(result["serverInfo"]["name"]).to eq "oacis"
+  end
+
+  it "answers ping" do
+    responses = run_server([request(1, "ping")])
+    expect(responses.first["result"]).to eq({})
+  end
+
+  it "lists all 13 tools at full access level" do
+    responses = run_server([request(1, "tools/list")])
+    tools = responses.first["result"]["tools"]
+    expect(tools.size).to eq 13
+    expect(tools.first).to include("name", "description", "inputSchema")
+  end
+
+  it "hides the 3 write tools at access level 0" do
+    responses = run_server([request(1, "tools/list")], access_level: 0)
+    tools = responses.first["result"]["tools"]
+    expect(tools.size).to eq 10
+    expect(tools.map {|t| t["name"] }).not_to include("create_runs", "find_or_create_parameter_set", "create_analysis")
+  end
+
+  it "executes a tool call and returns its payload as text content" do
+    FactoryBot.create(:host)
+    responses = run_server([request(1, "tools/call", {"name" => "list_hosts", "arguments" => {}})])
+    result = responses.first["result"]
+    expect(result["isError"]).to be false
+    payload = JSON.parse(result["content"].first["text"])
+    expect(payload["hosts"].size).to eq 1
+  end
+
+  it "returns a structured isError result when a tool fails" do
+    responses = run_server([request(1, "tools/call",
+                                    {"name" => "get_run", "arguments" => {"run_id" => "0" * 24}})])
+    result = responses.first["result"]
+    expect(result["isError"]).to be true
+    payload = JSON.parse(result["content"].first["text"])
+    expect(payload["error"]).to eq "not_found"
+    expect(payload).to have_key "hint"
+  end
+
+  it "returns a permission_denied tool error for write tools at access level 0" do
+    responses = run_server([request(1, "tools/call",
+                                    {"name" => "create_runs",
+                                     "arguments" => {"parameter_set_id" => "0" * 24, "num_runs" => 1}})],
+                           access_level: 0)
+    result = responses.first["result"]
+    expect(result["isError"]).to be true
+    payload = JSON.parse(result["content"].first["text"])
+    expect(payload["error"]).to eq "permission_denied"
+  end
+
+  it "maps unknown tools and invalid arguments to JSON-RPC -32602" do
+    responses = run_server([
+      request(1, "tools/call", {"name" => "no_such_tool", "arguments" => {}}),
+      request(2, "tools/call", {"name" => "get_run", "arguments" => {}})
+    ])
+    expect(responses[0]["error"]["code"]).to eq(-32602)
+    expect(responses[1]["error"]["code"]).to eq(-32602)
+    expect(responses[1]["error"]["message"]).to match(/missing required/)
+  end
+
+  it "maps unknown methods to -32601" do
+    responses = run_server([request(1, "resources/list")])
+    expect(responses.first["error"]["code"]).to eq(-32601)
+  end
+
+  it "maps malformed JSON to -32700 and keeps serving" do
+    input = StringIO.new("this is not json\n" + JSON.generate(request(2, "ping")) + "\n")
+    output = StringIO.new
+    registry = McpServer::Server.build_registry(access_level: 2, read_only: false)
+    McpServer::Server.new(input: input, output: output, registry: registry).run
+    responses = output.string.each_line.map {|line| JSON.parse(line) }
+    expect(responses[0]["error"]["code"]).to eq(-32700)
+    expect(responses[1]["result"]).to eq({})
+  end
+
+  it "ignores notifications (messages without an id)" do
+    responses = run_server([
+      { "jsonrpc" => "2.0", "method" => "notifications/initialized" },
+      request(1, "ping")
+    ])
+    expect(responses.size).to eq 1
+    expect(responses.first["id"]).to eq 1
+  end
+
+  it "survives a handler exception and reports it as a tool error" do
+    registry = McpServer::Server.build_registry(access_level: 2, read_only: false)
+    registry.register("boom", description: "raises", input_schema: {"type" => "object", "properties" => {}}) do
+      raise "kaboom"
+    end
+    input = StringIO.new(
+      JSON.generate(request(1, "tools/call", {"name" => "boom", "arguments" => {}})) + "\n" +
+      JSON.generate(request(2, "ping")) + "\n"
+    )
+    output = StringIO.new
+    McpServer::Server.new(input: input, output: output, registry: registry).run
+    responses = output.string.each_line.map {|line| JSON.parse(line) }
+    expect(responses[0]["result"]["isError"]).to be true
+    payload = JSON.parse(responses[0]["result"]["content"].first["text"])
+    expect(payload["error"]).to eq "internal_error"
+    expect(responses[1]["result"]).to eq({})
+  end
+end

--- a/spec/lib/mcp_server/tool_registry_spec.rb
+++ b/spec/lib/mcp_server/tool_registry_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+require Rails.root.join('lib/mcp_server/tool_registry')
+
+describe McpServer::ToolRegistry do
+
+  def build_registry(access_level: 2, read_only: false)
+    registry = McpServer::ToolRegistry.new(access_level: access_level, read_only: read_only)
+    registry.register("read_tool",
+                      description: "a read tool",
+                      input_schema: {
+                        "type" => "object",
+                        "properties" => {
+                          "name" => { "type" => "string" },
+                          "count" => { "type" => "integer" },
+                          "status" => { "type" => "string", "enum" => ["a", "b"] }
+                        },
+                        "required" => ["name"]
+                      }) {|args| { "echo" => args } }
+    registry.register("write_tool",
+                      description: "a write tool",
+                      input_schema: { "type" => "object", "properties" => {} },
+                      write: true) {|_args| { "wrote" => true } }
+    registry
+  end
+
+  describe "#visible_tools" do
+    it "lists all tools with name, description, and inputSchema" do
+      tools = build_registry.visible_tools
+      expect(tools.map {|t| t["name"] }).to match_array ["read_tool", "write_tool"]
+      expect(tools.first).to include("description", "inputSchema")
+    end
+
+    it "hides write tools when access level is 0" do
+      tools = build_registry(access_level: 0).visible_tools
+      expect(tools.map {|t| t["name"] }).to eq ["read_tool"]
+    end
+
+    it "hides write tools in read-only mode regardless of access level" do
+      tools = build_registry(access_level: 2, read_only: true).visible_tools
+      expect(tools.map {|t| t["name"] }).to eq ["read_tool"]
+    end
+  end
+
+  describe "#call" do
+    it "invokes the handler with the given arguments" do
+      expect(build_registry.call("read_tool", {"name" => "x"})).to eq({ "echo" => { "name" => "x" } })
+    end
+
+    it "raises UnknownToolError for an unregistered tool" do
+      expect {
+        build_registry.call("no_such_tool", {})
+      }.to raise_error(McpServer::UnknownToolError)
+    end
+
+    it "denies write tools when not writable" do
+      expect {
+        build_registry(access_level: 0).call("write_tool", {})
+      }.to raise_error(McpServer::ToolError) {|e| expect(e.code).to eq "permission_denied" }
+    end
+
+    it "allows write tools when writable" do
+      expect(build_registry.call("write_tool", {})).to eq({ "wrote" => true })
+    end
+
+    describe "argument validation" do
+      it "rejects missing required arguments" do
+        expect {
+          build_registry.call("read_tool", {})
+        }.to raise_error(McpServer::InvalidArgumentsError, /missing required/)
+      end
+
+      it "rejects unknown arguments" do
+        expect {
+          build_registry.call("read_tool", {"name" => "x", "bogus" => 1})
+        }.to raise_error(McpServer::InvalidArgumentsError, /unknown argument/)
+      end
+
+      it "rejects arguments of the wrong type" do
+        expect {
+          build_registry.call("read_tool", {"name" => "x", "count" => "many"})
+        }.to raise_error(McpServer::InvalidArgumentsError, /must be of type integer/)
+      end
+
+      it "rejects values outside an enum" do
+        expect {
+          build_registry.call("read_tool", {"name" => "x", "status" => "c"})
+        }.to raise_error(McpServer::InvalidArgumentsError, /must be one of/)
+      end
+    end
+  end
+end

--- a/spec/lib/mcp_server/write_tools_spec.rb
+++ b/spec/lib/mcp_server/write_tools_spec.rb
@@ -1,0 +1,186 @@
+require 'spec_helper'
+require Rails.root.join('lib/mcp_server/server')
+
+describe "McpServer write tools" do
+
+  let(:registry) { McpServer::Server.build_registry(access_level: 2, read_only: false) }
+
+  describe "find_or_create_parameter_set" do
+    before(:each) do
+      @sim = FactoryBot.create(:simulator, parameter_sets_count: 0, runs_count: 0, analyzers_count: 0)
+    end
+
+    it "creates a new parameter set, filling omitted keys with defaults" do
+      result = registry.call("find_or_create_parameter_set", {"simulator" => @sim.name, "v" => {"L" => 10}})
+      expect(result["created"]).to be true
+      expect(result["v"]).to eq({"L" => 10, "T" => 1.0})
+      expect(@sim.parameter_sets.count).to eq 1
+    end
+
+    it "is idempotent: returns the existing parameter set with created=false" do
+      first = registry.call("find_or_create_parameter_set", {"simulator" => @sim.name, "v" => {"L" => 10, "T" => 2.0}})
+      second = registry.call("find_or_create_parameter_set", {"simulator" => @sim.name, "v" => {"L" => 10, "T" => 2.0}})
+      expect(second["created"]).to be false
+      expect(second["id"]).to eq first["id"]
+      expect(@sim.parameter_sets.count).to eq 1
+    end
+
+    it "casts string values to the defined types" do
+      result = registry.call("find_or_create_parameter_set", {"simulator" => @sim.name, "v" => {"L" => "10", "T" => "2.0"}})
+      expect(result["v"]).to eq({"L" => 10, "T" => 2.0})
+    end
+
+    it "rejects unknown parameter keys with a structured error" do
+      expect {
+        registry.call("find_or_create_parameter_set", {"simulator" => @sim.name, "v" => {"bogus" => 1}})
+      }.to raise_error(McpServer::ToolError) {|e|
+        expect(e.code).to eq "invalid_parameters"
+        expect(e.details.join).to match(/bogus/)
+      }
+    end
+
+    it "rejects uncastable values" do
+      expect {
+        registry.call("find_or_create_parameter_set", {"simulator" => @sim.name, "v" => {"L" => "abc"}})
+      }.to raise_error(McpServer::ToolError) {|e| expect(e.code).to eq "invalid_parameters" }
+    end
+  end
+
+  describe "create_runs" do
+    before(:each) do
+      @sim = FactoryBot.create(:simulator, parameter_sets_count: 1, runs_count: 0, analyzers_count: 0)
+      @ps = @sim.parameter_sets.first
+      @host = @sim.executable_on.first
+    end
+
+    it "creates runs up to num_runs with status created" do
+      result = registry.call("create_runs", {"parameter_set_id" => @ps.id.to_s, "num_runs" => 3, "host" => @host.name})
+      expect(result["created_count"]).to eq 3
+      expect(result["total_runs_now"]).to eq 3
+      expect(result["runs"].map {|r| r["status"] }.uniq).to eq ["created"]
+      expect(result["runs"].map {|r| r["created"] }.uniq).to eq [true]
+    end
+
+    it "is idempotent: existing runs count toward the total" do
+      registry.call("create_runs", {"parameter_set_id" => @ps.id.to_s, "num_runs" => 3, "host" => @host.name})
+      result = registry.call("create_runs", {"parameter_set_id" => @ps.id.to_s, "num_runs" => 3, "host" => @host.name})
+      expect(result["created_count"]).to eq 0
+      result = registry.call("create_runs", {"parameter_set_id" => @ps.id.to_s, "num_runs" => 5, "host" => @host.name})
+      expect(result["created_count"]).to eq 2
+      expect(result["runs"].count {|r| r["created"] }).to eq 2
+      expect(@ps.reload.runs.count).to eq 5
+    end
+
+    it "requires exactly one of host and host_group" do
+      hg = FactoryBot.create(:host_group)
+      expect {
+        registry.call("create_runs", {"parameter_set_id" => @ps.id.to_s, "num_runs" => 1})
+      }.to raise_error(McpServer::InvalidArgumentsError)
+      expect {
+        registry.call("create_runs", {"parameter_set_id" => @ps.id.to_s, "num_runs" => 1,
+                                      "host" => @host.name, "host_group" => hg.name})
+      }.to raise_error(McpServer::InvalidArgumentsError)
+    end
+
+    it "accepts a host_group as destination" do
+      hg = FactoryBot.create(:host_group)
+      result = registry.call("create_runs", {"parameter_set_id" => @ps.id.to_s, "num_runs" => 1, "host_group" => hg.name})
+      expect(result["created_count"]).to eq 1
+      expect(result["runs"].first["host_group"]).to eq hg.name
+    end
+
+    it "caps num_runs" do
+      expect {
+        registry.call("create_runs", {"parameter_set_id" => @ps.id.to_s, "num_runs" => 101, "host" => @host.name})
+      }.to raise_error(McpServer::InvalidArgumentsError, /between 1 and 100/)
+    end
+
+    it "clamps mpi_procs when the simulator does not support MPI" do
+      result = registry.call("create_runs", {"parameter_set_id" => @ps.id.to_s, "num_runs" => 1,
+                                             "host" => @host.name, "mpi_procs" => 4})
+      expect(result["notes"].join).to match(/mpi_procs clamped/)
+      expect(@ps.runs.first.mpi_procs).to eq 1
+    end
+
+    it "surfaces host_parameters validation failures with the expected format" do
+      host = FactoryBot.create(:host_with_parameters)
+      host.host_parameter_definitions.first.format = '^\d+$'
+      host.host_parameter_definitions.first.default = "8"
+      host.save!
+      exception = nil
+      begin
+        registry.call("create_runs", {"parameter_set_id" => @ps.id.to_s, "num_runs" => 1,
+                                      "host" => host.name,
+                                      "host_parameters" => {"param1" => "abc", "param2" => "XXX"}})
+      rescue => e
+        exception = e
+      end
+      expect(exception).to be_a Mongoid::Errors::Validations
+      wrapped = McpServer::Errors.wrap(exception)
+      expect(wrapped.code).to eq "validation_failed"
+      expect(wrapped.details.join).to include('must satisfy ^\d+$')
+    end
+  end
+
+  describe "create_analysis" do
+    before(:each) do
+      @sim = FactoryBot.create(:simulator, parameter_sets_count: 1, runs_count: 0, analyzers_count: 0)
+      @ps = @sim.parameter_sets.first
+      @run = FactoryBot.create(:finished_run, parameter_set: @ps)
+      @azr = FactoryBot.create(:analyzer, simulator: @sim, type: :on_run, run_analysis: false)
+      @host = @azr.executable_on.first
+    end
+
+    it "creates an analysis on a finished run with default parameters" do
+      result = registry.call("create_analysis", {"analyzer" => @azr.name, "run_id" => @run.id.to_s, "host" => @host.name})
+      expect(result["created"]).to be true
+      expect(result["status"]).to eq "created"
+      expect(result["parameters"]).to eq({"param1" => 50, "param2" => 1.0})
+      expect(result["analyzable_type"]).to eq "Run"
+    end
+
+    it "is idempotent for the same analyzer and parameters" do
+      first = registry.call("create_analysis", {"analyzer" => @azr.name, "run_id" => @run.id.to_s, "host" => @host.name})
+      second = registry.call("create_analysis", {"analyzer" => @azr.name, "run_id" => @run.id.to_s, "host" => @host.name})
+      expect(second["created"]).to be false
+      expect(second["id"]).to eq first["id"]
+      third = registry.call("create_analysis", {"analyzer" => @azr.name, "run_id" => @run.id.to_s,
+                                                "host" => @host.name, "parameters" => {"param1" => 99}})
+      expect(third["created"]).to be true
+    end
+
+    it "rejects a run target for an on_parameter_set analyzer" do
+      azr_ps = FactoryBot.create(:analyzer, simulator: @sim, type: :on_parameter_set, run_analysis: false)
+      expect {
+        registry.call("create_analysis", {"analyzer" => azr_ps.name, "run_id" => @run.id.to_s, "host" => @host.name})
+      }.to raise_error(McpServer::ToolError) {|e|
+        expect(e.code).to eq "invalid_arguments"
+        expect(e.message).to match(/parameter_set_id/)
+      }
+    end
+
+    it "creates an analysis on a parameter set with finished runs" do
+      azr_ps = FactoryBot.create(:analyzer, simulator: @sim, type: :on_parameter_set, run_analysis: false)
+      result = registry.call("create_analysis", {"analyzer" => azr_ps.name, "parameter_set_id" => @ps.id.to_s,
+                                                 "host" => azr_ps.executable_on.first.name})
+      expect(result["created"]).to be true
+      expect(result["analyzable_type"]).to eq "ParameterSet"
+    end
+
+    it "rejects an unfinished run" do
+      unfinished = FactoryBot.create(:run, parameter_set: @ps)
+      expect {
+        registry.call("create_analysis", {"analyzer" => @azr.name, "run_id" => unfinished.id.to_s, "host" => @host.name})
+      }.to raise_error(McpServer::ToolError) {|e| expect(e.code).to eq "invalid_state" }
+    end
+
+    it "rejects a parameter set with no finished runs" do
+      azr_ps = FactoryBot.create(:analyzer, simulator: @sim, type: :on_parameter_set, run_analysis: false)
+      empty_ps = FactoryBot.create(:parameter_set, simulator: @sim, runs_count: 0)
+      expect {
+        registry.call("create_analysis", {"analyzer" => azr_ps.name, "parameter_set_id" => empty_ps.id.to_s,
+                                          "host" => azr_ps.executable_on.first.name})
+      }.to raise_error(McpServer::ToolError) {|e| expect(e.code).to eq "invalid_state" }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `bin/oacis_mcp`, a [Model Context Protocol](https://modelcontextprotocol.io) server speaking JSON-RPC 2.0 over stdio, so AI agents (Claude Code/Desktop and other MCP clients) can drive parameter exploration on OACIS: create parameter sets, submit runs, poll status, read result files, and trigger analyzers.

- **In-process, no HTTP**: the server loads the Rails environment like `bin/oacis_ruby` and wraps the existing model API (`find_or_create_parameter_set`, `find_or_create_runs_upto`, …). Jobs it creates start as `created` and are submitted by the ordinary JobSubmitter/JobObserver workers — the submission pipeline is untouched.
- **Hand-rolled minimal JSON-RPC** (`lib/mcp_server/server.rb`), zero new gem dependencies; the protocol layer is isolated from the tool registry so the official `mcp` gem could be swapped in later.
- **13 tools**: 10 read (simulators, hosts, parameter-set search with aggregated run counts, runs, analyses, size-capped result-file listing/paged reading with path-traversal + symlink-escape guards) and 3 idempotent writes (`find_or_create_parameter_set`, `create_runs` with "up to N" semantics, `create_analysis` with analyzer-type checking and dedup).
- **Safety**: write tools are hidden and rejected when `OACIS_ACCESS_LEVEL=0` or `OACIS_MCP_READONLY=1`; no destructive tools are exposed. stdout is reserved for the protocol before Rails boots (loggers to stderr) so nothing corrupts the stdio stream.
- **Agent ergonomics**: validation failures come back as structured errors including the expected host-parameter format regexps; tool descriptions teach the poll-based workflow.
- Docs: `docs/en/mcp.md` with Claude Code / docker client setup.

## Usage

```sh
claude mcp add oacis -- /path/to/oacis/bin/oacis_mcp
```

## Test plan

- 74 new RSpec examples (`spec/lib/mcp_server/`): tool handlers (idempotency, validation payloads, access gating, pagination, `../`/absolute/symlink escape rejection) and protocol round-trips (initialize/ping/tools, -32601/-32602/-32700, handler crash survival). All green.
- Verified end-to-end against a live OACIS with workers running: `find_or_create_parameter_set` → `create_runs` (2 runs on localhost) → daemons submitted/executed via xsub → `get_parameter_set` showed `finished: 2` → `read_result_file` returned the run's `_stdout.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)