### PR TITLE
Improve robustness of worker daemons and remote job handling

### DIFF
--- a/app/models/worker_log.rb
+++ b/app/models/worker_log.rb
@@ -6,6 +6,10 @@ class WorkerLog
   field :l, type: Integer, as: :level
   field :m, type: String, as: :message
 
+  # old logs are removed by MongoDB's TTL mechanism
+  LOG_RETENTION_PERIOD = 7.days
+  index({ created_at: 1 }, { expire_after_seconds: LOG_RETENTION_PERIOD.to_i })
+
   SEVERITY = {
     4 => "FATAL",
     3 => "ERROR",

--- a/app/services/remote_job_handler.rb
+++ b/app/services/remote_job_handler.rb
@@ -129,6 +129,10 @@ class RemoteJobHandler
       # the status check of each job, which tolerates transient errors
       raise RemoteSchedulerError, "#{cmd} failed: rc:#{rc}, #{out}, #{err}" if out.empty? or rc != 0
       statuses = scheduler.parse_remote_status_multiple(out)
+      # a successful status report resets the consecutive-failure count as well
+      jobs.each do |job|
+        self.class.status_check_failures.delete(job.id) if statuses.key?(job.job_id)
+      end
     end
     statuses
   end

--- a/app/services/remote_job_handler.rb
+++ b/app/services/remote_job_handler.rb
@@ -5,6 +5,21 @@ class RemoteJobHandler
   class RemoteSchedulerError < StandardError; end
   class RemoteJobError < StandardError; end
 
+  # A job is marked as failed only after this number of consecutive
+  # status-check failures, so that a transient scheduler error does not
+  # kill a job which is actually running.
+  STATUS_CHECK_FAILURE_LIMIT = 3
+
+  class << self
+    def status_check_failures
+      @status_check_failures ||= Hash.new(0)
+    end
+
+    def support_multiple_xstat_cache
+      @support_multiple_xstat_cache ||= {}
+    end
+  end
+
   def initialize(host)
     @host = host
     @logger = nil
@@ -52,6 +67,10 @@ class RemoteJobHandler
   end
 
   def support_multiple_xstat?(logger = nil)
+    # whether xstat supports '-m' does not change unless the remote xsub
+    # installation is replaced, so the result is cached per host
+    cache = self.class.support_multiple_xstat_cache
+    return cache[@host.id] if cache.key?(@host.id)
     scheduler = SchedulerWrapper.new(@host)
     cmd = scheduler.status_help_command
     ret = false
@@ -65,7 +84,7 @@ class RemoteJobHandler
         ret = true if rc == 0 and out =~ /multiple/
       end
     end
-    ret
+    cache[@host.id] = ret
   end
 
   def remote_status(job, logger = nil)
@@ -79,10 +98,18 @@ class RemoteJobHandler
         logger&.debug("  stdout: #{out.chomp}")
         logger&.debug("  stderr: #{err.chomp}")
         logger&.debug("  rc: #{rc}")
-        raise RemoteSchedulerError if out.empty? or rc != 0
+        raise RemoteSchedulerError, "#{cmd} failed: rc:#{rc}, #{out}, #{err}" if out.empty? or rc != 0
         status = scheduler.parse_remote_status(out)
+        self.class.status_check_failures.delete(job.id)
       rescue => ex
-        error_handle(ex, job, sh)
+        failures = (self.class.status_check_failures[job.id] += 1)
+        if failures >= STATUS_CHECK_FAILURE_LIMIT
+          self.class.status_check_failures.delete(job.id)
+          error_handle(ex, job, sh)
+        else
+          logger&.warn("status check of #{job.class}:#{job.id} failed (#{failures}/#{STATUS_CHECK_FAILURE_LIMIT}): #{ex.inspect}")
+          raise ex
+        end
       end
     end
     status
@@ -93,19 +120,15 @@ class RemoteJobHandler
     scheduler = SchedulerWrapper.new(@host)
     cmd = scheduler.status_multiple_command(jobs.map(&:job_id))
     @host.start_ssh_shell do |sh|
-      begin
-        logger&.debug("  executing: #{cmd}")
-        out,err,rc = SSHUtil.execute2(sh, cmd)
-        logger&.debug("  stdout: #{out.chomp}")
-        logger&.debug("  stderr: #{err.chomp}")
-        logger&.debug("  rc: #{rc}")
-        raise RemoteSchedulerError if out.empty? or rc != 0
-        statuses = scheduler.parse_remote_status_multiple(out)
-      rescue => ex
-        jobs.each do |job|
-          error_handle(ex, job, sh)
-        end
-      end
+      logger&.debug("  executing: #{cmd}")
+      out,err,rc = SSHUtil.execute2(sh, cmd)
+      logger&.debug("  stdout: #{out.chomp}")
+      logger&.debug("  stderr: #{err.chomp}")
+      logger&.debug("  rc: #{rc}")
+      # do not mark the jobs as failed here; the caller falls back to
+      # the status check of each job, which tolerates transient errors
+      raise RemoteSchedulerError, "#{cmd} failed: rc:#{rc}, #{out}, #{err}" if out.empty? or rc != 0
+      statuses = scheduler.parse_remote_status_multiple(out)
     end
     statuses
   end
@@ -175,7 +198,7 @@ class RemoteJobHandler
   end
 
   def create_remote_work_dir(job)
-    cmd = "mkdir -p #{RemoteFilePath.work_dir_path(@host,job)}"
+    cmd = "mkdir -p #{SSHUtil.escape_remote_path(RemoteFilePath.work_dir_path(@host,job))}"
     @host.start_ssh_shell do |sh|
       out,err,rc = SSHUtil.execute2(sh, cmd)
       raise RemoteOperationError, "\"#{cmd}\" failed: #{out}, #{err}" unless rc==0
@@ -249,7 +272,7 @@ class RemoteJobHandler
 
     relative_subdirs = org_dest_list.map {|o,d| File.dirname(d) }.uniq.select {|d| d != "."}
     subdirs = relative_subdirs.map {|d| remote_work_dir.join(d) }
-    cmd = "mkdir -p #{subdirs.join(' ')}"
+    cmd = "mkdir -p #{subdirs.map {|d| SSHUtil.escape_remote_path(d) }.join(' ')}"
 
     @host.start_ssh_shell do |sh|
       SSHUtil.execute(sh, cmd)
@@ -266,12 +289,12 @@ class RemoteJobHandler
       path = RemoteFilePath.pre_process_script_path(@host, job)
       @host.start_ssh_shell do |sh|
         SSHUtil.write_remote_file(@host.name, path, script.gsub(/\R/,"\n") )  # pre_process_script may contain "\r\n"
-        out,err,rc = SSHUtil.execute2(sh, "chmod +x #{path}")
+        out,err,rc = SSHUtil.execute2(sh, "chmod +x #{SSHUtil.escape_remote_path(path)}")
         raise RemoteOperationError, "chmod failed : #{out}, #{err}" unless rc==0
         cd = SSHUtil.execute(sh,'pwd')
-        cmd = "cd #{File.dirname(path)} && ./#{File.basename(path)} #{job.args} 1>> _stdout.txt 2>> _stderr.txt"
+        cmd = "cd #{SSHUtil.escape_remote_path(File.dirname(path))} && ./#{Shellwords.escape(File.basename(path))} #{job.args} 1>> _stdout.txt 2>> _stderr.txt"
         out, err, rc = SSHUtil.execute2(sh, cmd)
-        SSHUtil.execute(sh, "cd #{cd.chomp}")
+        SSHUtil.execute(sh, "cd #{Shellwords.escape(cd.chomp)}")
         raise RemoteJobError, "\"#{cmd}\" failed: rc:#{rc}, #{out}, #{err}" unless rc == 0
       end
     end
@@ -291,7 +314,7 @@ class RemoteJobHandler
     end
 
     @host.start_ssh_shell do |sh|
-      out,err,rc = SSHUtil.execute2(sh, "chmod +x #{jspath}")
+      out,err,rc = SSHUtil.execute2(sh, "chmod +x #{SSHUtil.escape_remote_path(jspath)}")
       raise RemoteOperationError, "chmod failed: #{out}, #{err}" unless rc == 0
     end
     jspath
@@ -306,9 +329,17 @@ class RemoteJobHandler
     @host.start_ssh_shell do |sh|
       out, err, rc = SSHUtil.execute2(sh, cmd)
       raise RemoteSchedulerError, "#{cmd} failed: rc:#{rc}, #{out}, #{err}" unless rc == 0
-      job.status = :submitted
 
-      job_id = wrapper.parse_jobid_from_submit_command(out)
+      # do not mark the job as submitted until job_id is obtained; otherwise
+      # a job without job_id could be persisted by the error handling below
+      job_id = begin
+        wrapper.parse_jobid_from_submit_command(out)
+      rescue => ex
+        raise RemoteSchedulerError, "failed to parse job_id from the output of \"#{cmd}\": #{out}, #{ex.inspect}"
+      end
+      raise RemoteSchedulerError, "job_id is not found in the output of \"#{cmd}\": #{out}" if job_id.nil?
+
+      job.status = :submitted
       job.job_id = job_id
       job.submitted_at = DateTime.now
       job.save!
@@ -331,6 +362,13 @@ class RemoteJobHandler
     end
   end
 
+  # net-ssh raises NoMethodError on nil when the underlying transport socket
+  # is gone; the message is version dependent, so match it loosely
+  def connection_error?(exception)
+    return true if Host::CONNECTION_EXCEPTIONS.any? {|klass| exception.is_a?(klass) }
+    exception.is_a?(NoMethodError) && exception.message.match?(/undefined method .stat. for nil/)
+  end
+
   def error_handle(exception, job, sh)
     if exception.is_a?(RemoteOperationError)
       job.update_attribute(:error_messages, "RemoteOperaion is failed.\n#{exception.inspect}\n#{exception.backtrace}")
@@ -346,12 +384,10 @@ class RemoteJobHandler
     elsif exception.is_a?(LocalPreprocessError)
       job.update_attribute(:error_messages, "failed to execute local preprocess.\n#{exception.inspect}\n#{exception.backtrace})")
       job.update_attribute(:status, :failed)
+    elsif connection_error?(exception)
+      job.update_attribute(:error_messages, "failed to establish ssh connection to host(#{job.submitted_to.name})\n#{exception.inspect}\n#{exception.backtrace}")
     else
-      if exception.inspect.to_s =~ /#<NoMethodError: undefined method `stat' for nil:NilClass>/
-        job.update_attribute(:error_messages, "failed to establish ssh connection to host(#{job.submitted_to.name})\n#{exception.inspect}\n#{exception.backtrace}")
-      else
-        job.update_attribute(:error_messages, "#{exception.inspect}\n#{exception.backtrace}")
-      end
+      job.update_attribute(:error_messages, "#{exception.inspect}\n#{exception.backtrace}")
     end
     StatusChannel.broadcast_to('message', OacisChannelUtil.createJobStatusMessage(job))
     raise exception  # this error is caught by job_submitter or job_observer

--- a/app/workers/host_polling.rb
+++ b/app/workers/host_polling.rb
@@ -1,0 +1,35 @@
+# Shared logic for tasks (JobSubmitter, JobObserver) that periodically poll
+# remote hosts. Extend this module in a task class.
+module HostPolling
+
+  # Iterates over enabled hosts, skipping hosts whose polling interval has not
+  # passed since the last poll. An exception raised while processing one host
+  # is logged and does not prevent processing of the remaining hosts.
+  def each_host_to_poll(logger)
+    @last_performed_at ||= {}
+    Host.where(status: :enabled).each do |host|
+      break if Worker.term_received?
+      next if DateTime.now.to_i - @last_performed_at[host.id].to_i < host.polling_interval
+      begin
+        yield host
+      rescue => ex
+        logger.error("Error in #{self.name}: #{ex.inspect}")
+        logger.error(ex.backtrace)
+      end
+      @last_performed_at[host.id] = DateTime.now
+    end
+  end
+
+  # Returns a logger for SSH debug messages when OACIS_SSH_DEBUG=1, nil otherwise.
+  def ssh_debug_logger
+    return @ssh_logger unless @ssh_logger.nil?
+    return nil unless ENV['OACIS_SSH_DEBUG'] == "1"
+    @ssh_logger = Logger.new( Rails.root.join('log/ssh_debug.log') )
+    @ssh_logger.level = :debug
+    @ssh_logger.formatter = proc do |severity, datetime, progname, msg|
+      "[#{self.name}] #{datetime.strftime('%Y-%m-%d %H:%M:%S')} #{severity}: #{msg}\n"
+    end
+    @ssh_logger.debug("printing SSH debug messages for #{self.name}")
+    @ssh_logger
+  end
+end

--- a/app/workers/job_observer.rb
+++ b/app/workers/job_observer.rb
@@ -1,39 +1,23 @@
 class JobObserver
 
+  extend HostPolling
+
   def self.perform(logger)
-    @last_performed_at ||= {}
     unless is_enough_disk_space_left?(logger)
       logger.error("Disk space is not enough to include submitted jobs. Aborting.")
       return
     end
-    if ENV['OACIS_SSH_DEBUG'] == "1" and @ssh_logger.nil?
-      @ssh_logger = Logger.new( Rails.root.join('log/ssh_debug.log') )
-      @ssh_logger.level = :debug
-      @ssh_logger.debug("printing SSH debug messages for JobObserver")
-      @ssh_logger.formatter = proc do |severity, datetime, progname, msg|
-        "[JobObserver] #{datetime.strftime('%Y-%m-%d %H:%M:%S')} #{severity}: #{msg}\n"
-      end
-    end
-    Host.where(status: :enabled).each do |host|
-      break if $term_received
-      next if DateTime.now.to_i - @last_performed_at[host.id].to_i < host.polling_interval
-      begin
-        logger.debug "observing host #{host.name}"
-        bm = Benchmark.measure {
-          observe_host(host, logger, @ssh_logger)
-        }
-        logger.info "observation of #{host.name} finished in #{sprintf('%.1f', bm.real)}" if bm.real > 1.0
-      rescue => ex
-        logger.error("Error in JobObserver: #{ex.inspect}")
-        logger.error(ex.backtrace)
-      end
-      @last_performed_at[host.id] = DateTime.now
+    each_host_to_poll(logger) do |host|
+      logger.debug "observing host #{host.name}"
+      bm = Benchmark.measure {
+        observe_host(host, logger, ssh_debug_logger)
+      }
+      logger.info "observation of #{host.name} finished in #{sprintf('%.1f', bm.real)}" if bm.real > 1.0
     end
   end
 
   private
   def self.observe_host(host, logger, ssh_logger = nil)
-    # host.check_submitted_job_status(logger)
     return if host.submitted_runs.count == 0 and host.submitted_analyses.count == 0
     host.start_ssh_shell(logger: logger, ssh_logger: ssh_logger) do |sh|
       logger.debug "making SSH connection to #{host.name}"
@@ -57,24 +41,37 @@ class JobObserver
   def self.destroy_jobs(jobs, host, handler, logger)
     logger.debug "deleting cancelled jobs #{jobs.map(&:id)}" if jobs.present?
     jobs.each do |job|
-      break if $term_received
-      if job.destroyable?
-        logger.info("canceling remote job: #{job.class}:#{job.id} from #{host.name}")
-        handler.cancel_remote_job(job)
-        logger.info("canceled remote job: #{job.class}:#{job.id} from #{host.name}")
-        job.destroy
-        logger.info("destroyed #{job.class} #{job.id}")
-      else
-        logger.warn("should not happen: #{job.class}:#{job.id} is not destroyable")
-        job.set_lower_submittable_to_be_destroyed
+      break if Worker.term_received?
+      begin
+        if job.destroyable?
+          logger.info("canceling remote job: #{job.class}:#{job.id} from #{host.name}")
+          handler.cancel_remote_job(job)
+          logger.info("canceled remote job: #{job.class}:#{job.id} from #{host.name}")
+          job.destroy
+          logger.info("destroyed #{job.class} #{job.id}")
+        else
+          logger.warn("should not happen: #{job.class}:#{job.id} is not destroyable")
+          job.set_lower_submittable_to_be_destroyed
+        end
+      rescue => ex
+        # continue to the remaining jobs; canceling is retried in the next cycle
+        logger.error("Error while canceling #{job.class}:#{job.id}: #{ex.inspect}")
+        logger.error(ex.backtrace)
       end
     end
   end
 
   def self.observe_jobs(jobs, host, handler, logger)
-    remote_statuses = handler.remote_status_multiple(jobs, logger) if jobs.present? and handler.support_multiple_xstat?
+    remote_statuses = nil
+    if jobs.present? and handler.support_multiple_xstat?
+      begin
+        remote_statuses = handler.remote_status_multiple(jobs, logger)
+      rescue => ex
+        logger.warn("remote_status_multiple failed: #{ex.inspect}; falling back to individual status check")
+      end
+    end
     jobs.each do |job|
-      break if $term_received
+      break if Worker.term_received?
       remote_status = remote_statuses[job.job_id] if remote_statuses
       observe_job(job, host, handler, remote_status, logger)
     end

--- a/app/workers/job_submitter.rb
+++ b/app/workers/job_submitter.rb
@@ -1,64 +1,49 @@
 class JobSubmitter
 
-  def self.perform(logger)
-    @last_performed_at ||= {}
-    destroy_jobs_to_be_destroyed(logger)
-    if ENV['OACIS_SSH_DEBUG'] == "1" and @ssh_logger.nil?
-       @ssh_logger = Logger.new( Rails.root.join('log/ssh_debug.log') )
-       @ssh_logger.level = :debug
-       @ssh_logger.debug("printing SSH debug messages for JobSubmitter")
-       @ssh_logger.formatter = proc do |severity, datetime, progname, msg|
-        "[JobSubmitter] #{datetime.strftime('%Y-%m-%d %H:%M:%S')} #{severity}: #{msg}\n"
-      end
-    end
-    Host.where(status: :enabled).each do |host|
-      break if $term_received
-      next if DateTime.now.to_i - @last_performed_at[host.id].to_i < host.polling_interval
-      begin
-        num = host.max_num_jobs - host.submitted_runs.count - host.submitted_analyses.count
-        logger.debug "checking jobs going to be submitted to #{host.name}."
-        if num > 0 and (host.submittable_analyses.count > 0 or host.submittable_runs.count > 0)
-          host.start_ssh_shell(ssh_logger: @ssh_logger) do |sh|
-            prev_num = num
-            Run::PRIORITY_ORDER.keys.sort.each do |priority|
-              break if $term_received
-              break unless num > 0
-              analyses = host.submittable_analyses.where(priority: priority).asc(:created_at).limit(num)
-              if analyses.present?
-                logger.info("submitting analyses to #{host.name}: #{analyses.map do |r| r.id.to_s end.inspect}")
-                num -= analyses.length  # [warning] analyses.length ignore 'limit', so 'num' can be negative.
-                bm = Benchmark.measure {
-                  submit(analyses, host, logger)
-                }
-                logger.info("submission of analyses (host:#{host.name}, pri:#{priority}) finished in #{sprintf('%.1f', bm.real)}")
-              else
-                logger.debug("no submittable analyses of priority #{priority} found for #{host.name}")
-              end
+  extend HostPolling
 
-              break if $term_received
-              break unless num > 0
-              runs = host.submittable_runs.where(priority: priority).asc(:created_at).limit(num)
-              if runs.present?
-                logger.info("submitting runs to #{host.name}: #{runs.map do |r| r.id.to_s end.inspect}")
-                num -= runs.length  # [warning] runs.length ignore 'limit', so 'num' can be negative.
-                bm = Benchmark.measure {
-                  submit(runs, host, logger)
-                }
-                logger.info("submission of runs (host:#{host.name}, pri:#{priority}) finished in #{sprintf('%.1f', bm.real)}")
-              else
-                logger.debug("no submittable runs of priority #{priority} found for #{host.name}")
-              end
+  def self.perform(logger)
+    destroy_jobs_to_be_destroyed(logger)
+    each_host_to_poll(logger) do |host|
+      num = host.max_num_jobs - host.submitted_runs.count - host.submitted_analyses.count
+      logger.debug "checking jobs going to be submitted to #{host.name}."
+      if num > 0 and (host.submittable_analyses.count > 0 or host.submittable_runs.count > 0)
+        host.start_ssh_shell(ssh_logger: ssh_debug_logger) do |sh|
+          prev_num = num
+          Run::PRIORITY_ORDER.keys.sort.each do |priority|
+            break if Worker.term_received?
+            break unless num > 0
+            analyses = host.submittable_analyses.where(priority: priority).asc(:created_at).limit(num).to_a
+            if analyses.present?
+              logger.info("submitting analyses to #{host.name}: #{analyses.map do |r| r.id.to_s end.inspect}")
+              num -= analyses.size
+              bm = Benchmark.measure {
+                submit(analyses, host, logger)
+              }
+              logger.info("submission of analyses (host:#{host.name}, pri:#{priority}) finished in #{sprintf('%.1f', bm.real)}")
+            else
+              logger.debug("no submittable analyses of priority #{priority} found for #{host.name}")
             end
-            if num == prev_num
-              logger.debug("no submittable runs or analyses is found for #{host.name}")
+
+            break if Worker.term_received?
+            break unless num > 0
+            runs = host.submittable_runs.where(priority: priority).asc(:created_at).limit(num).to_a
+            if runs.present?
+              logger.info("submitting runs to #{host.name}: #{runs.map do |r| r.id.to_s end.inspect}")
+              num -= runs.size
+              bm = Benchmark.measure {
+                submit(runs, host, logger)
+              }
+              logger.info("submission of runs (host:#{host.name}, pri:#{priority}) finished in #{sprintf('%.1f', bm.real)}")
+            else
+              logger.debug("no submittable runs of priority #{priority} found for #{host.name}")
             end
           end
+          if num == prev_num
+            logger.debug("no submittable runs or analyses is found for #{host.name}")
+          end
         end
-      rescue => ex
-        logger.error("Error in JobSubmitter: #{ex.inspect}")
-        logger.error(ex.backtrace)
       end
-      @last_performed_at[host.id] = DateTime.now
     end
   end
 
@@ -68,7 +53,7 @@ class JobSubmitter
     host.start_ssh_shell do |sh|
       handler = RemoteJobHandler.new(host)
       submittables.each do |job|
-        break if $term_received
+        break if Worker.term_received?
         begin
           logger.debug("submitting #{job.id} to #{host.name}")
           bm = Benchmark.measure {

--- a/app/workers/logger_for_worker.rb
+++ b/app/workers/logger_for_worker.rb
@@ -1,5 +1,16 @@
 class LoggerForWorker
 
+  # Same format as the one defined in config/environments/{development,production}.rb.
+  # Defined here as well because those copies do not exist in the test environment.
+  class LoggerFormatWithTime
+    def call(severity, timestamp, progname, msg)
+      format = "[%s] %5s -- %s: %s\n"
+      format % ["#{timestamp.strftime("%Y/%m/%d %H:%M:%S")}.#{'%06d' % timestamp.usec.to_s}", severity, progname, String === msg ? msg : msg.inspect]
+    end
+  end
+
+  LEVELS = { debug: 0, info: 1, warn: 2, error: 3, fatal: 4 }
+
   def initialize(worker_type, logdev, shift_age=0, shift_size=1048576)
     @type = worker_type
     @logger = Logger.new(logdev, shift_age, shift_size)
@@ -12,32 +23,12 @@ class LoggerForWorker
     WorkerLogChannel.broadcast_to('message', {@type => s})
   end
 
-  def debug(message)
-    send_by_cable(message, :debug)
-    @logger.debug(message)
-  end
-
-  def info(message)
-    send_by_cable(message, :info)
-    @logger.info(message)
-    WorkerLog.create({worker: @type, level: 1, message: message})
-  end
-
-  def warn(message)
-    send_by_cable(message, :warn)
-    @logger.warn(message)
-    WorkerLog.create({worker: @type, level: 2, message: message})
-  end
-
-  def error(message)
-    send_by_cable(message, :error)
-    @logger.error(message)
-    WorkerLog.create({worker: @type, level: 3, message: message})
-  end
-
-  def fatal(message)
-    send_by_cable(message, :fatal)
-    @logger.fatal(message)
-    WorkerLog.create({worker: @type, level: 4, message: message})
+  LEVELS.each do |severity, level|
+    define_method(severity) do |message|
+      send_by_cable(message, severity)
+      @logger.public_send(severity, message)
+      # debug messages are not persisted to avoid bloating the collection
+      WorkerLog.create({worker: @type, level: level, message: message}) if level >= LEVELS[:info]
+    end
   end
 end

--- a/app/workers/logger_for_worker.rb
+++ b/app/workers/logger_for_worker.rb
@@ -25,10 +25,25 @@ class LoggerForWorker
 
   LEVELS.each do |severity, level|
     define_method(severity) do |message|
-      send_by_cable(message, severity)
+      # the log file is the primary log; it must be written even when
+      # MongoDB (WorkerLog) or the ActionCable backend is down
       @logger.public_send(severity, message)
-      # debug messages are not persisted to avoid bloating the collection
-      WorkerLog.create({worker: @type, level: level, message: message}) if level >= LEVELS[:info]
+      best_effort("broadcast") { send_by_cable(message, severity) }
+      if level >= LEVELS[:info]
+        # debug messages are not persisted to avoid bloating the collection
+        best_effort("WorkerLog") { WorkerLog.create({worker: @type, level: level, message: message}) }
+      end
+    end
+  end
+
+  private
+  def best_effort(target)
+    yield
+  rescue => ex
+    begin
+      @logger.warn("failed to record log to #{target}: #{ex.inspect}")
+    rescue
+      # give up: logging must never raise
     end
   end
 end

--- a/app/workers/parameter_sets_creator.rb
+++ b/app/workers/parameter_sets_creator.rb
@@ -10,7 +10,7 @@ class ParameterSetsCreator
       ensure
         task.destroy
       end
-      break if $term_received
+      break if Worker.term_received?
     end
   rescue => ex
     logger.error("Error in ParameterSetsCreator: #{ex.inspect}")

--- a/app/workers/worker.rb
+++ b/app/workers/worker.rb
@@ -7,33 +7,50 @@ class Worker < DaemonSpawn::Base
   #   - WORKER_STDOUT_FILE
   #   - TASKS
 
+  # The flag is stored on Worker itself so that subclasses and task classes
+  # (JobSubmitter, JobObserver, ...) all see the same flag.
+  def self.term_received?
+    !!Worker.instance_variable_get(:@term_received)
+  end
+
+  def self.term_received=(val)
+    Worker.instance_variable_set(:@term_received, val)
+  end
+
   def start(args)
     @logger = LoggerForWorker.new(self.class::WORKER_ID, self.class::WORKER_LOG_FILE, 7)
     @logger.info("starting #{self.class}")
 
-    $term_received = false
+    Worker.term_received = false
     trap('TERM') {
-      $term_received = true
+      Worker.term_received = true
       puts "TERM received. stopping"
     }
 
     loop do
       self.class::TASKS.each do |task|
-        task.call(@logger)
-        break if $term_received
+        begin
+          task.call(@logger)
+        rescue => ex
+          # a failure of one task must not kill the daemon
+          @logger.error("Error in #{self.class}: #{ex.inspect}")
+          @logger.error(ex.backtrace)
+        end
+        break if Worker.term_received?
       end
-      self.class::INTERVAL.times do |t|
-        break if $term_received
+      break if Worker.term_received?
+      self.class::INTERVAL.times do
+        break if Worker.term_received?
         sleep 1
       end
-      break if $term_received
+      break if Worker.term_received?
     end
 
   rescue => ex
-    @logger.fatal(ex.message)
-    @logger.fatal(ex.backtrace)
+    @logger&.fatal(ex.message)
+    @logger&.fatal(ex.backtrace)
   ensure
-    @logger.info("stopped")
+    @logger&.info("stopped")
   end
 
   def stop
@@ -59,4 +76,3 @@ class Worker < DaemonSpawn::Base
     false
   end
 end
-

--- a/lib/popen_ssh.rb
+++ b/lib/popen_ssh.rb
@@ -80,29 +80,44 @@ module PopenSSH
       @on_close_block = block
     end
 
-    def wait(timeout: nil)
+    # `timeout` limits how long to wait without receiving any output.
+    # The optional block is an interrupt condition polled while waiting
+    # (e.g. an absolute deadline); when it returns true the SSH process is
+    # terminated and Timeout::Error is raised, even if the process keeps
+    # producing output.
+    def wait(timeout: nil, &interrupt)
       ios = [@stdout, @stderr]
+      last_activity = Time.now
 
       loop do
-        ready = IO.select(ios, nil, nil, timeout)
+        if interrupt&.call
+          close
+          raise Timeout::Error, "interrupted while waiting for SSH output"
+        end
 
-        break unless ready
+        select_timeout = [timeout, (0.5 if interrupt)].compact.min
+        ready = IO.select(ios, nil, nil, select_timeout)
 
-        ready[0].each do |io|
-          begin
-            data = io.read_nonblock(1024)
-            case io
-            when @stdout
-              @on_data_block&.call(self, data)
-            when @stderr
-              @on_extended_data_block&.call(self, 1, data)
+        if ready
+          last_activity = Time.now
+          ready[0].each do |io|
+            begin
+              data = io.read_nonblock(1024)
+              case io
+              when @stdout
+                @on_data_block&.call(self, data)
+              when @stderr
+                @on_extended_data_block&.call(self, 1, data)
+              end
+            rescue IO::WaitReadable
+              next
+            rescue EOFError
+              ios.delete(io)
+              io.close
             end
-          rescue IO::WaitReadable
-            next
-          rescue EOFError
-            ios.delete(io)
-            io.close
           end
+        elsif timeout && Time.now - last_activity >= timeout
+          break # no output within the inactivity timeout; the process is killed below
         end
 
         break if ios.empty?
@@ -114,6 +129,11 @@ module PopenSSH
       end
 
       @on_close_block&.call
+    end
+
+    def close
+      Process.kill("TERM", @wait_thr.pid) if @wait_thr&.alive?
+    rescue Errno::ESRCH
     end
   end
 end

--- a/lib/ssh_util.rb
+++ b/lib/ssh_util.rb
@@ -1,52 +1,83 @@
+require 'open3'
+require 'securerandom'
+
 module SSHUtil
+
+  class CommandTimeoutError < StandardError; end
 
   class ShellSession
 
-    TOKEN = "XXXDONEXXX"
-    PATTERN = /XXXDONEXXX (\d+)$/
+    # safeguard against a hung remote command blocking the worker forever;
+    # long enough for a legitimately slow pre-process script
+    DEFAULT_COMMAND_TIMEOUT = 3600 # seconds
 
-    def initialize(channel)
+    attr_reader :token
+
+    def initialize(channel, token:, command_timeout: DEFAULT_COMMAND_TIMEOUT)
       @ch = channel
+      @token = token
+      @pattern = /#{Regexp.escape(token)} (\d+)$/
+      @command_timeout = command_timeout
+      @deadline = nil
     end
 
     def exec!(command)
-      @ch.send_data("#{command}\necho '#{TOKEN}' $?\n")
-      o = Fiber.yield
-      o[:stdout]
+      exec2!(command)[:stdout]
     end
 
     def exec2!(command)
-      @ch.send_data("#{command}\necho '#{TOKEN}' $?\n")
+      send_command(command)
       Fiber.yield
     end
 
-    def self.start(session, shell:"bash -l", logger: nil)
+    def send_command(command)
+      @deadline = Time.now + @command_timeout if @command_timeout
+      @ch.send_data("#{command}\necho '#{@token}' $?\n")
+    end
+
+    def command_finished!
+      @deadline = nil
+    end
+
+    def deadline_exceeded?
+      !@deadline.nil? && Time.now > @deadline
+    end
+
+    def match_finished_token(buffer)
+      @pattern.match(buffer)
+    end
+
+    def self.start(session, shell: "bash -l", logger: nil, command_timeout: DEFAULT_COMMAND_TIMEOUT)
+      # a random token prevents command output from being mistaken for the marker
+      token = "OACIS_CMD_DONE_#{SecureRandom.hex(8)}"
+      sh = nil
       channel = session.open_channel do |ch|
         ch.exec(shell) do |ch2, success|
           raise "failed to open shell" unless success
-          # Set the terminal type
-          ch2.send_data "export TERM=vt100\necho '#{TOKEN}' $?\n"
 
-          sh = ShellSession.new(ch2)
+          sh = ShellSession.new(ch2, token: token, command_timeout: command_timeout)
+          # Set the terminal type
+          sh.send_command("export TERM=vt100")
+
           f = Fiber.new do
             yield sh
             ch2.send_data("exit\n")
           end
 
-          output = {stdout: "", stderr: "", rc: nil}
+          output = {stdout: "", stderr: ""}
 
           ch2.on_data do |c,data|
             logger&.debug "o: #{data.chomp.scrub}"
-            if data =~ PATTERN
-              output[:stdout] += data.chomp.sub(PATTERN,'')
-              rc = $1.to_i
+            # accumulate the output in a buffer; the completion token may be
+            # split across data chunks
+            output[:stdout] += data
+            if m = sh.match_finished_token(output[:stdout])
+              rc = m[1].to_i
               logger&.debug "rc: #{rc}"
-              output[:rc] = rc
-              o = output
-              output = {stdout: "", stderr: "", rc: nil}
+              o = { stdout: m.pre_match, stderr: output[:stderr], rc: rc }
+              output = {stdout: "", stderr: ""}
+              sh.command_finished!
               f.resume o
-            else
-              output[:stdout] += data
             end
           end
 
@@ -56,26 +87,52 @@ module SSHUtil
           end
         end
       end
-      channel.wait
+
+      if session.respond_to?(:loop)  # Net::SSH
+        session.loop(0.5) { channel.active? && !(sh && sh.deadline_exceeded?) }
+        if sh && sh.deadline_exceeded?
+          channel.close rescue nil
+          raise CommandTimeoutError, "remote command did not finish within #{command_timeout} seconds"
+        end
+      else  # PopenSSH
+        begin
+          channel.wait(timeout: command_timeout)
+        rescue Timeout::Error
+          raise CommandTimeoutError, "remote command did not finish within #{command_timeout} seconds"
+        end
+      end
+    end
+  end
+
+  # Escape a remote path for the remote shell, keeping a leading '~' intact
+  # so that tilde expansion works (work_base_dir defaults to '~/oacis_work')
+  def self.escape_remote_path(path)
+    s = path.to_s
+    if s == "~"
+      s
+    elsif s.start_with?("~/")
+      "~/" + Shellwords.escape(s[2..])
+    else
+      Shellwords.escape(s)
     end
   end
 
   def self.download_file(hostname, remote_path, local_path)
-    cmd = "scp -Bqr '#{hostname}:#{remote_path}' #{local_path} 2> /dev/null"
-    system(cmd)
-    raise "'#{cmd}' failed : #{$?.to_i}" unless $?.to_i == 0
+    cmd = "scp -Bqr '#{hostname}:#{remote_path}' #{local_path}"
+    _out, err, status = Open3.capture3(cmd)
+    raise "'#{cmd}' failed with #{status.exitstatus}: #{err.chomp}" unless status.success?
   end
 
   def self.download_directory(hostname, remote_path, local_path)
     FileUtils.mkdir_p(local_path)
-    cmd = "scp -Bqr '#{hostname}:#{remote_path}/*' #{local_path} 2> /dev/null"
-    system(cmd)
-    raise "'#{cmd}' failed : #{$?.to_i}" unless $?.to_i == 0
+    cmd = "scp -Bqr '#{hostname}:#{remote_path}/*' #{local_path}"
+    _out, err, status = Open3.capture3(cmd)
+    raise "'#{cmd}' failed with #{status.exitstatus}: #{err.chomp}" unless status.success?
   end
 
   def self.download_recursive_if_exist(sh, hostname, remote_path, local_path)
     if directory?(sh, remote_path)
-      out = sh.exec!("ls #{remote_path}/")  # checking empty directory
+      out = sh.exec!("ls #{escape_remote_path(remote_path)}/")  # checking empty directory
       if out.chomp.empty?
         FileUtils.mkdir_p(local_path)
       else
@@ -91,17 +148,18 @@ module SSHUtil
   end
 
   def self.upload(hostname, local_path, remote_path)
-    cmd = "scp -Bqr #{local_path} '#{hostname}:#{remote_path}'"
+    cmd = "scp -Bqr #{Shellwords.escape(local_path.to_s)} '#{hostname}:#{remote_path}'"
     if File.directory?(local_path)
-      cmd = "scp -Bqr #{local_path}/ '#{hostname}:#{remote_path}'"
+      cmd = "scp -Bqr #{Shellwords.escape(local_path.to_s)}/ '#{hostname}:#{remote_path}'"
     end
-    system(cmd)
-    raise "'#{cmd}' failed : #{$?.to_i}" unless $?.to_i == 0
+    _out, err, status = Open3.capture3(cmd)
+    raise "'#{cmd}' failed with #{status.exitstatus}: #{err.chomp}" unless status.success?
   end
 
   def self.rm_r(sh, remote_paths)
     remote_paths = [remote_paths] unless remote_paths.is_a?(Array)
-    sh.exec!("rm -rf #{remote_paths.join(' ')}")
+    escaped = remote_paths.map {|p| escape_remote_path(p) }
+    sh.exec!("rm -rf #{escaped.join(' ')}")
   end
 
   def self.uname(sh)
@@ -126,17 +184,17 @@ module SSHUtil
   end
 
   def self.file?(sh, remote_path)
-    _out,_err,rc = execute2(sh, "test -f #{remote_path}")
+    _out,_err,rc = execute2(sh, "test -f #{escape_remote_path(remote_path)}")
     rc == 0
   end
 
   def self.directory?(sh, remote_path)
-    _out,_err,rc = execute2(sh, "test -d #{remote_path}")
+    _out,_err,rc = execute2(sh, "test -d #{escape_remote_path(remote_path)}")
     rc == 0
   end
 
   def self.exist?(sh, remote_path)
-    _out,_err,rc = execute2(sh, "test -e #{remote_path}")
+    _out,_err,rc = execute2(sh, "test -e #{escape_remote_path(remote_path)}")
     rc == 0
   end
 end

--- a/lib/ssh_util.rb
+++ b/lib/ssh_util.rb
@@ -96,7 +96,9 @@ module SSHUtil
         end
       else  # PopenSSH
         begin
-          channel.wait(timeout: command_timeout)
+          # the block is polled as an absolute per-command deadline; the
+          # `timeout` argument alone only limits inactivity between outputs
+          channel.wait(timeout: command_timeout) { sh && sh.deadline_exceeded? }
         rescue Timeout::Error
           raise CommandTimeoutError, "remote command did not finish within #{command_timeout} seconds"
         end

--- a/spec/lib/shell_session_spec.rb
+++ b/spec/lib/shell_session_spec.rb
@@ -1,0 +1,124 @@
+require 'spec_helper'
+
+describe SSHUtil::ShellSession do
+
+  # Emulates an SSH channel: responds to each command sent by ShellSession
+  # with the chunks returned by the responder block.
+  class FakeShellChannel
+    def initialize(&responder)
+      @responder = responder # (command_data, token) -> array of data chunks
+      @pending = []
+      @active = true
+    end
+
+    def exec(shell)
+      yield self, true
+    end
+
+    def send_data(data)
+      @pending << data
+    end
+
+    def on_data(&block); @on_data = block; end
+    def on_extended_data(&block); end
+
+    def active?; @active; end
+    def close; @active = false; end
+
+    def wait(timeout: nil)
+      while @pending.any?
+        data = @pending.shift
+        token = data[/echo '([^']+)' \$\?/, 1]
+        next if token.nil? # e.g. "exit\n"
+        @responder.call(data, token).each do |chunk|
+          @on_data.call(self, chunk)
+        end
+      end
+    end
+  end
+
+  # PopenSSH-like session: no #loop, the channel drives the interaction in #wait
+  class FakeShellSession
+    def initialize(channel); @channel = channel; end
+
+    def open_channel
+      yield @channel
+      @channel
+    end
+  end
+
+  # Net::SSH-like session with #loop; used for the timeout test
+  class FakeLoopShellSession
+    def initialize(channel); @channel = channel; end
+
+    def open_channel
+      yield @channel
+      @channel
+    end
+
+    def loop(wait = nil)
+      while yield
+        sleep 0.01
+      end
+    end
+  end
+
+  def start_and_exec(responder, command)
+    channel = FakeShellChannel.new(&responder)
+    session = FakeShellSession.new(channel)
+    result = nil
+    SSHUtil::ShellSession.start(session) do |sh|
+      result = sh.exec2!(command)
+    end
+    result
+  end
+
+  it "returns stdout and rc of the executed command" do
+    responder = lambda do |data, token|
+      if data.include?("export TERM")
+        ["#{token} 0\n"]
+      else
+        ["hello\n#{token} 0\n"]
+      end
+    end
+    result = start_and_exec(responder, "echo hello")
+    expect(result[:stdout]).to eq "hello\n"
+    expect(result[:rc]).to eq 0
+  end
+
+  it "returns a non-zero rc" do
+    responder = lambda do |data, token|
+      if data.include?("export TERM")
+        ["#{token} 0\n"]
+      else
+        ["oops\n#{token} 2\n"]
+      end
+    end
+    expect(start_and_exec(responder, "false")[:rc]).to eq 2
+  end
+
+  it "detects the completion token even when it is split across data chunks" do
+    responder = lambda do |data, token|
+      if data.include?("export TERM")
+        ["#{token} 0\n"]
+      else
+        # the token arrives split into two chunks
+        ["hello\n" + token[0..4], token[5..] + " 0\n"]
+      end
+    end
+    result = start_and_exec(responder, "echo hello")
+    expect(result[:stdout]).to eq "hello\n"
+    expect(result[:rc]).to eq 0
+  end
+
+  it "raises CommandTimeoutError when the remote command does not finish in time" do
+    channel = FakeShellChannel.new {|data, token| [] } # never responds
+    session = FakeLoopShellSession.new(channel)
+    expect {
+      SSHUtil::ShellSession.start(session, command_timeout: 0.1) do |sh|
+        sh.exec!("sleep 100")
+      end
+    }.to raise_error(SSHUtil::CommandTimeoutError)
+    expect(channel.active?).to be_falsey
+  end
+end

--- a/spec/lib/shell_session_spec.rb
+++ b/spec/lib/shell_session_spec.rb
@@ -121,4 +121,31 @@ describe SSHUtil::ShellSession do
     }.to raise_error(SSHUtil::CommandTimeoutError)
     expect(channel.active?).to be_falsey
   end
