### PR TITLE
Harden local and SSH command execution

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -35,6 +35,7 @@ class Host
                      inclusion: {in: HOST_STATUS}
   validate :work_base_dir_is_not_editable_when_submitted_runs_exist
   validate :min_is_not_larger_than_max
+  validate :name_is_valid_ssh_alias
 
   before_validation :get_host_parameters,
                :if => lambda { status == :enabled }
@@ -49,6 +50,7 @@ class Host
     SocketError,
     Net::SSH::Exception,
     PopenSSH::ConnectionError,
+    SSHUtil::InvalidHostnameError,
     OpenSSL::PKey::RSAError,
     Timeout::Error
   ]
@@ -140,8 +142,9 @@ class Host
       yield @ssh
     else
       ssh_module = ssh_backend == "popen_ssh" ? PopenSSH : Net::SSH
-      ssh_logger.debug("starting SSH: #{self.name} using #{ssh_module}" ) if ssh_logger
-      ssh_module.start(name, nil, password: nil, timeout: 1, non_interactive: true, logger: ssh_logger) do |ssh|
+      hostname = SSHUtil.validate_hostname!(name)
+      ssh_logger.debug("starting SSH: #{hostname} using #{ssh_module}" ) if ssh_logger
+      ssh_module.start(hostname, nil, password: nil, timeout: 1, non_interactive: true, logger: ssh_logger) do |ssh|
         @ssh = ssh
         begin
           yield ssh
@@ -172,6 +175,12 @@ class Host
   end
 
   private
+  def name_is_valid_ssh_alias
+    return if name.blank? || SSHUtil.valid_hostname?(name)
+
+    errors.add(:name, SSHUtil::HOST_ALIAS_REQUIREMENTS)
+  end
+
   def work_base_dir_is_not_editable_when_submitted_runs_exist
     if work_base_dir_is_not_editable? and self.work_base_dir_changed?
       errors.add(:work_base_dir, "is not editable when submitted runs exist")
@@ -247,4 +256,3 @@ class Host
     end
   end
 end
-

--- a/app/services/job_includer.rb
+++ b/app/services/job_includer.rb
@@ -99,9 +99,10 @@ module JobIncluder
   def self.move_local_file(host, submittable)
     work_dir = map_remote_path_to_mounted_path(host, RemoteFilePath.work_dir_path(host, submittable))
     archive = map_remote_path_to_mounted_path(host, RemoteFilePath.result_file_path(host, submittable))
-    cmd = "rsync -a #{work_dir}/ #{submittable.dir} && mv #{archive} #{submittable.dir.join("..")}/"
-    system(cmd)
-    raise "can not move work_directory from #{work_dir}" unless $?.exitstatus == 0
+    copied = system("rsync", "-a", "--", "#{work_dir}/", submittable.dir.to_s)
+    raise "can not move work_directory from #{work_dir}" unless copied
+
+    FileUtils.mv(archive, submittable.dir.join(".."))
 
     RemoteFilePath.scheduler_log_file_paths(host, submittable).each do |path|
       if path.exist?

