### PR TITLE
MCP: report result directories for direct file access by agents

### DIFF
--- a/docs/en/mcp.md
+++ b/docs/en/mcp.md
@@ -62,7 +62,7 @@ When OACIS runs in a container and the agent on the host, set `OACIS_MCP_DIR_MAP
 - The server is stdio-only; it opens no network port. Whoever can execute `bin/oacis_mcp` gets the same database access as `bin/oacis_ruby`.
 - When `OACIS_ACCESS_LEVEL` is `0`, or when the environment variable `OACIS_MCP_READONLY=1` is set, the three write tools are hidden and rejected — the agent can only inspect.
 - There are no destructive tools: agents cannot delete simulators, parameter sets, runs, or analyses, and cannot modify simulator/host configurations.
-- File access is restricted to the result directories of runs and analyses, with size limits.
+- File access *through the MCP tools* (`list_result_files` / `read_result_file`) is restricted to the result directories of runs and analyses, with size limits and symlink-escape checks. These guarantees do not extend to direct reads: when the agent opens a reported `dir` with its own file tools, what it can access is governed solely by the agent's own sandbox and filesystem permissions — including symlinks inside a result directory, which may point anywhere. Confine the agent accordingly (e.g. Claude Code's permission prompts, or a container).
 
 ## Tools
 

--- a/docs/en/mcp.md
+++ b/docs/en/mcp.md
@@ -49,6 +49,14 @@ claude mcp add oacis_proj_a -- /path/to/proj_a/oacis_docker/oacis_mcp.sh
 claude mcp add oacis_proj_b -- /path/to/proj_b/oacis_docker/oacis_mcp.sh
 ```
 
+## Direct access to result files
+
+`get_run`, `get_analysis`, `get_parameter_set`, and `list_result_files` report the result directory of the record as `dir` (or `base_dir`). When the agent runs on a machine where that path is accessible — the same machine as OACIS, or a Docker host with the Result directory bind-mounted — it should read the output files there directly with its own file tools. This is the preferred way to consume results: unlike `read_result_file`, it has no size cap and works for binary files such as plot images, so a multimodal agent can look at the plots an analyzer produced.
+
+When OACIS runs in a container and the agent on the host, set `OACIS_MCP_DIR_MAP="<server_prefix>=<client_prefix>"` in the server's environment and all reported paths are rewritten accordingly. `oacis_docker`'s `oacis_mcp.sh` sets this automatically, mapping the container's Result directory to the bind-mounted `Result/` on the host.
+
+`read_result_file` remains available as a fallback for setups where the result directory is not reachable from the agent (e.g. OACIS on a remote server).
+
 ## Security model
 
 - The server is stdio-only; it opens no network port. Whoever can execute `bin/oacis_mcp` gets the same database access as `bin/oacis_ruby`.
@@ -76,7 +84,7 @@ A typical agent workflow:
 1. `list_simulators` and `list_hosts` to learn what exists,
 2. `find_or_create_parameter_set` → `create_runs` to submit jobs,
 3. poll `get_parameter_set` (or `search_parameter_sets` for many) until runs finish — jobs are submitted asynchronously by the background workers, so results take a while,
-4. inspect `get_run`, `read_result_file`, or aggregate with `include_average_results`,
+4. inspect `get_run` and read the files under its `dir` directly (or `read_result_file` remotely), or aggregate with `include_average_results`,
 5. `create_analysis` on the finished runs and poll `get_analysis`,
 6. decide the next parameter sets and repeat.
 

--- a/lib/mcp_server/serializers.rb
+++ b/lib/mcp_server/serializers.rb
@@ -8,6 +8,25 @@ module McpServer
 
     module_function
 