+
+  describe "command timeout with a real SSH connection to localhost" do
+
+    # the command keeps producing output at intervals shorter than the
+    # timeout: the deadline must be absolute, not an inactivity timeout
+    STREAMING_COMMAND = "while true; do echo tick; sleep 0.2; done"
+
+    it "raises CommandTimeoutError with the Net::SSH backend" do
+      Net::SSH.start('localhost', ENV['USER'], non_interactive: true, timeout: 1) do |ssh|
+        expect {
+          SSHUtil::ShellSession.start(ssh, command_timeout: 2) do |sh|
+            sh.exec!(STREAMING_COMMAND)
+          end
+        }.to raise_error(SSHUtil::CommandTimeoutError)
+      end
+    end
+
+    it "raises CommandTimeoutError with the PopenSSH backend" do
+      PopenSSH.start('localhost', ENV['USER'], non_interactive: true, timeout: 1) do |ssh|
+        expect {
+          SSHUtil::ShellSession.start(ssh, command_timeout: 2) do |sh|
+            sh.exec!(STREAMING_COMMAND)
+          end
+        }.to raise_error(SSHUtil::CommandTimeoutError)
+      end
+    end
+  end
 end

--- a/spec/lib/ssh_util_spec.rb
+++ b/spec/lib/ssh_util_spec.rb
@@ -284,4 +284,20 @@ describe SSHUtil do
   context "with PopenSSH backend" do
     it_behaves_like "SSHUtil backend", "PopenSSH", PopenSSH
   end