--- a/lib/job_script_util.rb
+++ b/lib/job_script_util.rb
@@ -71,9 +71,8 @@ EOS
   def self.expand_result_file(job)
 
     Dir.chdir(job.dir.join('..')) {
-      cmd = "tar xjf #{job.id}.tar.bz2"
-      system(cmd)
-      unless $?.to_i == 0
+      expanded = system("tar", "xjf", "#{job.id}.tar.bz2")
+      unless expanded
         job.update_attribute(:error_messages, "failed to extract the archive")
         raise "failed to extract the archive"
       end

--- a/lib/ssh_util.rb
+++ b/lib/ssh_util.rb
@@ -1,9 +1,15 @@
 require 'open3'
 require 'securerandom'
+require 'shellwords'
 
 module SSHUtil
 
   class CommandTimeoutError < StandardError; end
+  class InvalidHostnameError < ArgumentError; end
+
+  HOST_ALIAS_FORBIDDEN_PATTERN = /[[:space:]\x00-\x1f\x7f:@\/\\\[\]]/
+  HOST_ALIAS_REQUIREMENTS =
+    "must not start with '-' or contain whitespace, control characters, ':', '@', '/', '\\', '[' or ']'"
 
   class ShellSession
 
@@ -119,17 +125,30 @@ module SSHUtil
     end
   end
 
+  def self.valid_hostname?(hostname)
+    hostname = hostname.to_s
+    !hostname.empty? &&
+      !hostname.start_with?("-") &&
+      !HOST_ALIAS_FORBIDDEN_PATTERN.match?(hostname)
+  end
+
+  def self.validate_hostname!(hostname)
+    hostname = hostname.to_s
+    return hostname if valid_hostname?(hostname)
+
+    raise InvalidHostnameError,
+          "invalid SSH host alias #{hostname.inspect}; #{HOST_ALIAS_REQUIREMENTS}"
+  end
+
   def self.download_file(hostname, remote_path, local_path)
-    cmd = "scp -Bqr '#{hostname}:#{remote_path}' #{local_path}"
-    _out, err, status = Open3.capture3(cmd)
-    raise "'#{cmd}' failed with #{status.exitstatus}: #{err.chomp}" unless status.success?
+    source = remote_scp_operand(hostname, remote_path)
+    run_scp(source, local_path)
   end
 
   def self.download_directory(hostname, remote_path, local_path)
     FileUtils.mkdir_p(local_path)
-    cmd = "scp -Bqr '#{hostname}:#{remote_path}/*' #{local_path}"
-    _out, err, status = Open3.capture3(cmd)
-    raise "'#{cmd}' failed with #{status.exitstatus}: #{err.chomp}" unless status.success?
+    source = remote_scp_operand(hostname, remote_path, directory_contents: true)
+    run_scp(source, local_path)
   end
 
   def self.download_recursive_if_exist(sh, hostname, remote_path, local_path)
@@ -150,12 +169,10 @@ module SSHUtil
   end
 
   def self.upload(hostname, local_path, remote_path)
-    cmd = "scp -Bqr #{Shellwords.escape(local_path.to_s)} '#{hostname}:#{remote_path}'"
-    if File.directory?(local_path)
-      cmd = "scp -Bqr #{Shellwords.escape(local_path.to_s)}/ '#{hostname}:#{remote_path}'"
-    end
-    _out, err, status = Open3.capture3(cmd)
-    raise "'#{cmd}' failed with #{status.exitstatus}: #{err.chomp}" unless status.success?
+    source = local_path.to_s
+    source += "/" if File.directory?(local_path)
+    destination = remote_scp_operand(hostname, remote_path)
+    run_scp(source, destination)
   end
 
   def self.rm_r(sh, remote_paths)
@@ -199,4 +216,33 @@ module SSHUtil
     _out,_err,rc = execute2(sh, "test -e #{escape_remote_path(remote_path)}")
     rc == 0
   end
+
+  def self.remote_scp_operand(hostname, remote_path, directory_contents: false)
+    hostname = validate_hostname!(hostname)
+    path = escape_remote_path(remote_path)
+    path += "/*" if directory_contents
+    "#{hostname}:#{path}"
+  end
+  private_class_method :remote_scp_operand
+
+  def self.run_scp(source, destination)
+    # Remote operands are escaped for the legacy scp protocol's remote shell.
+    # Modern clients need -O because SFTP mode treats those backslashes literally;
+    # older clients already use the legacy protocol and reject -O, so retry safely.
+    argv = ["scp", "-O", "-Bqr", "--", source.to_s, destination.to_s]
+    _out, err, status = Open3.capture3(*argv)
+    if !status.success? && scp_legacy_option_unsupported?(err)
+      argv.delete("-O")
+      _out, err, status = Open3.capture3(*argv)
+    end
+    return if status.success?
+
+    raise "'#{Shellwords.shelljoin(argv)}' failed with #{status.exitstatus}: #{err.chomp}"
+  end
+  private_class_method :run_scp
+
+  def self.scp_legacy_option_unsupported?(stderr)
+    stderr.match?(/(?:illegal|unknown) option -- O/i)
+  end
+  private_class_method :scp_legacy_option_unsupported?
 end

--- a/lib/ssh_util.rb
+++ b/lib/ssh_util.rb
@@ -7,9 +7,9 @@ module SSHUtil
   class CommandTimeoutError < StandardError; end
   class InvalidHostnameError < ArgumentError; end
 
-  HOST_ALIAS_FORBIDDEN_PATTERN = /[[:space:]\x00-\x1f\x7f:@\/\\\[\]]/
+  HOST_ALIAS_FORBIDDEN_PATTERN = /[[:space:]\x00-\x1f\x7f:\/\\\[\]]/
   HOST_ALIAS_REQUIREMENTS =
-    "must not start with '-' or contain whitespace, control characters, ':', '@', '/', '\\', '[' or ']'"
+    "must not start with '-' or contain whitespace, control characters, ':', '/', '\\', '[' or ']'"
 
   class ShellSession
 

--- a/lib/ssh_util.rb
+++ b/lib/ssh_util.rb
@@ -229,6 +229,9 @@ module SSHUtil
     # Remote operands are escaped for the legacy scp protocol's remote shell.
     # Modern clients need -O because SFTP mode treats those backslashes literally;
     # older clients already use the legacy protocol and reject -O, so retry safely.
+    # Legacy mode requires an scp binary on the remote host. If a future client
+    # removes legacy scp support, switch this transfer to SFTP mode and adapt the
+    # remote path handling accordingly.
     argv = ["scp", "-O", "-Bqr", "--", source.to_s, destination.to_s]
     _out, err, status = Open3.capture3(*argv)
     if !status.success? && scp_legacy_option_unsupported?(err)

--- a/spec/lib/ssh_util_spec.rb
+++ b/spec/lib/ssh_util_spec.rb
@@ -25,6 +25,16 @@ RSpec.shared_examples "SSHUtil backend" do |backend_name, ssh_module|
       SSHUtil.download_file(@hostname, remote_path, local_path)
       expect(File.exist?(local_path)).to be_truthy
     end
+
+    it "handles spaces and shell metacharacters in remote and local paths" do
+      remote_path = @temp_dir.join(%q{remote ; $(not_a_command) 'quoted'}).expand_path
+      FileUtils.touch(remote_path)
+      local_path = @temp_dir.join(%q{local ; $(not_a_command) 'quoted'}).expand_path
+
+      SSHUtil.download_file(@hostname, remote_path, local_path)
+
+      expect(File.exist?(local_path)).to be_truthy
+    end
   end
 
   describe ".download_directory" do
@@ -50,6 +60,17 @@ RSpec.shared_examples "SSHUtil backend" do |backend_name, ssh_module|
       SSHUtil.download_directory(@hostname, remote_path, local_path)
       expect(File.directory?(local_path)).to be_truthy
       expect(File.exist?(local_path.join('file'))).to be_truthy
+    end
+
+    it "handles spaces and shell metacharacters while expanding directory contents" do
+      remote_path = @temp_dir.join(%q{remote dir ; $(not_a_command) 'quoted'}).expand_path
+      FileUtils.mkdir_p(remote_path)
+      FileUtils.touch(remote_path.join(%q{file ; $(not_a_command) 'quoted'}))
+      local_path = @temp_dir.join('local directory')
+
+      SSHUtil.download_directory(@hostname, remote_path, local_path)
+
+      expect(File.exist?(local_path.join(%q{file ; $(not_a_command) 'quoted'}))).to be_truthy
     end
 
     it "raise exception if the remote_path is not directory but file" do
@@ -127,6 +148,16 @@ RSpec.shared_examples "SSHUtil backend" do |backend_name, ssh_module|
       expect(File.exist?(remote_path)).to be_truthy
     end
 
+    it "handles spaces and shell metacharacters in local and remote paths" do
+      local_path = @temp_dir.join(%q{local ; $(not_a_command) 'quoted'})
+      FileUtils.touch(local_path)
+      remote_path = @temp_dir.join(%q{remote ; $(not_a_command) 'quoted'}).expand_path
+
+      SSHUtil.upload(@hostname, local_path, remote_path)
+
+      expect(File.exist?(remote_path)).to be_truthy
+    end
+
     it "upload local directory recursively" do
       local_dir = @temp_dir.join('dir/dir2')
       FileUtils.mkdir_p(local_dir)
@@ -137,6 +168,21 @@ RSpec.shared_examples "SSHUtil backend" do |backend_name, ssh_module|
       SSHUtil.upload(@hostname, @temp_dir.join('dir'), remote_path.join('dir'))
       expect( File.directory?(@temp_dir.join('remote/dir/dir2')) ).to be_truthy
       expect( File.exist?( @temp_dir.join('remote/dir/dir2/file')) ).to be_truthy
+    end
+
+    it "keeps tilde expansion for remote paths" do
+      remote_dir_name = ".oacis_ssh_util_#{SecureRandom.hex(8)}"
+      remote_dir = Pathname.new(Dir.home).join(remote_dir_name)
+      FileUtils.mkdir_p(remote_dir)
+      local_path = @temp_dir.join('local file')
+      File.write(local_path, "content")
+      remote_path = "~/#{remote_dir_name}/remote file"
+
+      SSHUtil.upload(@hostname, local_path, remote_path)
+
+      expect(remote_dir.join('remote file').read).to eq "content"
+    ensure
+      FileUtils.rm_rf(remote_dir) if remote_dir
     end
   end
 
@@ -298,6 +344,107 @@ describe SSHUtil do
 
     it "accepts a Pathname" do
       expect(SSHUtil.escape_remote_path(Pathname.new("/tmp/abc"))).to eq "/tmp/abc"
+    end
+  end
+
+  describe "scp command construction" do
+
+    let(:status) { double(success?: true) }
+
+    it "passes download arguments separately from the local shell" do
+      remote_path = %q{~/remote path;$(touch injected)'quoted}
+      local_path = Pathname.new(%q{/tmp/local path;$(touch injected)'quoted})
+      remote_operand = "host_alias:~/#{Shellwords.escape(remote_path[2..])}"
+      expect(Open3).to receive(:capture3)
+        .with("scp", "-O", "-Bqr", "--", remote_operand, local_path.to_s)
+        .and_return(["", "", status])
+
+      SSHUtil.download_file("host_alias", remote_path, local_path)
+    end
+
+    it "leaves only the directory contents wildcard unescaped" do
+      remote_path = %q{/remote path;$(touch injected)'quoted}
+      local_path = Pathname.new("/tmp/local path")
+      remote_operand = "host_alias:#{Shellwords.escape(remote_path)}/*"
+      allow(FileUtils).to receive(:mkdir_p)
+      expect(Open3).to receive(:capture3)
+        .with("scp", "-O", "-Bqr", "--", remote_operand, local_path.to_s)
+        .and_return(["", "", status])
+
+      SSHUtil.download_directory("host_alias", remote_path, local_path)
+    end
+
+    it "passes file upload arguments separately from the local shell" do
+      local_path = Pathname.new(%q{/tmp/local path;$(touch injected)'quoted})
+      remote_path = %q{~/remote path;$(touch injected)'quoted}
+      remote_operand = "host_alias:~/#{Shellwords.escape(remote_path[2..])}"
+      allow(File).to receive(:directory?).with(local_path).and_return(false)
+      expect(Open3).to receive(:capture3)
+        .with("scp", "-O", "-Bqr", "--", local_path.to_s, remote_operand)
+        .and_return(["", "", status])
+
+      SSHUtil.upload("host_alias", local_path, remote_path)
+    end
+
+    it "preserves the trailing slash when uploading a directory" do
+      local_path = Pathname.new("/tmp/local directory")
+      remote_path = "/tmp/remote directory"
+      remote_operand = "host_alias:#{Shellwords.escape(remote_path)}"
+      allow(File).to receive(:directory?).with(local_path).and_return(true)
+      expect(Open3).to receive(:capture3)
+        .with("scp", "-O", "-Bqr", "--", "#{local_path}/", remote_operand)
+        .and_return(["", "", status])
+
+      SSHUtil.upload("host_alias", local_path, remote_path)
+    end
+
+    it "falls back when the local scp is too old to accept -O" do
+      unsupported_status = double(success?: false)
+      remote_path = "/tmp/remote path"
+      local_path = Pathname.new("/tmp/local path")
+      remote_operand = "host_alias:#{Shellwords.escape(remote_path)}"
+      expect(Open3).to receive(:capture3)
+        .with("scp", "-O", "-Bqr", "--", remote_operand, local_path.to_s)
+        .and_return(["", "scp: illegal option -- O", unsupported_status])
+      expect(Open3).to receive(:capture3)
+        .with("scp", "-Bqr", "--", remote_operand, local_path.to_s)
+        .and_return(["", "", status])
+
+      SSHUtil.download_file("host_alias", remote_path, local_path)
+    end
+  end
+
+  describe ".validate_hostname!" do
+
+    it "accepts SSH config aliases beyond a restrictive hostname whitelist" do
+      valid_hostnames = [
+        "host-1.example_name",
+        "gpu+cluster%2"
+      ]
+
+      valid_hostnames.each do |hostname|
+        expect(SSHUtil.validate_hostname!(hostname)).to eq hostname
+      end
+    end
+
+    it "rejects only values that can break SSH or scp argument parsing" do
+      invalid_hostnames = [
+        "-oProxyCommand=touch",
+        "host:22",
+        "user@host",
+        "host/path",
+        "host\\name",
+        "[host]",
+        "host name",
+        "host\nname",
+        "host\0name"
+      ]
+
+      invalid_hostnames.each do |hostname|
+        expect {
+          SSHUtil.validate_hostname!(hostname)
+        }.to raise_error(SSHUtil::InvalidHostnameError)
+      end
     end
   end
 end

--- a/spec/lib/ssh_util_spec.rb
+++ b/spec/lib/ssh_util_spec.rb
@@ -419,7 +419,8 @@ describe SSHUtil do
     it "accepts SSH config aliases beyond a restrictive hostname whitelist" do
       valid_hostnames = [
         "host-1.example_name",
-        "gpu+cluster%2"
+        "gpu+cluster%2",
+        "user@host"
       ]
 
       valid_hostnames.each do |hostname|
@@ -431,7 +432,6 @@ describe SSHUtil do
       invalid_hostnames = [
         "-oProxyCommand=touch",
         "host:22",
-        "user@host",
         "host/path",
         "host\\name",
         "[host]",

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -30,6 +30,32 @@ describe Host do
       expect(Host.new(@valid_attr)).not_to be_valid
     end
 
+    it "'name' accepts SSH config aliases beyond a restrictive hostname whitelist" do
+      ['host-1.example_name', 'gpu+cluster%2'].each do |name|
+        @valid_attr.update(name: name)
+        expect(Host.new(@valid_attr)).to be_valid
+      end
+    end
+
+    it "'name' rejects only values that can break SSH or scp argument parsing" do
+      invalid_names = [
+        '-oProxyCommand=touch',
+        'host:22',
+        'user@host',
+        'host/path',
+        "host\\name",
+        '[host]',
+        'host name',
+        "host\nname",
+        "host\0name"
+      ]
+
+      invalid_names.each do |name|
+        @valid_attr.update(name: name)
+        expect(Host.new(@valid_attr)).not_to be_valid
+      end
+    end
+
     it "default of 'work_base_dir' is '~/oacis_work'" do
       @valid_attr.delete(:work_base_dir)
       expect(Host.new(@valid_attr).work_base_dir).to eq('~/oacis_work')

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -31,7 +31,7 @@ describe Host do
     end
 
     it "'name' accepts SSH config aliases beyond a restrictive hostname whitelist" do
-      ['host-1.example_name', 'gpu+cluster%2'].each do |name|
+      ['host-1.example_name', 'gpu+cluster%2', 'user@host'].each do |name|
         @valid_attr.update(name: name)
         expect(Host.new(@valid_attr)).to be_valid
       end
@@ -41,7 +41,6 @@ describe Host do
       invalid_names = [
         '-oProxyCommand=touch',
         'host:22',
-        'user@host',
         'host/path',
         "host\\name",
         '[host]',

--- a/spec/services/job_includer_spec.rb
+++ b/spec/services/job_includer_spec.rb
@@ -385,4 +385,50 @@ describe JobIncluder do
       end
     end
   end
+
+  describe ".move_local_file" do
+
+    let(:host) { instance_double(Host) }
+    let(:submittable) {
+      instance_double(Run, dir: Pathname.new(%q{/local/result dir;$(touch injected)/run}))
+    }
+    let(:remote_work_dir) { Pathname.new("/remote/work") }
+    let(:remote_archive) { Pathname.new("/remote/archive.tar.bz2") }
+    let(:mounted_work_dir) { Pathname.new(%q{/mounted/work dir;$(touch injected)}) }
+    let(:mounted_archive) { Pathname.new(%q{/mounted/archive ;$(touch injected).tar.bz2}) }
+
+    before do
+      allow(RemoteFilePath).to receive(:work_dir_path)
+        .with(host, submittable).and_return(remote_work_dir)
+      allow(RemoteFilePath).to receive(:result_file_path)
+        .with(host, submittable).and_return(remote_archive)
+      allow(JobIncluder).to receive(:map_remote_path_to_mounted_path)
+        .with(host, remote_work_dir).and_return(mounted_work_dir)
+      allow(JobIncluder).to receive(:map_remote_path_to_mounted_path)
+        .with(host, remote_archive).and_return(mounted_archive)
+      allow(RemoteFilePath).to receive(:scheduler_log_file_paths)
+        .with(host, submittable).and_return([])
+    end
+
+    it "runs rsync with argv and moves the archive only after success" do
+      expect(JobIncluder).to receive(:system)
+        .with("rsync", "-a", "--", "#{mounted_work_dir}/", submittable.dir.to_s)
+        .and_return(true)
+      expect(FileUtils).to receive(:mv)
+        .with(mounted_archive, submittable.dir.join(".."))
+
+      JobIncluder.send(:move_local_file, host, submittable)
+    end
+
+    it "does not move the archive when rsync fails" do
+      allow(JobIncluder).to receive(:system)
+        .with("rsync", "-a", "--", "#{mounted_work_dir}/", submittable.dir.to_s)
+        .and_return(false)
+      expect(FileUtils).not_to receive(:mv)
+
+      expect {
+        JobIncluder.send(:move_local_file, host, submittable)
+      }.to raise_error("can not move work_directory from #{mounted_work_dir}")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- execute `scp`, `rsync`, and archive extraction with argv arrays instead of single shell command strings
- preserve remote path escaping for spaces, metacharacters, `~/` expansion, and directory-content wildcards
- separate `rsync` from archive movement so a failed copy never moves the archive
- validate SSH aliases only for characters that break SSH/scp parsing, without imposing a restrictive hostname whitelist

## Why

OACIS interpolated host names and local or remote paths into shell command strings in several transfer paths. Even though users who can register Hosts and Simulators are trusted to run arbitrary commands, these internal file operations should not add unnecessary shell parsing or make ordinary paths behave as commands.

The Host alias check is therefore limited to structural correctness: it rejects leading option syntax, control or whitespace characters, and separators that break the `host:path` form, while allowing aliases containing characters such as `+` and `%`.

## Impact

- local paths are passed directly as process arguments
- remote paths remain quoted for the remote side of legacy scp
- modern scp clients use `-O`; older clients that already default to legacy scp fall back when `-O` is unsupported
- mounted-result inclusion preserves the existing success and failure behavior
- intentional Simulator, Analyzer, preprocessing, and scheduler shell commands are unchanged

## Validation

- `bundle exec rspec spec/lib/ssh_util_spec.rb spec/models/host_spec.rb`
  - 123 examples, 0 failures, 2 existing pending
- `bundle exec rspec spec/services/job_includer_spec.rb spec/models/host_spec.rb`
  - 115 examples, 0 failures, 2 existing pending
- `bundle exec rspec spec/lib/job_script_util_spec.rb`
  - 56 examples, 0 failures, 2 existing pending
- comprehensive run before the final Host-alias relaxation: `bundle exec rspec`
  - 1211 examples, 0 failures, 10 existing pending
- `git diff --check`
