### PR TITLE
Expand '~' in mounted work paths when including local jobs

### DIFF
--- a/app/services/job_includer.rb
+++ b/app/services/job_includer.rb
@@ -105,15 +105,17 @@ module JobIncluder
     FileUtils.mv(archive, submittable.dir.join(".."))
 
     RemoteFilePath.scheduler_log_file_paths(host, submittable).each do |path|
-      if path.exist?
-        FileUtils.mv(map_remote_path_to_mounted_path(host, path), submittable.dir)
-      end
+      mounted = map_remote_path_to_mounted_path(host, path)
+      FileUtils.mv(mounted, submittable.dir) if mounted.exist?
     end
   end
 
+  # work_base_dir/mounted_work_base_dir may contain "~" (the default host
+  # configuration does); expand it because these paths are used without a
+  # shell (argv-style system calls, FileUtils, Pathname#exist?).
   def self.map_remote_path_to_mounted_path(host, remote_path)
     relative_path = remote_path.relative_path_from(Pathname.new(host.work_base_dir))
-    Pathname.new(host.mounted_work_base_dir).join(relative_path)
+    Pathname.new(host.mounted_work_base_dir).join(relative_path).expand_path
   end
 
   def self.download_work_dir_if_exists(host, submittable, sh)

--- a/spec/services/job_includer_spec.rb
+++ b/spec/services/job_includer_spec.rb
@@ -430,5 +430,36 @@ describe JobIncluder do
         JobIncluder.send(:move_local_file, host, submittable)
       }.to raise_error("can not move work_directory from #{mounted_work_dir}")
     end
+
+    it "checks the existence of scheduler logs at the mounted path and moves them" do
+      Dir.mktmpdir do |tmpdir|
+        remote_log = Pathname.new("/remote/job.log")
+        mounted_log = Pathname.new(tmpdir).join("job.log")
+        FileUtils.touch(mounted_log)
+        allow(RemoteFilePath).to receive(:scheduler_log_file_paths)
+          .with(host, submittable).and_return([remote_log])
+        allow(JobIncluder).to receive(:map_remote_path_to_mounted_path)
+          .with(host, remote_log).and_return(mounted_log)
+        allow(JobIncluder).to receive(:system).and_return(true)
+        allow(FileUtils).to receive(:mv)
+
+        expect(FileUtils).to receive(:mv).with(mounted_log, submittable.dir)
+
+        JobIncluder.send(:move_local_file, host, submittable)
+      end
+    end
+  end
+
+  describe ".map_remote_path_to_mounted_path" do
+
+    it "expands '~' so that the path is usable without a shell" do
+      host = instance_double(Host, work_base_dir: "~/remote_work",
+                                   mounted_work_base_dir: "~/mounted_work")
+
+      mapped = JobIncluder.send(:map_remote_path_to_mounted_path,
+                                host, Pathname.new("~/remote_work/run_1"))
+
+      expect(mapped).to eq Pathname.new(File.expand_path("~/mounted_work/run_1"))
+    end
   end
 end


### PR DESCRIPTION
## Problem

On the v4.0.0-rc1 Docker image, every run submitted to the default `localhost` host got stuck in `submitted` status. The job itself finished, but `JobObserver` failed repeatedly with:

```
Error in RemoteJobHandler#remote_status: #<RuntimeError: can not move work_directory from ~/oacis/public/Result_development/work/__work__/...>
```

## Cause

`JobIncluder.map_remote_path_to_mounted_path` returns the path with a literal `~` when `work_base_dir` / `mounted_work_base_dir` contain it (the default host configuration of oacis_docker does). Up to v3, the tilde happened to be expanded by the shell in `system("rsync -a #{...}")`. The argv-style call introduced in #789 (`system("rsync", "-a", "--", ...)`) bypasses the shell — correctly, for safety — so the source directory no longer resolved and including any locally-mounted job failed.

`RemoteJobHandler#remote_path_to_mounted_local_path` already calls `.expand_path`, which is why the submission side worked; this brings `JobIncluder` in line.

## Changes

- `map_remote_path_to_mounted_path` now calls `.expand_path`
- Scheduler log existence is checked at the **mounted** path instead of the remote path (a `~`-prefixed remote path never exists locally, so xsub logs were silently dropped — a latent bug that also existed in v3)
- Regression specs for both

## Verification

- `spec/services/job_includer_spec.rb`: 70 examples, 0 failures
- Hot-patched the fix into a running `oacis/oacis:v4.0.0-rc1` container: a run stuck in `submitted` was included immediately (`finished`, stdout/result files and the xsub log directory all present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)