+    # Translates a server-local directory path into one valid for the MCP client,
+    # using OACIS_MCP_DIR_MAP="server_prefix=client_prefix" (e.g. set by
+    # oacis_docker's oacis_mcp.sh so an agent on the Docker host receives host
+    # paths for the mounted Result directory). No-op when the variable is unset
+    # or the path is outside the mapped prefix.
+    def map_dir(path)
+      s = path.to_s
+      mapping = ENV['OACIS_MCP_DIR_MAP'].to_s
+      return s if mapping.empty?
+      from, to = mapping.split('=', 2)
+      return s if from.nil? || to.nil? || from.empty?
+      from = from.chomp(File::SEPARATOR)
+      if s == from || s.start_with?(from + File::SEPARATOR)
+        to.chomp(File::SEPARATOR) + s[from.size..-1]
+      else
+        s
+      end
+    end
+
     def simulator(sim, runs_status_count: nil)
       {
         "id" => sim.id.to_s,
@@ -103,6 +122,7 @@ module McpServer
       h.merge(
         "parameter_set_id" => run.parameter_set_id.to_s,
         "simulator" => run.simulator&.name,
+        "dir" => map_dir(run.dir),
         "host_parameters" => clean(run.host_parameters),
         "mpi_procs" => run.mpi_procs,
         "omp_threads" => run.omp_threads,
@@ -133,6 +153,7 @@ module McpServer
       return h if brief
       h.merge(
         "parameter_set_id" => anl.parameter_set_id.to_s,
+        "dir" => map_dir(anl.dir),
         "submitted_to" => anl.submitted_to&.name,
         "host_group" => anl.host_group&.name,
         "host_parameters" => clean(anl.host_parameters),
@@ -158,7 +179,7 @@ module McpServer
       if json.bytesize > RESULT_JSON_LIMIT
         {
           "_truncated" => true,
-          "_note" => "result is #{json.bytesize} bytes of JSON (limit #{RESULT_JSON_LIMIT}); use list_result_files / read_result_file to inspect the raw output files.",
+          "_note" => "result is #{json.bytesize} bytes of JSON (limit #{RESULT_JSON_LIMIT}); read _output.json under 'dir' directly, or use list_result_files / read_result_file.",
           "_keys" => (cleaned.is_a?(Hash) ? cleaned.keys : nil)
         }.compact
       else

--- a/lib/mcp_server/tools/analysis_tools.rb
+++ b/lib/mcp_server/tools/analysis_tools.rb
@@ -15,8 +15,10 @@ module McpServer
         registry.register(
           "get_analysis",
           description: "Get one analysis: status, analyzer, target (run or parameter set), parameters, " \
-                       "and the parsed result once finished. Use list_result_files/read_result_file " \
-                       "with analysis_id to inspect its raw output files.",
+                       "and the parsed result once finished. 'dir' is the analysis result directory; " \
+                       "if it is accessible from your filesystem (local or Docker-mounted OACIS), read the " \
+                       "output files there directly — including binary ones such as plot images. " \
+                       "Fall back to list_result_files/read_result_file only when the path is not accessible.",
           input_schema: {
             "type" => "object",
             "properties" => { "analysis_id" => { "type" => "string" } },

--- a/lib/mcp_server/tools/file_tools.rb
+++ b/lib/mcp_server/tools/file_tools.rb
@@ -18,7 +18,9 @@ module McpServer
         registry.register(
           "list_result_files",
           description: "List the files in the result directory of a run or an analysis " \
-                       "(give exactly one of run_id / analysis_id). Pass relative_path to descend into a subdirectory.",
+                       "(give exactly one of run_id / analysis_id). Pass relative_path to descend into a subdirectory. " \
+                       "base_dir in the response is the result directory; if it is accessible from your filesystem, " \
+                       "prefer reading files there directly (binary files included) over read_result_file.",
           input_schema: {
             "type" => "object",
             "properties" => {
@@ -45,7 +47,7 @@ module McpServer
             }
           end
           {
-            "base_dir" => base.to_s,
+            "base_dir" => Serializers.map_dir(base),
             "entries" => entries,
             "total" => children.size,
             "truncated" => children.size > MAX_ENTRIES
@@ -60,7 +62,8 @@ module McpServer
                        "(give exactly one of run_id / analysis_id). Reads at most max_bytes " \
                        "(default #{DEFAULT_READ_BYTES}, max #{MAX_READ_BYTES}) starting at offset_bytes; " \
                        "when the response says truncated, call again with a larger offset_bytes to page through. " \
-                       "Binary files are rejected.",
+                       "Binary files are rejected. This is a fallback for when the result directory is not " \
+                       "accessible from your filesystem; when it is, read the files under base_dir directly.",
           input_schema: {
             "type" => "object",
             "properties" => {

--- a/lib/mcp_server/tools/parameter_set_tools.rb
+++ b/lib/mcp_server/tools/parameter_set_tools.rb
@@ -73,6 +73,7 @@ module McpServer
           ps = Resolvers.parameter_set(args["parameter_set_id"])
           counts = ParameterSet.runs_status_count_batch([ps])[ps.id]
           h = Serializers.parameter_set(ps, run_counts: counts)
+          h["dir"] = Serializers.map_dir(ps.dir)
           unless args["include_runs"] == false
             runs = ps.runs.asc(:created_at).limit(RUNS_PREVIEW_LIMIT).to_a
             h["runs"] = runs.map {|r| Serializers.run(r, brief: true) }

--- a/lib/mcp_server/tools/run_tools.rb
+++ b/lib/mcp_server/tools/run_tools.rb
@@ -17,8 +17,10 @@ module McpServer
         registry.register(
           "get_run",
           description: "Get one run: status, destination host, host parameters, seed, timings, error messages, " \
-                       "and the parsed result values once finished. Use list_result_files/read_result_file " \
-                       "to inspect its raw output files.",
+                       "and the parsed result values once finished. 'dir' is the run's result directory; " \
+                       "if it is accessible from your filesystem (local or Docker-mounted OACIS), read the " \
+                       "output files there directly — including binary ones such as plot images. " \
+                       "Fall back to list_result_files/read_result_file only when the path is not accessible.",
           input_schema: {
             "type" => "object",
             "properties" => { "run_id" => { "type" => "string" } },

--- a/spec/lib/mcp_server/file_tools_spec.rb
+++ b/spec/lib/mcp_server/file_tools_spec.rb
@@ -32,6 +32,16 @@ describe "McpServer file tools" do
     it "requires exactly one of run_id and analysis_id" do
       expect { registry.call("list_result_files", {}) }.to raise_error(McpServer::InvalidArgumentsError)
     end
+
+    it "reports base_dir through OACIS_MCP_DIR_MAP" do
+      ENV['OACIS_MCP_DIR_MAP'] = "#{ResultDirectory.root}=/host/Result"
+      begin
+        result = registry.call("list_result_files", {"run_id" => @run.id.to_s})
+        expect(result["base_dir"]).to eq @run.dir.to_s.sub(ResultDirectory.root.to_s, "/host/Result")
+      ensure
+        ENV.delete('OACIS_MCP_DIR_MAP')
+      end
+    end
   end
 
   describe "read_result_file" do

--- a/spec/lib/mcp_server/read_tools_spec.rb
+++ b/spec/lib/mcp_server/read_tools_spec.rb
@@ -98,6 +98,7 @@ describe "McpServer read tools" do
       expect(result["run_counts"]).to include("created" => 1, "finished" => 2)
       expect(result["runs"].size).to eq 3
       expect(result["runs"].first).to include("id", "status")
+      expect(result["dir"]).to eq @ps.dir.to_s
     end
 
     it "omits runs when include_runs is false" do
@@ -131,6 +132,7 @@ describe "McpServer read tools" do
       expect(result["result"].keys).to match_array ["Energy", "Flow"]
       expect(result["v"]).to eq @ps.v
       expect(result["submitted_to"]).to eq @run.submitted_to.name
+      expect(result["dir"]).to eq @run.dir.to_s
     end
 
     it "raises not_found for a nonexistent id" do

--- a/spec/lib/mcp_server/serializers_spec.rb
+++ b/spec/lib/mcp_server/serializers_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require Rails.root.join('lib/mcp_server/serializers')
+
+describe McpServer::Serializers do
+
+  describe ".map_dir" do
+
+    after(:each) do
+      ENV.delete('OACIS_MCP_DIR_MAP')
+    end
+
+    it "returns the path unchanged when OACIS_MCP_DIR_MAP is unset" do
+      expect(described_class.map_dir("/srv/oacis/public/Result/sim")).to eq "/srv/oacis/public/Result/sim"
+    end
+
+    it "rewrites the mapped prefix to the client-side prefix" do
+      ENV['OACIS_MCP_DIR_MAP'] = "/srv/oacis/public/Result=/host/Result"
+      expect(described_class.map_dir("/srv/oacis/public/Result/sim/ps/run")).to eq "/host/Result/sim/ps/run"
+    end
+
+    it "maps a path equal to the prefix itself" do
+      ENV['OACIS_MCP_DIR_MAP'] = "/srv/oacis/public/Result=/host/Result"
+      expect(described_class.map_dir("/srv/oacis/public/Result")).to eq "/host/Result"
+    end
+
+    it "does not rewrite a partial path-component match" do
+      ENV['OACIS_MCP_DIR_MAP'] = "/srv/oacis/public/Result=/host/Result"
+      expect(described_class.map_dir("/srv/oacis/public/Result_backup/sim")).to eq "/srv/oacis/public/Result_backup/sim"
+    end
+
+    it "leaves paths outside the prefix unchanged" do
+      ENV['OACIS_MCP_DIR_MAP'] = "/srv/oacis/public/Result=/host/Result"
+      expect(described_class.map_dir("/var/log/oacis.log")).to eq "/var/log/oacis.log"
+    end
+
+    it "accepts Pathname input and trailing separators in the mapping" do
+      ENV['OACIS_MCP_DIR_MAP'] = "/srv/oacis/public/Result/=/host/Result/"
+      expect(described_class.map_dir(Pathname.new("/srv/oacis/public/Result/sim"))).to eq "/host/Result/sim"
+    end
+
+    it "ignores a malformed mapping" do
+      ENV['OACIS_MCP_DIR_MAP'] = "no-separator-here"
+      expect(described_class.map_dir("/srv/oacis/public/Result/sim")).to eq "/srv/oacis/public/Result/sim"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Makes direct filesystem reads the primary way for MCP agents to consume result files. Unlike `read_result_file`, direct reads have no size cap and work for binary files, so a multimodal agent can look at plot images produced by analyzers — a prerequisite for autonomously driving the explore→interpret→next-ParameterSet loop.

- `get_run` / `get_analysis` / `get_parameter_set` now report the record's result directory as `dir`; `list_result_files`' `base_dir` gets the same treatment
- New env var `OACIS_MCP_DIR_MAP="server_prefix=client_prefix"` (implemented in `Serializers.map_dir`) rewrites reported paths, so a Docker-hosted OACIS reports host-side bind-mount paths that the agent can actually open
- Tool descriptions now steer agents to read under `dir` directly when accessible, keeping `read_result_file` as the fallback for remote setups
- Docs: new "Direct access to result files" section in `docs/en/mcp.md`

Companion PR: crest-cassia/oacis_docker#110 (sets `OACIS_MCP_DIR_MAP` in `oacis_mcp.sh`)

## Test plan

- `bundle exec rspec spec/lib/mcp_server/` — 82 examples, 0 failures
- New unit specs for `Serializers.map_dir` (prefix match, partial-component non-match, malformed mapping)
- `dir` assertions added to `get_run` / `get_parameter_set` / `list_result_files` specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)