### PR TITLE
Replace hard-coded secret_key_base with per-installation generated secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ __work__
 
 # user_config file
 config/user_config.yml
+
+# per-installation secret_key_base (generated on first boot)
+/config/local_secret.txt

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,11 +18,12 @@ Rails.application.configure do
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
-  # OACIS runs on localhost or in a trusted network (see the docs); the fixed
-  # fallback keeps zero-config installs working like the old secrets.yml did.
-  # Set SECRET_KEY_BASE when exposing the server beyond a trusted network.
+  # A per-installation secret is generated on first boot and stored in
+  # config/local_secret.txt (gitignored), so zero-config installs keep working.
+  # Set SECRET_KEY_BASE to override, e.g. when sharing a key across hosts.
+  require Rails.root.join("lib", "oacis_local_secret")
   config.secret_key_base = ENV["SECRET_KEY_BASE"].presence ||
-    "b78110841c7eeb79db7495922baabb24f2a4205938bfa0239fda26f48f13f0ec659080529f8d0b952b4c90288a9c98631bb2eaf5cff0b48d958f94588bb00cfc"
+    OacisLocalSecret.load_or_generate(Rails.root.join("config", "local_secret.txt"))
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.

--- a/lib/oacis_local_secret.rb
+++ b/lib/oacis_local_secret.rb
@@ -1,0 +1,36 @@
+require "securerandom"
+
+# Provides a per-installation secret for `config.secret_key_base`.
+# The secret is generated on first boot and persisted to a gitignored file,
+# so every OACIS installation gets its own key without any configuration
+# while sessions survive server restarts.
+module OacisLocalSecret
+
+  # Returns the secret stored at +path+, generating and persisting it first
+  # if the file does not exist yet. Publication is atomic (write to a temp
+  # file, then hard-link into place) because `rake daemon:start` boots four
+  # Rails processes concurrently and all of them must end up with the same key.
+  def self.load_or_generate(path)
+    path = path.to_s
+    secret = read_secret(path)
+    return secret if secret
+
+    tmp_path = "#{path}.#{Process.pid}.tmp"
+    File.write(tmp_path, SecureRandom.hex(64), perm: 0o600)
+    begin
+      File.link(tmp_path, path)
+    rescue Errno::EEXIST
+      # another process published its secret first; use that one
+    ensure
+      File.unlink(tmp_path)
+    end
+    read_secret(path) or raise "failed to generate secret at #{path}"
+  end
+
+  def self.read_secret(path)
+    return nil unless File.exist?(path)
+    secret = File.read(path).strip
+    secret.empty? ? nil : secret
+  end
+  private_class_method :read_secret
+end


### PR DESCRIPTION
## Summary
- The production `secret_key_base` fallback in `config/environments/production.rb` was a hard-coded hex string that has been committed publicly since the old `config/secrets.yml` — a known key that lets anyone forge or decrypt the `_oacis_session` cookie.
- Replace it with a per-installation secret: generated with `SecureRandom.hex(64)` on first boot and persisted to `config/local_secret.txt` (gitignored, mode 0600). Zero-config installs keep working, and sessions survive restarts.
- The file is published atomically (temp file + `File.link`), so the four Rails processes started concurrently by `rake daemon:start` (web server + 3 workers) all converge on the same key even on a racy first boot.
- `ENV["SECRET_KEY_BASE"]` still takes precedence when set.

## Why not random-per-launch?
A key generated at every boot would work for OACIS (the only consumer is the cookie session store and there is no auth), but it would reset all sessions on each restart and would diverge across the daemon processes. Persisting the generated key gives the same zero-config experience with a stable per-installation secret.

## Test plan
- [x] `RAILS_ENV=production rails runner 'puts Rails.application.secret_key_base'` twice → identical 128-char key; `config/local_secret.txt` created with mode 0600
- [x] 6 forked processes racing on a clean state converge on a single key, no temp files left behind
- [x] `SECRET_KEY_BASE=...` env var takes precedence
- [x] `git check-ignore` confirms `config/local_secret.txt` is ignored
- [x] `bundle exec rspec spec/lib` → 283 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)