+
+  describe ".escape_remote_path" do
+
+    it "escapes shell special characters" do
+      expect(SSHUtil.escape_remote_path("/tmp/dir with space")).to eq "/tmp/dir\\ with\\ space"
+    end
+
+    it "keeps a leading tilde intact so that it is expanded by the remote shell" do
+      expect(SSHUtil.escape_remote_path("~/oacis work/run1")).to eq "~/oacis\\ work/run1"
+      expect(SSHUtil.escape_remote_path("~")).to eq "~"
+    end
+
+    it "accepts a Pathname" do
+      expect(SSHUtil.escape_remote_path(Pathname.new("/tmp/abc"))).to eq "/tmp/abc"
+    end
+  end
 end

--- a/spec/services/remote_job_handler_spec.rb
+++ b/spec/services/remote_job_handler_spec.rb
@@ -267,6 +267,24 @@ shared_examples_for RemoteJobHandler do
           RemoteJobHandler.new(@host).submit_remote_job(@submittable)
         }.to raise_error(RemoteJobHandler::RemoteSchedulerError)
       end
+
+      it "does not persist status=submitted when job_id is not obtained" do
+        expect_any_instance_of(SchedulerWrapper).to receive(:submit_command).and_return("echo '{}'")
+        expect {
+          RemoteJobHandler.new(@host).submit_remote_job(@submittable)
+        }.to raise_error(RemoteJobHandler::RemoteSchedulerError)
+        expect(@submittable.reload.status).to eq :failed
+        expect(@submittable.reload.job_id).to be_nil
+      end
+
+      it "does not persist status=submitted when the submit output is not parsable" do
+        expect_any_instance_of(SchedulerWrapper).to receive(:submit_command).and_return("echo not-a-json")
+        expect {
+          RemoteJobHandler.new(@host).submit_remote_job(@submittable)
+        }.to raise_error(RemoteJobHandler::RemoteSchedulerError)
+        expect(@submittable.reload.status).to eq :failed
+        expect(@submittable.reload.job_id).to be_nil
+      end
     end
   end
 
