### PR TITLE
Position MCP as the primary interface; keep Ruby API for batch scripting

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,18 @@ For native installation and advanced usage, see the [full documentation](http://
 ![screenshot](docs/images/screenshots/5.png)
 ![screenshot](docs/images/screenshots/8.png)
 
-## A sample of APIs
+## Controlling OACIS with AI agents
 
+OACIS ships an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server, `bin/oacis_mcp`, which lets AI agents such as Claude operate OACIS on your behalf: create parameter sets, submit runs, monitor their status, and inspect the results.
+See http://crest-cassia.github.io/oacis/en/mcp.html for more details.
+
+```shell
+claude mcp add oacis -- /path/to/oacis/bin/oacis_mcp
+```
+
+## Scripting with the Ruby API
+
+For scripted, reproducible workflows, use the Ruby API.
 A small sample of parameter sweep over parameters "p1" and "p2" of your simulator.
 See http://crest-cassia.github.io/oacis/en/api.html for more details.
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -49,6 +49,7 @@
                 <li><a href="{{ site.baseurl }}/{{ page.lang }}/configuring_analyzer.html">アナライザーの設定</a></li>
               </ul>
             </li>
+            <li> <a href="{{ site.baseurl }}/en/mcp.html">MCP (English only)</a> </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">API (English only)<span class="caret"></span></a>
               <ul class="dropdown-menu">
@@ -73,6 +74,7 @@
                 <li><a href="{{ site.baseurl }}/{{ page.lang }}/configuring_analyzer.html">Analyzer</a></li>
               </ul>
             </li>
+            <li> <a href="{{ site.baseurl }}/{{ page.lang }}/mcp.html">MCP</a> </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">API <span class="caret"></span></a>
               <ul class="dropdown-menu">

--- a/docs/en/api.md
+++ b/docs/en/api.md
@@ -13,6 +13,9 @@ OACIS is implemented in Ruby, and has Ruby APIs. You can operate OACIS by writin
 In this page, we will give a brief instruction on how to use the Ruby APIs. 
 You can find samples at [samples page]({{ site.baseurl }}/{{ page.lang }}/api_samples.html).
 
+The Ruby API is the right tool for reproducible batch workflows: parameter sweeps, optimization loops, and other scripts that you can rerun and publish.
+For interactive, AI-agent-driven control of OACIS, see the [MCP server]({{ site.baseurl }}/{{ page.lang }}/mcp.html) instead.
+
 ## Prerequisites
 
 In the following, we assume that a Simulator "my_simulator" is registered on OACIS, which has three parameters "p1", "p2", and "p3".

--- a/docs/en/api_samples.md
+++ b/docs/en/api_samples.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Samples"
 lang: en
-next_page: mcp
+next_page: tips
 ---
 
 # Samples

--- a/docs/en/cli.md
+++ b/docs/en/cli.md
@@ -2,7 +2,7 @@
 layout: default
 title: "Command Line Interface"
 lang: en
-next_page: api
+next_page: mcp
 ---
 
 # {{ page.title }}

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -35,7 +35,7 @@ With a user-friendly interface, you can easily submit various jobs to appropriat
 After these jobs are finished, all the result files are automatically downloaded from the remote hosts and stored in a traceable way together with logs of the date, host, and elapsed time of the jobs.
 You can easily find the status of the jobs or results files from the browser-based UI, which lets you focus on more productive and essential parts of your research activities.
 
-It also provides Ruby APIs, which help us automate parameter sweep, optimization of parameters, and sensitivity analysis etc.
+It also provides an MCP (Model Context Protocol) server so that AI agents can operate OACIS on your behalf, and Ruby APIs for writing reproducible scripts that automate parameter sweep, optimization of parameters, and sensitivity analysis etc.
 
 ## Screenshots
 
@@ -107,8 +107,15 @@ It also provides Ruby APIs, which help us automate parameter sweep, optimization
   </a>
 </div>
 
+## Controlling OACIS with AI agents
+
+OACIS ships an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server, which lets AI agents such as Claude operate OACIS on your behalf.
+An agent connected to the server can create parameter sets, submit runs, monitor their status, and inspect the results — you can simply ask it to "sweep parameters p1 and p2 of my simulator and report the results".
+See http://crest-cassia.github.io/oacis/en/mcp.html for more details.
+
 ## A sample of APIs
 
+For scripted, reproducible workflows, use the Ruby API.
 A small sample of parameter sweep over parameters "p1" and "p2" of your simulator.
 See http://crest-cassia.github.io/oacis/en/api.html for more details.
 
@@ -142,6 +149,8 @@ The remaining pages are organized as follows.
 - Tutorial
 - Configuration
 - Command Line Interface(CLI)
+- MCP Server
+- Ruby API
 - Tips
 
 You will be able to start using OACIS if you read the first three pages.

--- a/docs/en/mcp.md
+++ b/docs/en/mcp.md
@@ -2,7 +2,7 @@
 layout: default
 title: "MCP Server"
 lang: en
-next_page: tips
+next_page: api
 ---
 
 # MCP Server for AI agents
@@ -13,6 +13,8 @@ OACIS ships an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) s
 An agent connected to this server can explore parameter spaces autonomously: create parameter sets, submit runs, poll their status, read result files, and trigger analyzers.
 
 The server speaks JSON-RPC over stdio and accesses the OACIS database in-process, exactly like the [Ruby API]({{ site.baseurl }}/{{ page.lang }}/api.html). Jobs created through it are picked up and submitted to remote hosts by the ordinary OACIS background workers.
