### PR TITLE
Fix plot rendering bugs: color mismatch and cross-plot state leaks

### DIFF
--- a/app/assets/javascripts/plot/figure_viewer.js
+++ b/app/assets/javascripts/plot/figure_viewer.js
@@ -13,7 +13,7 @@ FigureViewer.prototype.figure_size = "point";
 
 FigureViewer.prototype.Init = function(data, url, parameter_set_base_url, current_ps_id) {
   Plot.prototype.Init.call(this, data, url, parameter_set_base_url, current_ps_id);
-  d3.select("#clip rect")
+  this.main_group.select("#" + this.clipId + " rect")
     .attr("y", -5-92)
     .attr("width", this.width+10+112)
     .attr("height", this.height+10+92);
@@ -65,7 +65,7 @@ FigureViewer.prototype.SetYScale = function(yscale) {
     break;
   case "log":
     const data_in_logscale = this.data.data.filter(function(element) {
-      return element[0] > 0.0;
+      return element[1] > 0.0;
     });
     scale = d3.scale.log().clamp(true).range([this.height, 0]);
     min = d3.min( data_in_logscale, function(d) { return d[1];});
@@ -101,7 +101,7 @@ FigureViewer.prototype.UpdatePlot = function(new_size) {
     if(new_size == "point") {
       this.UpdatePointPlot();
     } else {
-      this.main_group.select("g#point-group").remove();
+      this.main_group.select("g.point-group").remove();
       this.AddPlot();
     }
     break;
@@ -109,7 +109,7 @@ FigureViewer.prototype.UpdatePlot = function(new_size) {
   case "large":
     this.figure_size = new_size;
     if(new_size == "point") {
-      this.main_group.select("g#figure-group").remove();
+      this.main_group.select("g.figure-group").remove();
       this.AddPlot();
     } else {
       this.UpdateFigurePlot();
@@ -129,11 +129,11 @@ FigureViewer.prototype.AddFigurePlot = function() {
       return { x: v[0], y: v[1], path:v[2], psid: v[3] };
     });
     const figure_group = plot.main_group.append("g")
-      .attr("id", "figure-group");
+      .attr("class", "figure-group");
     const figure = figure_group.selectAll("image")
       .data(mapped).enter();
     figure.append("svg:image")
-      .attr("clip-path", "url(#clip)")
+      .attr("clip-path", "url(#" + plot.clipId + ")")
       .attr("xlink:href", function(d) { return d.path; })
       .on("mouseover", function(d) {
         tooltip.transition()
@@ -182,7 +182,7 @@ FigureViewer.prototype.UpdateFigurePlot = function() {
     y_figure_scale*=(plot.yaxis_original_domain[1] - plot.yaxis_original_domain[0])/(ydomain[1] - ydomain[0]);
   }
   function update_figure_plot() {
-    const figure_group = plot.main_group.select("g#figure-group");
+    const figure_group = plot.main_group.select("g.figure-group");
     figure_group.selectAll("image")
       .attr("x", function(d) { return plot.xScale(d.x);})
       .attr("y", function(d) { return plot.yScale(d.y) - plot.height*y_figure_scale;})
@@ -202,11 +202,11 @@ FigureViewer.prototype.AddPointPlot = function() {
       return { x: v[0], y: v[1], path:v[2], psid: v[3] };
     });
     const point_group = plot.main_group.append("g")
-      .attr("id", "point-group");
+      .attr("class", "point-group");
     const point = point_group.selectAll("circle")
       .data(mapped).enter();
     point.append("circle")
-      .attr("clip-path", "url(#clip)")
+      .attr("clip-path", "url(#" + plot.clipId + ")")
       .style("fill", function() { return "black";})
       .attr("r", function(d) { return (d.psid == plot.current_ps_id) ? 5 : 3;})
       .on("mouseover", function(d) {
@@ -248,7 +248,7 @@ FigureViewer.prototype.UpdatePointPlot = function() {
   const plot = this;
 
   function update_point_group() {
-    const point_group = plot.main_group.select("g#point-group");
+    const point_group = plot.main_group.select("g.point-group");
     point_group.selectAll("circle")
       .attr("cx", function(d) { return plot.xScale(d.x);})
       .attr("cy", function(d) { return plot.yScale(d.y);});
@@ -312,25 +312,23 @@ FigureViewer.prototype.AddDescription = function() {
     plot.description.append("div").style("padding-bottom", "50px");
 
     const log_check_box = plot.description.append("div").attr("class", "checkbox");
-    const check_box_x_label = log_check_box.append("label").attr("id", "x_log_check");
+    const check_box_x_label = log_check_box.append("label");
     check_box_x_label.html('<input type="checkbox"> log scale on x axis');
-    //d3.select gets the first element. This selection is available only when new svg will appear at the above of the old svg.
-    d3.select('label#x_log_check input').on("change", function() {
+    check_box_x_label.select("input").on("change", function() {
       reset_brush(this.checked ? "log" : "linear", plot.IsLog[1] ? "log" : "linear");
     });
     log_check_box.append("br");
 
-    const check_box_y_label = log_check_box.append("label").attr("id", "y_log_check");
+    const check_box_y_label = log_check_box.append("label");
     check_box_y_label.html('<input type="checkbox"> log scale on y axis');
-    //d3.select gets the first element. This selection is available only when new svg will appear at the above of the old svg.
-    d3.select('label#y_log_check input').on("change", function() {
+    check_box_y_label.select("input").on("change", function() {
       reset_brush(plot.IsLog[0] ? "log" : "linear", this.checked ? "log" : "linear");
     });
 
     plot.description.append("br");
     const control_plot = plot.description.append("div").style("margin-top", "10px");
     function add_brush() {
-      const selector = (plot.figure_size == "point") ? "g#point-group" : "g#figure-group";
+      const selector = (plot.figure_size == "point") ? "g.point-group" : "g.figure-group";
       const clone = plot.main_group.select(selector).node().cloneNode(true);
       control_plot.append("svg")
         .attr("width","210")

--- a/app/assets/javascripts/plot/line_plot.js
+++ b/app/assets/javascripts/plot/line_plot.js
@@ -4,7 +4,6 @@ function LinePlot() {
 
 LinePlot.prototype = Object.create(Plot.prototype);// LinePlot is sub class of Plot
 LinePlot.prototype.constructor = LinePlot;// override constructor
-LinePlot.prototype.IsLog = [false,false];
 
 LinePlot.prototype.SetXScale = function(xscale) {
   let scale = null, min, max;
@@ -53,11 +52,6 @@ LinePlot.prototype.SetYScale = function(yscale) {
     this.IsLog[1] = false;
     break;
   case "log":
-    const data_in_logscale = this.data.data.map(function(element) {
-      return element.filter(function(element){
-        return element[0] > 0.0;
-      });
-    });
     scale = d3.scale.log().clamp(true).range([this.height, 0]);
     min = d3.min( this.data.data, function(r) { return d3.min(r, function(v) { return v[1] - v[2];});});
     max = d3.max( this.data.data, function(r) { return d3.max(r, function(v) { return v[1] + v[2];});});
@@ -102,10 +96,11 @@ LinePlot.prototype.SetYDomain = function(ymin, ymax) {
 
 LinePlot.prototype.AddPlot = function() {
   const plot = this;
-  const colorScale = d3.scale.category10();
+  plot.colorScale = d3.scale.category10().domain(d3.range(plot.data.data.length));
+  const colorScale = plot.colorScale;
 
   function add_series_group() {
-    const plot_group = plot.main_group.append("g").attr("id", "plot-group");
+    const plot_group = plot.main_group.append("g").attr("class", "plot-group");
     const series = plot_group
       .selectAll("g")
       .data(plot.data.data)
@@ -114,7 +109,7 @@ LinePlot.prototype.AddPlot = function() {
 
     // add line
     series.append("path")
-      .attr("clip-path", "url(#clip)")
+      .attr("clip-path", "url(#" + plot.clipId + ")")
       .style({
         "stroke": function(d, i) { return colorScale(i);},
         "fill": "none",
@@ -134,7 +129,7 @@ LinePlot.prototype.AddPlot = function() {
         });
       }).enter();
     point.append("circle")
-      .attr("clip-path", "url(#clip)")
+      .attr("clip-path", "url(#" + plot.clipId + ")")
       .style("fill", function(d) { return colorScale(d.series_index);})
       .attr("r", function(d) { return (d.psid == plot.current_ps_id) ? 5 : 3;})
       .on("mouseover", function(d) {
@@ -143,7 +138,7 @@ LinePlot.prototype.AddPlot = function() {
           .style("opacity", 0.8);
         let html = plot.data.xlabel + " : " + d.x + "<br/>" +
             plot.data.ylabel + " : " + Math.round(d.y*1000000)/1000000 +
-            " (" + Math.round(d.yerror*1000000)/1000000 + ")<br/>" +
+            (d.yerror != null ? " (" + Math.round(d.yerror*1000000)/1000000 + ")" : "") + "<br/>" +
             (plot.data.series ? (plot.data.series + " : " + d.series_value + "<br/>") : "") +
             "ID: " + d.psid;
         if (d.count) html += `<br />${d.count} Runs`;
@@ -166,23 +161,23 @@ LinePlot.prototype.AddPlot = function() {
 
     // add error bar
     point.insert("line", "circle")
-      .attr("clip-path", "url(#clip)")
+      .attr("clip-path", "url(#" + plot.clipId + ")")
       .attr("class", "line yerror bar");
     point.insert("line", "circle")
-      .attr("clip-path", "url(#clip)")
+      .attr("clip-path", "url(#" + plot.clipId + ")")
       .attr("class", "line yerror top");
     point.insert("line", "circle")
-      .attr("clip-path", "url(#clip)")
+      .attr("clip-path", "url(#" + plot.clipId + ")")
       .attr("class", "line yerror bottom");
   }
   add_series_group();
 
   function add_legend_group() {
     const legend_region = plot.main_group.append("g")
-      .attr("id", "legend-group")
+      .attr("class", "legend-group")
       .attr("transform", "translate(" + plot.width + "," + 0 + ")");
     const legend = legend_region.append("g")
-      .attr("id", "legend")
+      .attr("class", "legend")
       .attr("transform", "translate(" + 0 + "," + 20 + ")");
 
     // add legend
@@ -205,7 +200,7 @@ LinePlot.prototype.AddPlot = function() {
 
     // add legend title
     const legend_title = legend_region.append("g")
-      .attr("id", "legend-title");
+      .attr("class", "legend-title");
     legend_title.append("text")
       .attr({
         x: 0,
@@ -222,7 +217,7 @@ LinePlot.prototype.AddPlot = function() {
 
 LinePlot.prototype.UpdatePlot = function() {
   const plot = this;
-  const colorScale = d3.scale.category10();
+  const colorScale = plot.colorScale;
   const line = d3.svg.line()
     .x( function(d) { return plot.xScale(d[0]);} )
     .y( function(d) { return plot.yScale(d[1]);} );
@@ -332,25 +327,23 @@ LinePlot.prototype.AddDescription = function() {
     plot.description.append("div").style("padding-bottom", "50px");
 
     const log_check_box = plot.description.append("div").attr("class", "checkbox");
-    const check_box_x_label = log_check_box.append("label").attr("id", "x_log_check");
+    const check_box_x_label = log_check_box.append("label");
     check_box_x_label.html('<input type="checkbox"> log scale on x axis');
-    //d3.select gets the first element. This selection is available only when new svg will appear at the above of the old svg.
-    d3.select('label#x_log_check input').on("change", function() {
+    check_box_x_label.select("input").on("change", function() {
       reset_brush(this.checked ? "log" : "linear", plot.IsLog[1] ? "log" : "linear");
     });
     log_check_box.append("br");
 
-    const check_box_y_label = log_check_box.append("label").attr("id", "y_log_check");
+    const check_box_y_label = log_check_box.append("label");
     check_box_y_label.html('<input type="checkbox"> log scale on y axis');
-    //d3.select gets the first element. This selection is available only when new svg will appear at the above of the old svg.
-    d3.select('label#y_log_check input').on("change", function() {
+    check_box_y_label.select("input").on("change", function() {
       reset_brush(plot.IsLog[0] ? "log" : "linear", this.checked ? "log" : "linear");
     });
 
     plot.description.append("br");
     const control_plot = plot.description.append("div").style("margin-top", "10px");
     function add_brush() {
-      const clone = plot.main_group.select("g#plot-group").node().cloneNode(true);
+      const clone = plot.main_group.select("g.plot-group").node().cloneNode(true);
       control_plot.append("svg")
         .attr("width","210")
         .attr("height","155")

--- a/app/assets/javascripts/plot/plot.js
+++ b/app/assets/javascripts/plot/plot.js
@@ -1,4 +1,6 @@
 function Plot() {
+  this.plotId = Plot.plotIdCounter++;
+  this.clipId = "clip" + this.plotId;
   this.row = d3.select("#plot").insert("div","div").attr("class", "row");
   this.plot_region = this.row.append("div").attr("class", "col-md-8");
   this.description = this.row.append("div").attr("class", "col-md-4");
@@ -11,6 +13,8 @@ function Plot() {
     .append("g")
       .attr("transform", "translate(" + this.margin.left + "," + this.margin.top + ")");
 }
+
+Plot.plotIdCounter = 0;
 
 Plot.prototype.margin = {top: 10, right: 100, bottom: 100, left: 120};
 Plot.prototype.width = 560;
@@ -25,6 +29,7 @@ Plot.prototype.current_ps_id = null;
 Plot.prototype.parameter_set_base_url = null;
 
 Plot.prototype.Init = function(data, url, parameter_set_base_url, current_ps_id) {
+  this.IsLog = [false, false];
   this.data = data;
   this.url = url;
   this.parameter_set_base_url = parameter_set_base_url;
@@ -36,7 +41,7 @@ Plot.prototype.Init = function(data, url, parameter_set_base_url, current_ps_id)
   this.SetYScale("linear");
 
   this.main_group.append("defs").append("clipPath")
-    .attr("id", "clip")
+    .attr("id", this.clipId)
     .append("rect")
     .attr("x", -5) // 5 is radius of large point
     .attr("y", -5) // 5 is radius of large point

--- a/app/assets/javascripts/plot/scatter_plot.js
+++ b/app/assets/javascripts/plot/scatter_plot.js
@@ -6,7 +6,6 @@ function ScatterPlot() {
 
 ScatterPlot.prototype = Object.create(Plot.prototype);// ScatterPlot is sub class of Plot
 ScatterPlot.prototype.constructor = ScatterPlot;// override constructor
-ScatterPlot.prototype.IsLog = [false, false];   // true if x/y scale is log
 
 ScatterPlot.prototype.SetXScale = function(xscale) {
   const plot = this;
@@ -116,7 +115,7 @@ ScatterPlot.prototype.AddPlot = function() {
     const color_map = plot.main_group.append("g")
       .attr({
         "transform": "translate(" + plot.width + "," + plot.margin.top + ")",
-        "id": "color-map-group"
+        "class": "color-map-group"
       });
     const scale = d3.scale.linear().domain([0.0, 0.5, 1.0]).range(plot.colorScale.range());
     color_map.append("text")
@@ -134,25 +133,25 @@ ScatterPlot.prototype.AddPlot = function() {
         fill: function(d) { return scale(d); }
       });
     color_map.append("text")
-      .attr({id:"result-range-max", x: 30.0, y: 40.0, dx: "0.2em", dy: "-0.3em"})
+      .attr({class:"result-range-max", x: 30.0, y: 40.0, dx: "0.2em", dy: "-0.3em"})
       .style("text-anchor", "begin")
       .text( plot.colorScale.domain()[2] );
     color_map.append("text")
-      .attr({id:"result-range-middle", x: 30.0, y: 100.0, dx: "0.2em", dy: "-0.3em"})
+      .attr({class:"result-range-middle", x: 30.0, y: 100.0, dx: "0.2em", dy: "-0.3em"})
       .style("text-anchor", "begin")
       .text( plot.colorScale.domain()[1] );
     color_map.append("text")
-      .attr({id:"result-range-min", x: 30.0, y: 160.0, dx: "0.2em", dy: "-0.3em"})
+      .attr({class:"result-range-min", x: 30.0, y: 160.0, dx: "0.2em", dy: "-0.3em"})
       .style("text-anchor", "begin")
       .text( plot.colorScale.domain()[0] );
   }
   add_color_map_group();
 
-  const plot_group = plot.main_group.append("g").attr("id", "plot-group");
+  const plot_group = plot.main_group.append("g").attr("class", "plot-group");
 
   function add_voronoi_group() {
     const voronoi_group = plot_group.append("g")
-      .attr("id", "voronoi-group");
+      .attr("class", "voronoi-group");
   }
   add_voronoi_group();
 
@@ -166,12 +165,12 @@ ScatterPlot.prototype.AddPlot = function() {
       };
     });
     const point = plot_group.append("g")
-      .attr("id", "point-group");
+      .attr("class", "point-group");
     point.selectAll("circle")
       .data(mapped)
       .enter()
         .append("circle")
-        .attr("clip-path", "url(#clip)")
+        .attr("clip-path", "url(#" + plot.clipId + ")")
         .style("fill", function(d) { return plot.colorScalePoint(d.average);})
         .on("mouseover", function(d) {
           tooltip.transition()
@@ -212,11 +211,11 @@ ScatterPlot.prototype.UpdatePlot = function() {
   function update_color_scale() {
     const scale = d3.scale.linear().domain([0.0, 0.5, 1.0]).range(plot.colorScale.range());
 
-    plot.main_group.select("#result-range-max")
+    plot.main_group.select(".result-range-max")
       .text( plot.colorScale.domain()[2] );
-    plot.main_group.select("#result-range-middle")
+    plot.main_group.select(".result-range-middle")
       .text( plot.colorScale.domain()[1] );
-    plot.main_group.select("#result-range-min")
+    plot.main_group.select(".result-range-min")
       .text( plot.colorScale.domain()[0] );
 
     plot.main_group.selectAll("circle")
@@ -227,7 +226,7 @@ ScatterPlot.prototype.UpdatePlot = function() {
   function update_voronoi_group() {
     const result_min_val = d3.min( plot.data.data, function(d) { return d[1];});
     const result_max_val = d3.max( plot.data.data, function(d) { return d[1];});
-    const voronoi = plot.main_group.select("g#voronoi-group");
+    const voronoi = plot.main_group.select("g.voronoi-group");
     const d3voronoi = d3.geom.voronoi()
       .clipExtent([[0, 0], [plot.width, plot.height]]);
     const filtered_data = plot.data.data.filter(function(v) {
@@ -252,8 +251,8 @@ ScatterPlot.prototype.UpdatePlot = function() {
         .enter()
           .append("path")
           .attr("fill", function(d, i) {
-            if(filtered_data[i][1] < plot.colorScale.domain()[0]) {return "url(#TrianglePattern)";}
-            if(filtered_data[i][1] > plot.colorScale.domain()[2]) {return "url(#TrianglePattern)";}
+            if(filtered_data[i][1] < plot.colorScale.domain()[0]) {return "url(#triangle-pattern-" + plot.plotId + ")";}
+            if(filtered_data[i][1] > plot.colorScale.domain()[2]) {return "url(#triangle-pattern-" + plot.plotId + ")";}
             return plot.colorScale(filtered_data[i][1]);
           })
           .attr("d", function(d) { return "M" + d.join('L') + "Z"; })
@@ -272,7 +271,7 @@ ScatterPlot.prototype.UpdatePlot = function() {
   update_voronoi_group();
 
   function update_point_group() {
-    const point = plot.main_group.select("g#point-group");
+    const point = plot.main_group.select("g.point-group");
     point.selectAll("circle")
       .attr("r", function(d) { return (d.psid == plot.current_ps_id) ? 5 : 3;})
       .attr("cx", function(d) { return plot.xScale(d.x);})
@@ -340,25 +339,23 @@ ScatterPlot.prototype.AddDescription = function() {
     plot.description.append("div").style("margin-bottom", "20px");
 
     const log_check_box = plot.description.append("div").attr("class", "checkbox");
-    const check_box_x_label = log_check_box.append("label").attr("id", "x_log_check");
+    const check_box_x_label = log_check_box.append("label");
     check_box_x_label.html('<input type="checkbox"> log scale on x axis');
-    //d3.select gets the first element. This selection is available only when new svg will appear at the above of the old svg.
-    d3.select('label#x_log_check input').on("change", function() {
+    check_box_x_label.select("input").on("change", function() {
       reset_brush(this.checked ? "log" : "linear", plot.IsLog[1] ? "log" : "linear");
     });
     log_check_box.append("br");
 
-    const check_box_y_label = log_check_box.append("label").attr("id", "y_log_check");
+    const check_box_y_label = log_check_box.append("label");
     check_box_y_label.html('<input type="checkbox"> log scale on y axis');
-    //d3.select gets the first element. This selection is available only when new svg will appear at the above of the old svg.
-    d3.select('label#y_log_check input').on("change", function() {
+    check_box_y_label.select("input").on("change", function() {
       reset_brush(plot.IsLog[0] ? "log" : "linear", this.checked ? "log" : "linear");
     });
 
     plot.description.append("br");
     const control_plot = plot.description.append("div").style("margin-top", "10px");
     function add_brush() {
-      const clone = plot.main_group.select("g#plot-group").node().cloneNode(true);
+      const clone = plot.main_group.select("g.plot-group").node().cloneNode(true);
       control_plot.append("svg")
         .attr("width","210")
         .attr("height","155")
@@ -421,7 +418,7 @@ ScatterPlot.prototype.AddDescription = function() {
     function add_result_scale_controller() {
       const pattern = plot.main_group.select("defs").append("pattern");
       pattern
-        .attr("id", "TrianglePattern")
+        .attr("id", "triangle-pattern-" + plot.plotId)
         .attr("patternUnits", "userSpaceOnUse")
         .attr("x", 0)
         .attr("y", 0)
@@ -435,22 +432,20 @@ ScatterPlot.prototype.AddDescription = function() {
         .attr("fill", "black");
 
       const color_scale_control = plot.description.append("div")
-        .attr("id","color-scale-control")
+        .attr("class","color-scale-control")
         .style("margin-top", "10px");
 
       color_scale_control.text("Result range :");
       const form = color_scale_control.append("form").attr("class", "form-inline");
       form.append("input").attr({
         "type": "text",
-        "class": "input-sm form-control",
-        "placeholder": "min",
-        "id": "range-min"
+        "class": "input-sm form-control range-min",
+        "placeholder": "min"
       });
       form.append("input").attr({
         "type": "text",
-        "class": "input-sm form-control",
-        "placeholder": "max",
-        "id": "range-max"
+        "class": "input-sm form-control range-max",
+        "placeholder": "max"
       });
 
       const range_change = function(key, text_field) {
@@ -483,12 +478,12 @@ ScatterPlot.prototype.AddDescription = function() {
           alert(e);
         }
       };
-      plot.description.select("#range-max")
+      plot.description.select(".range-max")
         .attr("value", plot.colorScale.domain()[2])
         .on("change", function() {
           range_change("max", this);
         });
-      plot.description.select("#range-min")
+      plot.description.select(".range-min")
         .attr("value", plot.colorScale.domain()[0])
         .on("change", function() {
           range_change("min", this);


### PR DESCRIPTION
## Summary

Fixes the intermittently wrong colors in line plots and several cross-plot state leaks in the D3 plot code (`app/assets/javascripts/plot/`). No D3 upgrade — all changes stay on the d3 v3 API.

### Root cause of the color bug

`LinePlot` built **two independent** `d3.scale.category10()` instances — one in `AddPlot`, another in `UpdatePlot` — both with implicit domains. In d3 v3 an ordinal scale's domain is built lazily in first-seen order. `UpdatePlot`'s scale was seeded only from series that pass `.filter(d => d.yerror)`, so whenever any series lacked error values (single-run points, elapsed-time plots where error is always `nil`), error-bar colors shifted by one relative to their own lines/points — and the shift re-appeared on every brush zoom or log toggle.

### Changes

- Share one color scale with an explicit domain (`d3.range(numSeries)`) between `AddPlot` and `UpdatePlot`
- Make `IsLog` per-instance: it was a prototype-level array mutated in place, so **all plots on a page shared one log/linear state**, corrupting the brush scales of other plots
- Give each plot a unique `clipPath` id — `url(#clip)` always resolved to the first plot's clip in the document, so deleting or resizing one plot corrupted the clipping of others (`FigureViewer.Init` even enlarged the *first* plot's clip rect)
- Scope the log-scale checkbox handlers to their own plot; the old code did a document-global `d3.select('label#x_log_check input')` and only worked because new plots happened to be prepended (the code commented on this fragility)
- Convert duplicated internal DOM ids (`plot-group`, `legend`, `point-group`, `voronoi-group`, `figure-group`, `TrianglePattern`, `result-range-*`, `range-min/max`, ...) to classes or per-plot unique ids
- `FigureViewer.SetYScale("log")`: filter the domain data by the y value (was filtering by x)
- Line plot tooltip: omit the parenthesized error when the error value is `nil` (previously displayed `(0)`)

## Verification

- Headless test (jsdom + d3@3) driving the real classes with data fetched from a dev server plus synthetic data where one series lacks errors: on the **old code it reproduces the reported bug** (error bars one color off, crash/mis-resolution with two plots); on this branch all 35 checks pass — line/point/legend/error-bar colors consistent, colors stay correct after zoom and log toggles, two coexisting plots keep independent log state and clipping
- `bundle exec rspec spec/controllers/parameter_sets_controller_spec.rb` (covers the plot JSON endpoints): 75 examples, 0 failures
- Sprockets serves the updated assets in the dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)