@@ -290,6 +308,13 @@ shared_examples_for RemoteJobHandler do
       allow(SSHUtil).to receive(:execute2).and_return([out,'',0])
       expect(RemoteJobHandler.new(@host).support_multiple_xstat?).to be_falsey
     end
+
+    it "caches the result per host and does not run the command again" do
+      allow_any_instance_of(SchedulerWrapper).to receive(:status_help_command).and_return("xstat --help")
+      expect(SSHUtil).to receive(:execute2).once.and_return(["-m, --multiple","",0])
+      expect(RemoteJobHandler.new(@host).support_multiple_xstat?).to be_truthy
+      expect(RemoteJobHandler.new(@host).support_multiple_xstat?).to be_truthy
+    end
   end
 
   describe ".remote_status" do
@@ -304,17 +329,47 @@ shared_examples_for RemoteJobHandler do
     end
 
     it "raise RemoteSchedulerError if remote status is not obtained by SchedulerWrapper" do
-      allow(SSHUtil).to receive(:execute2).and_return("","",1)
+      allow(SSHUtil).to receive(:execute2).and_return(["","",1])
       expect {
         RemoteJobHandler.new(@host).remote_status(@submittable)
       }.to raise_error(RemoteJobHandler::RemoteSchedulerError)
     end
 