+
+MCP is the recommended interface for interactive, agent-driven use. For unattended long-running workflows — for example an optimization loop that keeps submitting jobs for days — a script using the [Ruby API]({{ site.baseurl }}/{{ page.lang }}/api.html) and [OACIS watcher]({{ site.baseurl }}/{{ page.lang }}/api_watcher.html) is the better tool. The two combine well: you can ask an agent to write such a script for you.
 
 ## Setup
 

--- a/docs/ja/cli.md
+++ b/docs/ja/cli.md
@@ -2,7 +2,7 @@
 layout: default
 title: "CLIの使い方"
 lang: ja
-next_page: api
+next_page: tips
 ---
 
 # Command Line Interface(CLI)の使い方

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -103,8 +103,15 @@ OACISはRubyのAPIを持っており、パラメータの選択やジョブの�
   </a>
 </div>
 
+## AIエージェントによる操作
+
+OACISは [MCP (Model Context Protocol)](https://modelcontextprotocol.io) サーバーを同梱しており、ClaudeなどのAIエージェントからOACISを操作できます。
+エージェントはパラメータセットの作成、ジョブの投入、実行状況の監視、結果の確認を自律的に行えます。例えば「シミュレーターのp1とp2をスイープして結果を報告して」と依頼するだけでパラメータスイープを実行できます。
+詳細は [MCP Server]({{ site.baseurl }}/en/mcp.html) をみてください。
+
 ## APIのサンプル
 
+再現可能なスクリプトとして実験を記述したい場合はRuby APIを使います。
 例えば、あるシミュレーターの"p1"と"p2"というパラメータを変化させながらジョブを実行したいとします。
 OACISのAPIを使って書く場合、以下のようになります。
 詳細は [How to use APIs]({{ site.baseurl }}/en/api.html) をみてください。
@@ -138,6 +145,8 @@ end
 - 基本的な使い方
 - 高度な使い方
 - Command Line Interface(CLI)の使い方
+- MCPサーバー (英語のみ)
+- Ruby API (英語のみ)
 - Tips
 
 とりあえず使ってみたい場合は「基本的な使い方」の章までを見れば使い始められるようになっています。


### PR DESCRIPTION
## Summary
Supersedes #784, which removed the Ruby API. On reflection, MCP and the Ruby API are complements, not substitutes — MCP for interactive agent-driven use, the Ruby API for deterministic, reproducible, unattended batch work (optimization loops via OacisWatcher, large sweeps). This PR keeps the Ruby API and instead repositions the docs so MCP is the headline programmatic interface:

- Add MCP to the docs navigation in both language menus (it was missing entirely).
- Move MCP ahead of the Ruby API in the docs reading chain: `CLI → MCP → Ruby API → Watcher → Samples → Tips`.
- README and both landing pages now introduce "Controlling OACIS with AI agents" first; the Ruby API sample stays, framed as the scripted/reproducible path.
- `mcp.md` and `api.md` each gained a short paragraph on when to prefer the other.
- Bugfix: the Japanese CLI page's Next button pointed to `/ja/api.html`, which never existed; it now goes to Tips.

No code changes — docs, layout, and README only.

## Test plan
- [x] `next_page` chain verified: every target exists in its language directory
- [x] `git diff --stat` — only README.md, docs/_layouts, docs/en, docs/ja touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)