### PR TITLE
Fix latent bugs and clean up minor code smells (phase 1 quick wins)

### DIFF
--- a/app/controllers/parameter_sets_controller.rb
+++ b/app/controllers/parameter_sets_controller.rb
@@ -547,7 +547,7 @@ class ParameterSetsController < ApplicationController
   def collect_latest_analyses(ps_ids, analyzer)
     Analysis.collection.aggregate([
       { '$match' => Analysis.where(analyzer: analyzer).in(parameter_set_id: ps_ids).where(status: :finished).selector },
-      { '$sort' => { updatd_at: -1 } },
+      { '$sort' => { updated_at: -1 } },
       { '$group' => { _id: '$parameter_set_id',
                       analysis_id: {'$first' => '$_id'},
                       analyzable_id: {'$first' => '$analyzable_id'}}}
@@ -557,7 +557,7 @@ class ParameterSetsController < ApplicationController
   def collect_latest_runs(ps_ids)
     Run.collection.aggregate([
       { '$match' => Run.in(parameter_set_id: ps_ids).where(status: :finished).selector },
-      { '$sort' => { updatd_at: -1 } },
+      { '$sort' => { updated_at: -1 } },
       { '$group' => { _id: '$parameter_set_id',
                       run_id: {'$first' => '$_id'}}}
       ])

--- a/app/helpers/worker_logs_helper.rb
+++ b/app/helpers/worker_logs_helper.rb
@@ -1,2 +1,0 @@
-module WorkerLogsHelper
-end

--- a/app/models/parameter_set.rb
+++ b/app/models/parameter_set.rb
@@ -14,12 +14,12 @@ class ParameterSet
 
   validates :simulator, :presence => true
   validate :cast_parameter_values, on: :create
-  validate :validate_parameter_values, on: :create, unless: :skip_check_uniquness
+  validate :validate_parameter_values, on: :create, unless: :skip_check_uniqueness
 
   after_create :create_parameter_set_dir
   before_destroy :delete_parameter_set_dir
 
-  attr_accessor :skip_check_uniquness
+  attr_accessor :skip_check_uniqueness
 
   public
   def dir

--- a/app/models/parameter_set_filter.rb
+++ b/app/models/parameter_set_filter.rb
@@ -111,7 +111,7 @@ class ParameterSetFilter
       return "#{key} #{s} #{val}"
     elsif self::StringTypeMatchers.index(matcher)
       return "#{key} #{matcher} #{val}"
-    elsif self::ObjectTypeMatchers.index(matcher)
+    elsif idx = self::ObjectTypeMatchers.index(matcher)
       s = self::ObjectTypeMatcherStrings[idx]
       return "#{key} #{s} #{val}"
     else

--- a/app/workers/job_submitter.rb
+++ b/app/workers/job_submitter.rb
@@ -90,7 +90,7 @@ class JobSubmitter
         run.destroy
         logger.info "Deleted Run #{run.id}"
       else
-        logger.warn("should not happen: #{job.class}:#{job.id} is not destroyable")
+        logger.warn("should not happen: #{run.class}:#{run.id} is not destroyable")
         run.set_lower_submittable_to_be_destroyed
       end
     end

--- a/lib/cli/oacis_cli_common.rb
+++ b/lib/cli/oacis_cli_common.rb
@@ -98,7 +98,7 @@ EOS
     parsed = load_json_file_or_string(path_or_str)
     validate_parameter_set_ids(parsed)
     parameter_sets = ParameterSet.in(id: parsed.map {|h| h["parameter_set_id"] } ).to_a
-    raise "Invalid #{parsed.length - parameter_sets.count} prameter_set_ids are found" if parameter_sets.count != parsed.length
+    raise "Invalid #{parsed.length - parameter_sets.count} parameter_set_ids are found" if parameter_sets.count != parsed.length
     parameter_sets
   end
 
@@ -115,7 +115,7 @@ EOS
     parsed = load_json_file_or_string(path_or_str)
     validate_run_ids(parsed)
     runs = Run.in(id: parsed.map {|h| h["run_id"] } )
-    raise "Invalid #{parsed.length - runs.count} prameter_set_ids are incdluding" if runs.count != parsed.length
+    raise "Invalid #{parsed.length - runs.count} run_ids are included" if runs.count != parsed.length
     runs
   end
 
@@ -132,7 +132,7 @@ EOS
     parsed = load_json_file_or_string(path_or_str)
     validate_analyzer_ids(parsed)
     analyzers = Analyzer.in(id: parsed.map {|h| h["analyzer_id"] } )
-    raise "Invalid #{parsed.length - analyzers.count} prameter_set_ids are incdluding" if analyzers.count != parsed.length
+    raise "Invalid #{parsed.length - analyzers.count} analyzer_ids are included" if analyzers.count != parsed.length
     analyzers
   end
 

--- a/lib/cli/oacis_cli_parameter_set.rb
+++ b/lib/cli/oacis_cli_parameter_set.rb
@@ -62,7 +62,7 @@ class OacisCli < Thor
     input.each do |psid_value|
       ps_value = psid_value[:value]
       progressbar.log "  parameter values : #{ps_value.inspect}" if options[:verbose]
-      param_set = simulator.parameter_sets.build({v: ps_value, skip_check_uniquness: true})
+      param_set = simulator.parameter_sets.build({v: ps_value, skip_check_uniqueness: true})
       if (! psid_value[:id]) and param_set.valid?
         param_set.save!
         parameter_set_ids << param_set.id

--- a/lib/scheduler_wrapper.rb
+++ b/lib/scheduler_wrapper.rb
@@ -50,6 +50,13 @@ class SchedulerWrapper
     "xdel #{job_id}"
   end
 
+  def scheduler_log_file_paths(run)
+    paths = []
+    dir = Pathname.new(@work_base_dir)
+    paths << dir.join("#{run.id}_log")
+    paths
+  end
+
   private
   def translate_status(remote_status)
     case remote_status
@@ -62,12 +69,5 @@ class SchedulerWrapper
     else
       raise "unknown status"
     end
-  end
-
-  def scheduler_log_file_paths(run)
-    paths = []
-    dir = Pathname.new(@work_base_dir)
-    paths << dir.join("#{run.id}_log")
-    paths
   end
 end

--- a/lib/scheduler_wrapper.rb
+++ b/lib/scheduler_wrapper.rb
@@ -34,7 +34,25 @@ class SchedulerWrapper
 
   def parse_remote_status(stdout)
     return :unknown if stdout.empty?
-    case JSON.load(stdout)["status"]
+    translate_status(JSON.load(stdout)["status"])
+  end
+
+  def parse_remote_status_multiple(stdout)
+    parsed = JSON.load(stdout)
+    statuses = {}
+    parsed.each do |key,val|
+      statuses[key] = translate_status(val["status"])
+    end
+    statuses
+  end
+
+  def cancel_command(job_id)
+    "xdel #{job_id}"
+  end
+
+  private
+  def translate_status(remote_status)
+    case remote_status
     when "queued"
       :submitted
     when "running"
@@ -44,29 +62,6 @@ class SchedulerWrapper
     else
       raise "unknown status"
     end
-  end
-
-  def parse_remote_status_multiple(stdout)
-    parsed = JSON.load(stdout)
-    statuses = {}
-    parsed.each do |key,val|
-      status = case val["status"]
-               when "queued"
-                 :submitted
-               when "running"
-                 :running
-               when "finished"
-                 :includable
-               else
-                 raise "unknown status"
-               end
-      statuses[key] = status
-    end
-    statuses
-  end
-
-  def cancel_command(job_id)
-    "xdel #{job_id}"
   end
 
   def scheduler_log_file_paths(run)

--- a/spec/lib/cli/oacis_cli_run_spec.rb
+++ b/spec/lib/cli/oacis_cli_run_spec.rb
@@ -244,7 +244,7 @@ describe OacisCli do
         at_temp_dir {
           expect {
             invoke_create_runs_with_invalid_parameter_set_ids
-          }.to raise_error "Invalid 1 prameter_set_ids are found"
+          }.to raise_error "Invalid 1 parameter_set_ids are found"
         }
       end
 


### PR DESCRIPTION
First installment of the code readability / design improvement plan (phase 1: quick wins). All changes are small, behavior-preserving fixes found during a repository-wide review.

## Bug fixes

- **`JobSubmitter.destroy_jobs_to_be_destroyed`** (`app/workers/job_submitter.rb`): the warn-log line referenced an undefined variable `job` instead of `run`, so hitting that branch would raise `NameError` inside the worker loop.
- **`ParameterSetsController#collect_latest_analyses` / `#collect_latest_runs`**: the `$sort` stage sorted on `updatd_at` (typo), making it silently ineffective — "latest" run/analysis selection for plots was effectively unordered. Now sorts on `updated_at`.
- **`ParameterSetFilter.format`**: the `ObjectTypeMatchers` branch read `idx`, which is only assigned in the `NumTypeMatchers` branch — a stale/nil variable. Now assigns `idx` in its own branch.

## Cleanups

- `SchedulerWrapper`: the xsub status translation (`queued/running/finished` → `:submitted/:running/:includable`) was duplicated between `parse_remote_status` and `parse_remote_status_multiple`; extracted into a single private `translate_status`.
- Renamed `skip_check_uniquness` → `skip_check_uniqueness` (`ParameterSet` + CLI call site).
- Fixed CLI error messages that reported the wrong entity with typos ("Invalid N prameter_set_ids are incdluding" now says `run_ids` / `analyzer_ids` "are included"); updated the spec asserting the old message.
- Deleted `WorkerLogsHelper` (empty module).

Notes from the review that deliberately did **not** change: `ApplicationFormBuilder` is used by four form views, and `utf8_enforcer_tag` is an intentional override that keeps the UTF-8 param out of GET URLs — both were initially flagged as dead code but verified to be live/intentional.

## Testing

- `spec/lib/scheduler_wrapper_spec.rb`, `spec/models/parameter_set_spec.rb`, `spec/models/parameter_set_filter_spec.rb`, `spec/workers/job_submitter_spec.rb`: 76 examples, 0 failures
- `spec/lib/cli/oacis_cli_run_spec.rb`, `spec/lib/cli/oacis_cli_parameter_set_spec.rb`, `spec/controllers/parameter_sets_controller_spec.rb`: 130 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)