-    it "run.error_message is updated if remote status is not obtained by SchedulerWrapper" do
-      allow(SSHUtil).to receive(:execute2).and_return([nil, nil, 1])
+    it "does not update the job until the status check fails several times in a row" do
+      allow(SSHUtil).to receive(:execute2).and_return(["","",1])
+      handler = RemoteJobHandler.new(@host)
       expect {
-        RemoteJobHandler.new(@host).remote_status(@submittable) rescue nil
-      }.to change { @submittable.reload.error_messages }
+        (RemoteJobHandler::STATUS_CHECK_FAILURE_LIMIT - 1).times do
+          handler.remote_status(@submittable) rescue nil
+        end
+      }.to_not change { [@submittable.reload.error_messages, @submittable.reload.status] }
+    end
+
+    it "marks the job as failed after consecutive status check failures" do
+      allow(SSHUtil).to receive(:execute2).and_return(["","",1])
+      handler = RemoteJobHandler.new(@host)
+      expect {
+        RemoteJobHandler::STATUS_CHECK_FAILURE_LIMIT.times do
+          handler.remote_status(@submittable) rescue nil
+        end
+      }.to change { @submittable.reload.status }.to(:failed)
+      expect(@submittable.reload.error_messages).to_not be_empty
+    end
+
+    it "resets the failure count when a status check succeeds" do
+      handler = RemoteJobHandler.new(@host)
+      allow(SSHUtil).to receive(:execute2).and_return(["","",1])
+      (RemoteJobHandler::STATUS_CHECK_FAILURE_LIMIT - 1).times do
+        handler.remote_status(@submittable) rescue nil
+      end
+      allow(SSHUtil).to receive(:execute2).and_return(['{"status":"running"}',"",0])
+      expect( handler.remote_status(@submittable) ).to eq :running
+      allow(SSHUtil).to receive(:execute2).and_return(["","",1])
+      expect {
+        (RemoteJobHandler::STATUS_CHECK_FAILURE_LIMIT - 1).times do
+          handler.remote_status(@submittable) rescue nil
+        end
+      }.to_not change { @submittable.reload.status }
     end
   end
 
@@ -331,13 +386,18 @@ shared_examples_for RemoteJobHandler do
       expect(RemoteJobHandler.new(@host).remote_status_multiple([@submittable])).to eq(expected)
     end
 
-    it "raise RemoteSchedulerError is remote status is not obtained and change run.error_message" do
+    it "raise RemoteSchedulerError if remote status is not obtained" do
       allow(SSHUtil).to receive(:execute2).and_return(["", "", 1])
       expect {
-        expect {
-          RemoteJobHandler.new(@host).remote_status_multiple([@submittable])
-        }.to raise_error(RemoteJobHandler::RemoteSchedulerError)
-      }.to change { @submittable.reload.error_messages }
+        RemoteJobHandler.new(@host).remote_status_multiple([@submittable])
+      }.to raise_error(RemoteJobHandler::RemoteSchedulerError)
+    end
+
+    it "does not update the jobs on failure so that the caller can fall back to individual status checks" do
+      allow(SSHUtil).to receive(:execute2).and_return(["", "", 1])
+      expect {
+        RemoteJobHandler.new(@host).remote_status_multiple([@submittable]) rescue nil
+      }.to_not change { [@submittable.reload.error_messages, @submittable.reload.status] }
     end
   end
 
@@ -463,17 +523,26 @@ shared_examples_for RemoteJobHandler do
     context "when it get ssh connection error" do
 
       it "write error_message" do
-        expect_any_instance_of(RemoteJobHandler).to receive(:create_remote_work_dir).and_raise("#<NoMethodError: undefined method `stat' for nil:NilClass>")
+        # net-ssh raises NoMethodError on nil when the transport socket is gone
+        expect_any_instance_of(RemoteJobHandler).to receive(:create_remote_work_dir).and_raise(NoMethodError, "undefined method 'stat' for nil")
         expect {
           RemoteJobHandler.new(@host).submit_remote_job(@submittable) rescue nil
         }.to change { @submittable.reload.error_messages }.to match(/failed to establish ssh connection to host\(#{@submittable.submitted_to.name}\)/)
       end
 
       it "does not change run status" do
-        expect_any_instance_of(RemoteJobHandler).to receive(:create_remote_work_dir).and_raise("#<NoMethodError: undefined method `stat' for nil:NilClass>")
+        expect_any_instance_of(RemoteJobHandler).to receive(:create_remote_work_dir).and_raise(NoMethodError, "undefined method 'stat' for nil")
         expect {
           RemoteJobHandler.new(@host).submit_remote_job(@submittable) rescue nil
         }.not_to change { @submittable.reload.status }
+      end
+
+      it "handles Net::SSH exceptions as connection errors" do
+        expect_any_instance_of(RemoteJobHandler).to receive(:create_remote_work_dir).and_raise(Net::SSH::Exception, "connection closed by remote host")
+        expect {
+          RemoteJobHandler.new(@host).submit_remote_job(@submittable) rescue nil
+        }.to change { @submittable.reload.error_messages }.to match(/failed to establish ssh connection to host\(#{@submittable.submitted_to.name}\)/)
+        expect(@submittable.reload.status).to_not eq :failed
       end
     end
 

--- a/spec/services/remote_job_handler_spec.rb
+++ b/spec/services/remote_job_handler_spec.rb
@@ -371,6 +371,22 @@ shared_examples_for RemoteJobHandler do
         end
       }.to_not change { @submittable.reload.status }
     end
+
+    it "resets the failure count when remote_status_multiple succeeds for the job" do
+      handler = RemoteJobHandler.new(@host)
+      allow(SSHUtil).to receive(:execute2).and_return(["","",1])
+      (RemoteJobHandler::STATUS_CHECK_FAILURE_LIMIT - 1).times do
+        handler.remote_status(@submittable) rescue nil
+      end
+      allow(SSHUtil).to receive(:execute2).and_return(['{"12345":{"status":"running"}}',"",0])
+      expect( handler.remote_status_multiple([@submittable]) ).to eq({"12345" => :running})
+      allow(SSHUtil).to receive(:execute2).and_return(["","",1])
+      expect {
+        (RemoteJobHandler::STATUS_CHECK_FAILURE_LIMIT - 1).times do
+          handler.remote_status(@submittable) rescue nil
+        end
+      }.to_not change { @submittable.reload.status }
+    end
   end
 
   describe "#remote_status_multiple" do

--- a/spec/workers/host_polling_spec.rb
+++ b/spec/workers/host_polling_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe HostPolling do
+
+  before(:each) do
+    @task_class = Class.new { extend HostPolling }
+    @logger = Logger.new( File.open('/dev/null','w') )
+    Worker.term_received = false
+  end
+
+  after(:each) do
+    Worker.term_received = false
+  end
+
+  describe ".each_host_to_poll" do
+
+    it "yields each enabled host" do
+      host1 = FactoryBot.create(:host)
+      host2 = FactoryBot.create(:host)
+      FactoryBot.create(:host, status: :disabled)
+      yielded = []
+      @task_class.each_host_to_poll(@logger) {|host| yielded << host.id }
+      expect(yielded).to match_array [host1.id, host2.id]
+    end
+
+    it "continues with the remaining hosts when processing of one host fails" do
+      host1 = FactoryBot.create(:host)
+      host2 = FactoryBot.create(:host)
+      yielded = []
+      expect {
+        @task_class.each_host_to_poll(@logger) do |host|
+          yielded << host.id
+          raise "error" if host.id == host1.id
+        end
+      }.to_not raise_error
+      expect(yielded).to match_array [host1.id, host2.id]
+    end
+
+    it "skips a host until its polling interval has passed" do
+      FactoryBot.create(:host)
+      count = 0
+      @task_class.each_host_to_poll(@logger) {|host| count += 1 }
+      @task_class.each_host_to_poll(@logger) {|host| count += 1 }
+      expect(count).to eq 1
+    end
+
+    it "does not yield hosts after TERM is received" do
+      FactoryBot.create(:host)
+      Worker.term_received = true
+      yielded = false
+      @task_class.each_host_to_poll(@logger) {|host| yielded = true }
+      expect(yielded).to be_falsey
+    end
+  end
+end

--- a/spec/workers/job_observer_spec.rb
+++ b/spec/workers/job_observer_spec.rb
@@ -135,6 +135,30 @@ describe JobObserver do
           JobObserver.__send__(:observe_host, @host, @logger)
         }.to change { Run.unscoped.count }.by(-1)
       end
+
+      it "continues processing other jobs when canceling one job fails" do
+        run2 = @sim.parameter_sets.first.runs.create(submitted_to: @host)
+        run2.status = :submitted
+        run2.job_id = "234"
+        run2.save!
+        allow_any_instance_of(RemoteJobHandler).to receive(:support_multiple_xstat?).and_return(false)
+        allow_any_instance_of(RemoteJobHandler).to receive(:cancel_remote_job).and_raise("cancel failed")
+        expect_any_instance_of(RemoteJobHandler).to receive(:remote_status).and_return(:submitted)
+        expect {
+          JobObserver.__send__(:observe_host, @host, @logger)
+        }.to_not change { Run.unscoped.count }
+      end
+    end
+
+    context "when remote_status_multiple fails" do
+
+      it "falls back to the status check of each job" do
+        allow_any_instance_of(RemoteJobHandler).to receive(:support_multiple_xstat?).and_return(true)
+        allow_any_instance_of(RemoteJobHandler).to receive(:remote_status_multiple).and_raise(RemoteJobHandler::RemoteSchedulerError)
+        expect_any_instance_of(RemoteJobHandler).to receive(:remote_status).and_return(:running)
+        JobObserver.__send__(:observe_host, @host, @logger)
+        expect(@run.reload.status).to eq :running
+      end
     end
 
     context "when ssh connection error occers" do

--- a/spec/workers/logger_for_worker_spec.rb
+++ b/spec/workers/logger_for_worker_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe LoggerForWorker do
+
+  before(:each) do
+    @temp_dir = Pathname.new('__temp_logger__')
+    FileUtils.mkdir_p(@temp_dir)
+    @log_path = @temp_dir.join('worker.log')
+    @logger = LoggerForWorker.new(:service, @log_path, 7)
+  end
+
+  after(:each) do
+    FileUtils.rm_r(@temp_dir) if File.directory?(@temp_dir)
+  end
+
+  it "creates a WorkerLog record for info and above" do
+    expect {
+      @logger.info("recorded message")
+    }.to change { WorkerLog.count }.by(1)
+  end
+
+  it "does not create a WorkerLog record for debug" do
+    expect {
+      @logger.debug("debug message")
+    }.to_not change { WorkerLog.count }
+  end
+
+  context "when WorkerLog cannot be saved (e.g. MongoDB is down)" do
+
+    before(:each) do
+      allow(WorkerLog).to receive(:create).and_raise("mongodb is down")
+    end
+
+    it "does not raise and still writes to the log file" do
+      expect {
+        @logger.error("error while db is down")
+      }.to_not raise_error
+      expect(File.read(@log_path)).to include("error while db is down")
+    end
+  end
+
+  context "when ActionCable broadcast fails (e.g. Redis is down)" do
+
+    before(:each) do
+      allow(WorkerLogChannel).to receive(:broadcast_to).and_raise("redis is down")
+    end
+
+    it "does not raise and still writes to the log file" do
+      expect {
+        @logger.info("info while cable is down")
+      }.to_not raise_error
+      expect(File.read(@log_path)).to include("info while cable is down")
+    end
+  end
+end

--- a/spec/workers/worker_spec.rb
+++ b/spec/workers/worker_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe Worker do
+
+  before(:each) do
+    @temp_dir = Pathname.new('__temp_worker__')
+    FileUtils.mkdir_p(@temp_dir)
+    dummy = Class.new(Worker)
+    dummy.const_set(:INTERVAL, 0)
+    dummy.const_set(:WORKER_ID, :service)
+    dummy.const_set(:WORKER_PID_FILE, @temp_dir.join("worker.pid"))
+    dummy.const_set(:WORKER_LOG_FILE, @temp_dir.join("worker.log"))
+    dummy.const_set(:WORKER_STDOUT_FILE, @temp_dir.join("worker_out.log"))
+    stub_const("WorkerSpecDummy", dummy)
+    Worker.term_received = false
+  end
+
+  after(:each) do
+    Worker.term_received = false
+    FileUtils.rm_r(@temp_dir) if File.directory?(@temp_dir)
+  end
+
+  describe "#start" do
+
+    it "continues with the next task when a task raises an exception" do
+      calls = []
+      WorkerSpecDummy.const_set(:TASKS, [
+        lambda {|logger| calls << :first; raise "task error" },
+        lambda {|logger| calls << :second; Worker.term_received = true }
+      ])
+      WorkerSpecDummy.allocate.start([])
+      expect(calls).to eq [:first, :second]
+    end
+
+    it "stops the loop when term_received is set" do
+      count = 0
+      WorkerSpecDummy.const_set(:TASKS, [
+        lambda {|logger| count += 1; Worker.term_received = true }
+      ])
+      WorkerSpecDummy.allocate.start([])
+      expect(count).to eq 1
+    end
+  end
+
+  describe ".term_received?" do
+
+    it "is shared between Worker and its subclasses" do
+      Worker.term_received = true
+      expect(WorkerSpecDummy.term_received?).to be_truthy
+      Worker.term_received = false
+      expect(WorkerSpecDummy.term_received?).to be_falsey
+    end
+  end
+end

--- a/spec/workers/worker_spec.rb
+++ b/spec/workers/worker_spec.rb
@@ -32,6 +32,17 @@ describe Worker do
       expect(calls).to eq [:first, :second]
     end
 
+    it "keeps running when both a task and the log persistence fail (e.g. MongoDB is down)" do
+      allow(WorkerLog).to receive(:create).and_raise("mongodb is down")
+      calls = []
+      WorkerSpecDummy.const_set(:TASKS, [
+        lambda {|logger| calls << :first; raise "task error" },
+        lambda {|logger| calls << :second; Worker.term_received = true }
+      ])
+      WorkerSpecDummy.allocate.start([])
+      expect(calls).to eq [:first, :second]
+    end
+
     it "stops the loop when term_received is set" do
       count = 0
       WorkerSpecDummy.const_set(:TASKS, [


### PR DESCRIPTION
## Summary

Worker周り(`app/workers/`, `app/services/remote_job_handler.rb`, `lib/ssh_util.rb`)のコードレビューで見つかった堅牢性の問題を修正します。

### 高優先度の修正

- **デーモンの恒久停止を防止** — `Worker#start` のループ内でタスク単位に rescue し、一時的な例外(Mongo接続断など)でデーモンプロセスが死なないようにした
- **Ruby 3.3+ で機能していなかったSSH接続エラー判定を修正** — `NoMethodError` のメッセージ文字列マッチ(``undefined method `stat' for nil:NilClass``)は Ruby 3.4 では形式が変わり二度とマッチしない。例外クラス(`Host::CONNECTION_EXCEPTIONS`)+クォート非依存の正規表現による判定に変更
- **一時的な `xstat` 失敗でジョブが failed 化されるのを防止** — 3回連続で status check に失敗した場合のみ failed 化+リモート work_dir 回収を行う。`remote_status_multiple` の失敗で全ジョブが failed になる問題も修正し、JobObserver は個別チェックにフォールバック
- **job_id なしで status=submitted が永続化されうる問題を修正** — `xsub` 出力から job_id が取れた後に `status = :submitted` を代入
- **SSHシェルセッションのハング対策** — 完了トークンがパケット境界で分割されても検出できるようバッファリング化、セッション毎のランダムトークン化、コマンドタイムアウト(デフォルト1時間)を導入
- **キャンセル失敗1件でホストの残り全ジョブの処理が止まる問題を修正** — `destroy_jobs` をジョブ単位で rescue

### その他の改善

- JobSubmitter / JobObserver の重複(ホストポーリング、SSHデバッグロガー)を `HostPolling` モジュールに抽出
- `$term_received` グローバル変数を `Worker.term_received?` にカプセル化
- `support_multiple_xstat?` をホスト毎にキャッシュ(毎サイクルの `xstat --help` SSH実行を削減)
- `WorkerLog` に TTL インデックス(7日)を追加し、コレクションの無制限成長を防止
- リモートパスのシェルエスケープを導入(`~` 展開は維持)、scp のエラー詳細(stderr)を例外メッセージに含める
- `job_submitter.rb` の既知の `[warning]`(`limit` が無視され `num` が負になる)を `to_a` で解消
- `LoggerFormatWithTime` を `LoggerForWorker` 内にネスト定義し、test 環境でも worker が動作するように修正(これにより `Worker` のspecが初めて書けるようになった)

## Test plan

- [x] `bundle exec rspec spec/workers spec/services spec/lib/ssh_util_spec.rb spec/lib/shell_session_spec.rb spec/lib/scheduler_wrapper_spec.rb spec/lib/popen_ssh_spec.rb` → **302 examples, 0 failures** (4 pending は既存の skip)
- [x] `rails zeitwerk:check` パス
- [x] 新規spec: `worker_spec.rb`(タスク失敗時の継続・TERM停止)、`host_polling_spec.rb`、`shell_session_spec.rb`(トークン分割・タイムアウト)、status check リトライ / job_id 未取得 / フォールバックの回帰テスト

## 運用上の注意

- `WorkerLog` の TTL インデックスは `rake daemon:start` 時の `db:mongoid:create_indexes` で適用され、**7日より古いworkerログは削除されるようになります**
- status check 失敗時のジョブ failed 化は最大2ポーリングサイクル遅延します(意図的な変更)

🤖 Generated with [Claude Code](https://claude.com/claude-code)